### PR TITLE
Add support for getting configuration from a secret

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -88,6 +88,8 @@ jobs:
         - additional_seeds
         - cluster_wide_install
         - config_change
+        - internode_encryption
+        - config_secret
         - multi_cluster_management
         - oss_test_all_the_things
         - scale_down

--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -88,7 +88,6 @@ jobs:
         - additional_seeds
         - cluster_wide_install
         - config_change
-        - internode_encryption
         - config_secret
         - multi_cluster_management
         - oss_test_all_the_things

--- a/charts/cass-operator-chart/templates/customresourcedefinition.yaml
+++ b/charts/cass-operator-chart/templates/customresourcedefinition.yaml
@@ -164,6 +164,17 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            configSecret:
+              description: "ConfigSecret is the name of a secret that contains configuration
+                for Cassandra. The secret is expected to have a property named config
+                whose value should be a JSON formatted string that should look like
+                this: \n    config: |-      {        \"cassandra-yaml\": {          \"read_request_timeout_in_ms\":
+                10000        },        \"jmv-options\": {          \"max_heap_size\":
+                1024M        }      } \n ConfigSecret is mutually exclusive with Config.
+                ConfigSecret takes precedence and will be used exclusively if both
+                properties are set. The operator sets a watch such that an update
+                to the secret will trigger an update of the StatefulSets."
+              type: string
             disableSystemLoggerSidecar:
               description: Configuration for disabling the simple log tailing sidecar
                 container. Our default is to have it enabled.

--- a/mage/ginkgo/lib.go
+++ b/mage/ginkgo/lib.go
@@ -217,11 +217,15 @@ func (ns *NsWrapper) WaitForOutputContainsAndLog(description string, kcmd kubect
 }
 
 func (ns *NsWrapper) WaitForDatacenterCondition(dcName string, conditionType string, value string) {
+	ns.WaitForDatacenterConditionWithTimeout(dcName, conditionType, value, 600)
+}
+
+func (ns *NsWrapper) WaitForDatacenterConditionWithTimeout(dcName, conditionType, value string, seconds int) {
 	step := fmt.Sprintf("checking that dc condition %s has value %s", conditionType, value)
 	json := fmt.Sprintf("jsonpath={.status.conditions[?(.type=='%s')].status}", conditionType)
 	k := kubectl.Get("cassandradatacenter", dcName).
 		FormatOutput(json)
-	ns.WaitForOutputAndLog(step, k, value, 600)
+	ns.WaitForOutputAndLog(step, k, value, seconds)
 }
 
 func (ns *NsWrapper) WaitForDatacenterConditionWithReason(dcName string, conditionType string, value string, reason string) {

--- a/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
+++ b/operator/deploy/crds/cassandra.datastax.com_cassandradatacenters_crd.yaml
@@ -164,6 +164,17 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            configSecret:
+              description: "ConfigSecret is the name of a secret that contains configuration
+                for Cassandra. The secret is expected to have a property named config
+                whose value should be a JSON formatted string that should look like
+                this: \n    config: |-      {        \"cassandra-yaml\": {          \"read_request_timeout_in_ms\":
+                10000        },        \"jmv-options\": {          \"max_heap_size\":
+                1024M        }      } \n ConfigSecret is mutually exclusive with Config.
+                ConfigSecret takes precedence and will be used exclusively if both
+                properties are set. The operator sets a watch such that an update
+                to the secret will trigger an update of the StatefulSets."
+              type: string
             disableSystemLoggerSidecar:
               description: Configuration for disabling the simple log tailing sidecar
                 container. Our default is to have it enabled.

--- a/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/operator/pkg/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -102,7 +102,7 @@ func Test_GenerateBaseConfigString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.dc.GetConfigAsJSON()
+			got, err := tt.dc.GetConfigAsJSON(tt.dc.Spec.Config)
 			if got != tt.want {
 				t.Errorf("GenerateBaseConfigString() got = %v, want %v", got, tt.want)
 			}

--- a/operator/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/operator/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -4,7 +4,6 @@
 package reconciliation
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"

--- a/operator/pkg/reconciliation/construct_statefulset.go
+++ b/operator/pkg/reconciliation/construct_statefulset.go
@@ -174,17 +174,6 @@ func newStatefulSetForCassandraDatacenterHelper(
 		template.Spec.NodeSelector = utils.MergeMap(map[string]string{}, dc.Spec.NodeSelector)
 	}
 
-	// workaround for https://cloud.google.com/kubernetes-engine/docs/security-bulletins#may-31-2019
-
-	//if shouldDefineSecurityContext(dc) {
-	//	var userID int64 = 999
-	//	template.Spec.SecurityContext = &corev1.PodSecurityContext{
-	//		RunAsUser:  &userID,
-	//		RunAsGroup: &userID,
-	//		FSGroup:    &userID,
-	//	}
-	//}
-
 	_ = httphelper.AddManagementApiServerSecurity(dc, template)
 
 	result := &appsv1.StatefulSet{

--- a/operator/pkg/reconciliation/reconcile_configsecret.go
+++ b/operator/pkg/reconciliation/reconcile_configsecret.go
@@ -1,0 +1,153 @@
+package reconciliation
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"github.com/k8ssandra/cass-operator/operator/internal/result"
+	api "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/util/hash"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CheckConfigSecret When the ConfigSecret property is set, take the configuration from the
+// specified secret and add to the datacenter configuration secret. The datacenter
+// configuration is created by cass-operator. A second secret is used because cass-operator
+// adds additional properties to the configuration, and we do not want to write that
+// updated configuration back to the user's secret since we do not own it.
+func (rc *ReconciliationContext) CheckConfigSecret() result.ReconcileResult {
+	rc.ReqLogger.Info("reconcile_racks::CheckConfigSecret")
+
+	if len(rc.Datacenter.Spec.ConfigSecret) == 0 {
+		return result.Continue()
+	}
+
+	key := types.NamespacedName{Namespace: rc.Datacenter.Namespace, Name: rc.Datacenter.Spec.ConfigSecret}
+	secret, err := rc.retrieveSecret(key)
+
+	if err != nil {
+		rc.ReqLogger.Error(err, "failed to get config secret", "ConfigSecret", key.Name)
+		return result.Error(err)
+	}
+
+	if err := rc.checkDatacenterNameAnnotation(secret); err != nil {
+		rc.ReqLogger.Error(err, "annotation check for config secret failed", "ConfigSecret", secret.Name)
+	}
+
+	config, err := getConfigFromConfigSecret(rc.Datacenter, secret)
+	if err != nil {
+		rc.ReqLogger.Error(err, "failed to get json config from secret", "ConfigSecret", rc.Datacenter.Spec.ConfigSecret)
+		return result.Error(err)
+	}
+
+	secretName := getDatacenterConfigSecretName(rc.Datacenter)
+	dcConfigSecret, exists, err := rc.getDatacenterConfigSecret(secretName)
+	if err != nil {
+		rc.ReqLogger.Error(err, "failed to get datacenter config secret")
+		return result.Error(err)
+	}
+
+	storedConfig, found := dcConfigSecret.Data["config"]
+	if !(found && bytes.Equal(storedConfig, config)) {
+		if err := rc.updateConfigHashAnnotation(dcConfigSecret); err != nil {
+			rc.ReqLogger.Error(err, "failed to update config hash annotation")
+			return result.Error(err)
+		}
+
+		rc.ReqLogger.Info("updating datacenter config secret", "ConfigSecret", dcConfigSecret.Name)
+		dcConfigSecret.Data["config"] = config
+
+		if exists {
+			if err := rc.Client.Update(rc.Ctx, dcConfigSecret); err != nil {
+				rc.ReqLogger.Error(err,"failed to update datacenter config secret", "ConfigSecret", dcConfigSecret.Name)
+				return result.Error(err)
+			}
+		}
+		if err := rc.Client.Create(rc.Ctx, dcConfigSecret); err != nil {
+			rc.ReqLogger.Error(err, "failed to create datacenter config secret", "ConfigSecret", dcConfigSecret.Name)
+			return result.Error(err)
+		}
+	}
+
+	return result.Continue()
+}
+
+// checkDatacenterNameAnnotation Checks to see if the secret has the datacenter annotation.
+// If the secret does not have the annotation, it is added, and the secret is patched. The
+// secret should be the one specifiied by ConfigSecret.
+func (rc *ReconciliationContext) checkDatacenterNameAnnotation(secret *corev1.Secret) error {
+	if v, ok := secret.Annotations[api.DatacenterAnnotation]; ok &&  v == rc.Datacenter.Name {
+		return nil
+	}
+
+	patch := client.MergeFrom(secret.DeepCopy())
+	secret.Annotations[api.DatacenterAnnotation] = rc.Datacenter.Name
+	return rc.Client.Patch(rc.Ctx, secret, patch)
+}
+
+// updateConfigHashAnnotation Adds the config hash annotation to the datacenter. The value
+// of the annotation is a hash of the secret. The datacenter is then patched. Note that the
+// secret should be the datacenter secret created by the operator, NOT the secret specified
+// by ConfigSecret.
+func (rc *ReconciliationContext) updateConfigHashAnnotation(secret *corev1.Secret) error {
+	rc.ReqLogger.Info("updating config hash annotation")
+
+	hasher := sha256.New()
+	hash.DeepHashObject(hasher, secret)
+	hashBytes := hasher.Sum([]byte{})
+	b64Hash := base64.StdEncoding.EncodeToString(hashBytes)
+
+	patch := client.MergeFrom(rc.Datacenter.DeepCopy())
+	rc.Datacenter.Annotations[api.ConfigHashAnnotation] = b64Hash
+
+	return rc.Client.Patch(rc.Ctx, rc.Datacenter, patch)
+}
+
+// getConfigFromConfigSecret Generates the JSON with properties added by cass-operator.
+func getConfigFromConfigSecret(dc *api.CassandraDatacenter, secret *corev1.Secret) ([]byte, error) {
+	if b, found := secret.Data["config"]; found {
+		jsonConfig, err := dc.GetConfigAsJSON(b)
+		if err == nil {
+			return []byte(jsonConfig), nil
+		} else {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("invalid config secret %s: config property is required", dc.Spec.ConfigSecret)
+	}
+}
+
+// getDatacenterConfigSecretName The format is clusterName-dcName-config
+func getDatacenterConfigSecretName(dc *api.CassandraDatacenter) string {
+	return dc.Spec.ClusterName + "-" + dc.Name + "-config"
+}
+
+// getDatacenterConfigSecret Fetches the secret from the api server or creates a new secret
+// if one is not already stored. The bool return parameter is true if the api server has
+// the secret, false if a secret has to be created. This function does not persist the new
+// secret. That is the caller's responsibility. Lastly, note that this NOT the secret
+// specified by the ConfigSecret property. This is the secret created based on the
+// contents of ConfigSecret.
+func (rc *ReconciliationContext) getDatacenterConfigSecret(name string) (*corev1.Secret, bool, error) {
+	key := types.NamespacedName{Namespace: rc.Datacenter.Namespace, Name: name}
+	secret, err := rc.retrieveSecret(key)
+
+	if err == nil {
+		return secret, true, nil
+	} else if errors.IsNotFound(err)  {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: key.Namespace,
+				Name: name,
+			},
+			Data: map[string][]byte{},
+		}, false, nil
+	} else {
+		return nil, false, err
+	}
+}

--- a/operator/pkg/reconciliation/reconcile_configsecret.go
+++ b/operator/pkg/reconciliation/reconcile_configsecret.go
@@ -140,13 +140,19 @@ func (rc *ReconciliationContext) getDatacenterConfigSecret(name string) (*corev1
 	if err == nil {
 		return secret, true, nil
 	} else if errors.IsNotFound(err)  {
-		return &corev1.Secret{
+		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: key.Namespace,
 				Name: name,
 			},
 			Data: map[string][]byte{},
-		}, false, nil
+		}
+
+		if err = rc.SetDatacenterAsOwner(secret); err != nil {
+			return nil, false, err
+		}
+
+		return secret, false, nil
 	} else {
 		return nil, false, err
 	}

--- a/operator/pkg/reconciliation/reconcile_racks.go
+++ b/operator/pkg/reconciliation/reconcile_racks.go
@@ -2276,6 +2276,10 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
+	if recResult := rc.CheckConfigSecret(); recResult.Completed() {
+		return recResult.Output()
+	}
+
 	if recResult := rc.CheckRackCreation(); recResult.Completed() {
 		return recResult.Output()
 	}

--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -74,7 +74,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterOperatorProgress(dcName, "Ready", 1800)
 
 			step = "checking that the init container got the updated config roles_validity_in_ms=256000, garbage_collector=CMS"
-			json = "jsonpath={.spec.initContainers[0].env[0].value}"
+			json = "jsonpath={.spec.initContainers[0].env[7].value}"
 			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").
 				FormatOutput(json)
 			ns.WaitForOutputContainsAndLog(step, k, "\"roles_validity_in_ms\":256000", 30)

--- a/tests/config_secret/config_secret_suite_test.go
+++ b/tests/config_secret/config_secret_suite_test.go
@@ -1,0 +1,89 @@
+package config_secret
+
+import (
+	"fmt"
+	api "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ginkgo_util "github.com/k8ssandra/cass-operator/mage/ginkgo"
+	"github.com/k8ssandra/cass-operator/mage/kubectl"
+)
+
+var (
+	testName   = "Config change rollout with config secret"
+	namespace  = "test-config-change-rollout-secret"
+	dcName     = "dc1"
+	dcYaml     = "../testdata/cluster-with-config-secret.yaml"
+ 	dcResource = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	dcLabel    = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)
+	secretName = "test-config"
+	secretYaml = "../testdata/test-config-secret.yaml"
+	updatedSecretYaml = "../testdata/updated-test-config-secret.yaml"
+	secretResource = fmt.Sprintf("secret/%s", secretName)
+	ns         = ginkgo_util.NewWrapper(testName, namespace)
+)
+
+func TestLifecycle(t *testing.T) {
+	AfterSuite(func() {
+		logPath := fmt.Sprintf("%s/aftersuite", ns.LogDir)
+		err := kubectl.DumpAllLogs(logPath).ExecV()
+		if err != nil {
+			fmt.Printf("\n\tError during dumping logs: %s\n\n", err.Error())
+		}
+		fmt.Printf("\n\tPost-run logs dumped at: %s\n\n", logPath)
+		ns.Terminate()
+	})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, testName)
+}
+
+var _ = Describe(testName, func() {
+	Context("when in a new cluster", func() {
+		Specify("cassandra configuration can be applied with a secret", func() {
+			By("creating a namespace")
+			err := kubectl.CreateNamespace(namespace).ExecV()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("setting up cass-operator resources via helm chart")
+			ns.HelmInstall("../../charts/cass-operator-chart")
+			ns.WaitForOperatorReady()
+
+			step := "creating config secret"
+			k := kubectl.ApplyFiles(secretYaml)
+			ns.ExecAndLog(step, k)
+
+			step = "creating datacenter"
+			k = kubectl.ApplyFiles(dcYaml)
+			ns.ExecAndLog(step, k)
+			ns.WaitForDatacenterReadyWithTimeouts(dcName, 420, 30)
+
+			step = "update config secret"
+			k = kubectl.ApplyFiles(updatedSecretYaml)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
+			ns.WaitForDatacenterConditionWithTimeout(dcName, string(api.DatacenterReady), string(corev1.ConditionTrue), 450)
+
+			step = "checking cassandra.yaml"
+			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", "/etc/cassandra/cassandra.yaml")
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout_in_ms: 10000", 60)
+
+			step = "stop using config secret"
+			json := `[{"op": "remove", "path": "/spec/configSecret"}, {"op": "add", "path": "/spec/config", "value": {"cassandra-yaml": {"read_request_timeout_in_ms": 25000}, "jvm-options": {"initial_heap_size": "512M", "max_heap_size": "512M"}}}]`
+			k = kubectl.PatchJson(dcResource, json)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 120)
+			ns.WaitForDatacenterConditionWithTimeout(dcName, string(api.DatacenterReady), string(corev1.ConditionTrue), 450)
+
+			step = "checking cassandra.yaml"
+			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", "/etc/cassandra/cassandra.yaml")
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout_in_ms: 25000", 60)
+		})
+	})
+})

--- a/tests/testdata/cluster-with-config-secret.yaml
+++ b/tests/testdata/cluster-with-config-secret.yaml
@@ -10,18 +10,15 @@ spec:
     insecure: {}
   size: 3
   storageConfig:
-      cassandraDataVolumeClaimSpec:
-        storageClassName: standard
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
+    cassandraDataVolumeClaimSpec:
+      storageClassName: standard
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
   racks:
     - name: r1
     - name: r2
     - name: r3
-  config:
-    jvm-options:
-      initial_heap_size: "512m"
-      max_heap_size: "512m"
+  configSecret: test-config

--- a/tests/testdata/test-config-secret.yaml
+++ b/tests/testdata/test-config-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-config
+type: Opaque
+stringData:
+  config: |-
+    {
+      "cassandra-yaml": {
+        "read_request_timeout_in_ms": 5000
+      },
+      "jvm-options": {
+        "initial_heap_size": "512M",
+        "max_heap_size": "512M"
+      }
+    }

--- a/tests/testdata/updated-test-config-secret.yaml
+++ b/tests/testdata/updated-test-config-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-config
+type: Opaque
+stringData:
+  config: |-
+    {
+      "cassandra-yaml": {
+        "read_request_timeout_in_ms": 10000
+      },
+      "jvm-options": {
+        "initial_heap_size": "512M",
+        "max_heap_size": "512M"
+      }
+    }


### PR DESCRIPTION
Fixes #13

This PR adds support for specifying Cassandra configuration with a secret. Here is an example to illustrate the usage. 

cassdc.yaml:

```yaml
apiVersion: cassandra.datastax.com/v1beta1
kind: CassandraDatacenter
metadata:
  name: dc1
spec:
  clusterName: test
  configSecret: cassdc-config
  size: 1
  storageConfig:
    cassandraDataVolumeClaimSpec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 5Gi
      storageClassName: standard
```

config-secret.yaml:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: cassdc-config
type: Opaque
stringData:
  config: |-
    {
      "cassandra-yaml": {
        "roles_update_interval_in_ms": 65000,
        "read_request_timeout_in_ms": 5000
      },
      "jvm-options": {
        "initial_heap_size": "512M",
        "max_heap_size": "512M"
      }
    }
```

Here is a summary of how things work:

* If the secret does not exist reconciliation fails
* Fetch the secret specified by `configSecret`
* Add an annotation with the name of the datacenter to the secret
    * This annotation is used to set up a watch
* Get the config from the secret and apply additional properties 
    * Note that this is existing functionality but needs to be pointed out
* Get or create the _datacenter config secret_
    * This secret is created by cass-operator. It contains the combined config.
* Check to see if the config has changed
* If the config has changed
    * Add annotation with a hash of the datacenter config secret to the datacenter object
    * Patch the datacenter
    * Persist the datacenter config secret
* When the statefulset is constructed check to see if `configSecret` is set. It takes precedence over the inline config
    * Add the `CONFIG_FILE_DATA env var to the server config init container and the value comes from the datacenter config secret
    * Add a `CONFIG_HASH` env that contains the config has
        * This is to facilitate statefulset updates when the config secret is updated      