### PR TITLE
Allow dns lookup by pod name for all pods

### DIFF
--- a/operator/pkg/reconciliation/construct_statefulset.go
+++ b/operator/pkg/reconciliation/construct_statefulset.go
@@ -198,7 +198,7 @@ func newStatefulSetForCassandraDatacenterHelper(
 				MatchLabels: statefulSetSelectorLabels,
 			},
 			Replicas:             &replicaCountInt32,
-			ServiceName:          dc.GetDatacenterServiceName(),
+			ServiceName:          dc.GetAllPodsServiceName(),
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			Template:             *template,
 			VolumeClaimTemplates: volumeClaimTemplates,

--- a/tools/k8s-code-generator/Dockerfile
+++ b/tools/k8s-code-generator/Dockerfile
@@ -3,7 +3,7 @@
 FROM golang:1.16-stretch
 
 ENV CGO_ENABLED=0
-ENV GOPROXY=https://proxy.golang.org,https://gocenter.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 ENV GOPATH=/go
 ENV GO111MODULE=on
 


### PR DESCRIPTION
Some background for this change:
The purpose of the `ServiceName` field of a StatefulSet is to specify the name of the service under which DNS subdomain records are created for each pod: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id

The operator makes two services for dse pods, one with `PublishNotReadyAddresses` set to `true` and one with it set to `false`.

Setting the `ServiceName` to the service which has `PublishNotReadyAddresses` set to `true` allows dns lookups for pods that are not ready yet.

This can be useful in a number of scenarios, one of which is having the pods on an overlay network with stable IPs, where pod to pod communication happens via dns names: https://www.datastax.com/blog/2021/05/how-connect-stateful-workloads-across-kubernetes-clusters
