### PR TITLE
Always include `max_direct_memory` in examples

### DIFF
--- a/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-full.yaml
+++ b/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-full.yaml
@@ -136,9 +136,10 @@ spec:
 
     jvm-options:
 
-      # Set the database to use 14 GB of Java heap
-      initial_heap_size: "14G"
-      max_heap_size: "14G"
+      # Set the database to use 12 GB of Java heap
+      initial_heap_size: "12G"
+      max_heap_size: "12G"
+      max_direct_memory: "6G"
 
       additional-jvm-opts:
 

--- a/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-full.yaml
+++ b/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-full.yaml
@@ -139,6 +139,7 @@ spec:
       # Set the database to use 12 GB of Java heap
       initial_heap_size: "12G"
       max_heap_size: "12G"
+      # Set the JVM's -XX:MaxDirectMemorySize
       max_direct_memory: "6G"
 
       additional-jvm-opts:

--- a/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-minimal.yaml
+++ b/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-minimal.yaml
@@ -27,6 +27,7 @@ spec:
     jvm-options:
       initial_heap_size: "800M"
       max_heap_size: "800M"
+      max_direct_memory: "800M"
       additional-jvm-opts:
         # As the database comes up for the first time, set system keyspaces to RF=3
         - "-Ddse.system_distributed_replication_dc_names=dc1"

--- a/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-three-rack-three-node.yaml
+++ b/operator/example-cassdc-yaml/cassandra-3.11.x/example-cassdc-three-rack-three-node.yaml
@@ -36,6 +36,7 @@ spec:
     jvm-options:
       initial_heap_size: "2G"
       max_heap_size: "2G"
+      max_direct_memory: "1G"      
       additional-jvm-opts:
         - "-Dcassandra.system_distributed_replication_dc_names=dc1"
         - "-Dcassandra.system_distributed_replication_per_dc=3"

--- a/operator/example-cassdc-yaml/dse-6.8.x/example-cassdc-full.yaml
+++ b/operator/example-cassdc-yaml/dse-6.8.x/example-cassdc-full.yaml
@@ -146,16 +146,17 @@ spec:
       allocate_tokens_for_local_replication_factor: 3
       backup_service:
         enabled: true
-      file_cache_size_in_mb: 1000
       authenticator: com.datastax.bdp.cassandra.auth.DseAuthenticator
       authorizer: com.datastax.bdp.cassandra.auth.DseAuthorizer
       role_manager: com.datastax.bdp.cassandra.auth.DseRoleManager
 
     jvm-server-options:
 
-      # Set the database to use 14 GB of Java heap
-      initial_heap_size: "14G"
-      max_heap_size: "14G"
+      # Set the database to use 12 GB of Java heap
+      initial_heap_size: "12G"
+      max_heap_size: "12G"
+      # Set the JVM's -XX:MaxDirectMemorySize
+      max_direct_memory: "6G"
 
       additional-jvm-opts:
       

--- a/operator/example-cassdc-yaml/dse-6.8.x/example-cassdc-minimal.yaml
+++ b/operator/example-cassdc-yaml/dse-6.8.x/example-cassdc-minimal.yaml
@@ -23,6 +23,7 @@ spec:
     jvm-server-options:
       initial_heap_size: "800M"
       max_heap_size: "800M"
+      max_direct_memory: "800M"
       additional-jvm-opts:
         # As the database comes up for the first time, set system keyspaces to RF=3
         - "-Ddse.system_distributed_replication_dc_names=dc1"

--- a/operator/example-cassdc-yaml/dse-6.8.x/example-cassdc-three-rack-three-node.yaml
+++ b/operator/example-cassdc-yaml/dse-6.8.x/example-cassdc-three-rack-three-node.yaml
@@ -42,6 +42,7 @@ spec:
     jvm-server-options:
       initial_heap_size: "2G"
       max_heap_size: "2G"
+      max_direct_memory: "1G"      
       additional-jvm-opts:
         - "-Ddse.system_distributed_replication_dc_names=dc1"
         - "-Ddse.system_distributed_replication_per_dc=3"


### PR DESCRIPTION
Given that the scripts for starting Cassandra do some calculations on the amount of memory that aren't container aware, I think it's important to have this in every example file.