### PR TITLE
When new docker image is created, push an update PR to k8ssandra

### DIFF
--- a/.github/workflows/operatorBuildAndDeploy.yml
+++ b/.github/workflows/operatorBuildAndDeploy.yml
@@ -127,3 +127,42 @@ jobs:
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+  push_k8ssandra_update:
+    runs-on: ubuntu-latest
+    needs: [build_system_logger, build_operator_docker]
+    name: Update dependency in k8ssandra
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Set git parsed values
+        id: vars
+        run: |
+          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
+          echo ::set-output name=tag_name::${GITHUB_REF#refs/tags/}
+      - name: Checkout k8ssandra charts
+        uses: actions/checkout@v2
+        with:
+          repository: k8ssandra/k8ssandra
+          path: k8ssandra
+      - name: Update cass-operator values in k8ssandra
+        run: |
+          # Update the CRD
+          cp charts/cass-operator-chart/templates/customresourcedefinition.yaml k8ssandra/charts/cass-operator/crds/customresourcedefinition.yaml
+          # Update values.yaml's tag to use the newly built image
+          cd k8ssandra
+          pip3 install ruamel.yaml
+          scripts/image-update.py --chart cass-operator --tag ${{ steps.vars.outputs.sha_short }}
+      - name: Create PR to k8ssandra
+        id: master-pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          path: k8ssandra
+          commit-message: Automated update for cass-operator release
+          delete-branch: true
+          title: Update cass-operator to ${{ steps.vars.outputs.sha_short }}
+          body: |
+            This is auto-generated update from the cass-operator's github actions.
+      - name: Log outputs
+        run: |
+          echo "Pull request number ${{ steps.master-pr.outputs.pull-request-number }}"


### PR DESCRIPTION
**What this PR does**:
Whenever the master branch is updated and new docker images are created, this sends a PR to the k8ssandra repo that updates the CRD and the values.yaml image path. If the PR hasn't been merged, it will be updated.

**Which issue(s) this PR fixes**:

**Checklist**


* [ ] Changes manually tested
* [ ] Automated Tests added/updated
* [ ] Documentation added/updated
* [ ] CHANGELOG.md updated (not required for documentation PRs)
* [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)



┆Issue is synchronized with this [Jira Bug](https://k8ssandra.atlassian.net/browse/K8SSAND-539) by [Unito](https://www.unito.io)
