### PR TITLE
If defunct labels are used, do not overwrite them in the StatefulSet

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -66,7 +66,7 @@ jobs:
         - smoke_test_dse
         # - terminate # Completes too fast, the test doesn't catch it
         - timeout_prestop_termination
-        # - upgrade_operator # Should be updated to datastax 1.6.0 -> k8ssandra/latest test
+        - upgrade_operator
         - webhook_validation
         # Three worker tests:
         - canary_upgrade

--- a/operator/pkg/reconciliation/construct_statefulset_test.go
+++ b/operator/pkg/reconciliation/construct_statefulset_test.go
@@ -44,7 +44,7 @@ func Test_newStatefulSetForCassandraDatacenter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Log(tt.name)
-		got, err := newStatefulSetForCassandraDatacenter(nil, tt.args.rackName, tt.args.dc, tt.args.replicaCount, false)
+		got, err := newStatefulSetForCassandraDatacenter(nil, tt.args.rackName, tt.args.dc, tt.args.replicaCount)
 		assert.NoError(t, err, "newStatefulSetForCassandraDatacenter should not have errored")
 		assert.NotNil(t, got, "newStatefulSetForCassandraDatacenter should not have returned a nil statefulset")
 		assert.Equal(t, map[string]string{"dedicated": "cassandra"}, got.Spec.Template.Spec.NodeSelector)
@@ -155,7 +155,7 @@ func Test_newStatefulSetForCassandraDatacenterWithAdditionalVolumes(t *testing.T
 	}
 	for _, tt := range tests {
 		t.Log(tt.name)
-		got, err := newStatefulSetForCassandraDatacenter(nil, tt.args.rackName, tt.args.dc, tt.args.replicaCount, false)
+		got, err := newStatefulSetForCassandraDatacenter(nil, tt.args.rackName, tt.args.dc, tt.args.replicaCount)
 		assert.NoError(t, err, "newStatefulSetForCassandraDatacenter should not have errored")
 		assert.NotNil(t, got, "newStatefulSetForCassandraDatacenter should not have returned a nil statefulset")
 
@@ -345,7 +345,7 @@ func Test_newStatefulSetForCassandraPodSecurityContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Log(tt.name)
-		statefulSet, err := newStatefulSetForCassandraDatacenter(nil, rack, tt.dc, replicas, false)
+		statefulSet, err := newStatefulSetForCassandraDatacenter(nil, rack, tt.dc, replicas)
 		assert.NoError(t, err, fmt.Sprintf("%s: failed to create new statefulset", tt.name))
 		assert.NotNil(t, statefulSet, fmt.Sprintf("%s: statefulset is nil", tt.name))
 

--- a/operator/pkg/reconciliation/reconcile_racks.go
+++ b/operator/pkg/reconciliation/reconcile_racks.go
@@ -334,7 +334,8 @@ func (rc *ReconciliationContext) CheckRackForceUpgrade() result.ReconcileResult 
 
 			// have to use zero here, because each statefulset is created with no replicas
 			// in GetStatefulSetForRack()
-			desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, 0)
+			// We want to construct new desired state, that's why the previous state is not passed
+			desiredSts, err := newStatefulSetForCassandraDatacenter(nil, rackName, dc, 0)
 			if err != nil {
 				logger.Error(err, "error calling newStatefulSetForCassandraDatacenter")
 				return result.Error(err)

--- a/operator/pkg/reconciliation/reconcile_racks.go
+++ b/operator/pkg/reconciliation/reconcile_racks.go
@@ -172,9 +172,7 @@ func (rc *ReconciliationContext) desiredStatefulSetForExistingStatefulSet(sts *a
 	// label of "cassandra-operator" we have since fixed this to be "cass-operator",
 	// but unfortunately, we cannot modify the labels in the volumeClaimTemplates of a
 	// StatefulSet. Consequently, we must preserve the old labels in this case.
-	usesDefunct := usesDefunctPvcManagedByLabel(sts)
-
-	return newStatefulSetForCassandraDatacenter(sts, rackName, dc, replicas, usesDefunct)
+	return newStatefulSetForCassandraDatacenter(sts, rackName, dc, replicas)
 }
 
 func (rc *ReconciliationContext) CheckRackPodTemplate() result.ReconcileResult {
@@ -336,7 +334,7 @@ func (rc *ReconciliationContext) CheckRackForceUpgrade() result.ReconcileResult 
 
 			// have to use zero here, because each statefulset is created with no replicas
 			// in GetStatefulSetForRack()
-			desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, 0, false)
+			desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, 0)
 			if err != nil {
 				logger.Error(err, "error calling newStatefulSetForCassandraDatacenter")
 				return result.Error(err)
@@ -1367,8 +1365,7 @@ func (rc *ReconciliationContext) GetStatefulSetForRack(
 		currentStatefulSet,
 		nextRack.RackName,
 		rc.Datacenter,
-		0,
-		false)
+		0)
 	if err != nil {
 		return nil, false, err
 	}

--- a/operator/pkg/reconciliation/reconcile_racks_test.go
+++ b/operator/pkg/reconciliation/reconcile_racks_test.go
@@ -155,8 +155,7 @@ func TestReconcileRacks_ReconcilePods(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	desiredStatefulSet.Spec.Replicas = &one
@@ -325,8 +324,7 @@ func TestReconcilePods(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 	statefulSet.Status.Replicas = int32(1)
 
@@ -344,8 +342,7 @@ func TestReconcilePods_WithVolumes(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 	statefulSet.Status.Replicas = int32(1)
 
@@ -403,8 +400,7 @@ func TestReconcileNextRack(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	err = rc.ReconcileNextRack(statefulSet)
@@ -428,8 +424,7 @@ func TestReconcileNextRack_CreateError(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	mockClient := &mocks.Client{}
@@ -506,8 +501,7 @@ func TestReconcileRacks(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	trackObjects := []runtime.Object{
@@ -580,8 +574,7 @@ func TestReconcileRacks_WaitingForReplicas(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	trackObjects := []runtime.Object{
@@ -623,8 +616,7 @@ func TestReconcileRacks_NeedMoreReplicas(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	trackObjects := []runtime.Object{
@@ -659,8 +651,7 @@ func TestReconcileRacks_DoesntScaleDown(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	trackObjects := []runtime.Object{
@@ -701,8 +692,7 @@ func TestReconcileRacks_NeedToPark(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		3,
-		false)
+		3)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	trackObjects := []runtime.Object{
@@ -747,8 +737,7 @@ func TestReconcileRacks_AlreadyReconciled(t *testing.T) {
 		nil,
 		"default",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	desiredStatefulSet.Status.ReadyReplicas = 2
@@ -789,8 +778,7 @@ func TestReconcileStatefulSet_ImmutableSpec(t *testing.T) {
 		nil,
 		"rack0",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(err, "error occurred creating statefulset")
 
 	assert.NotEqual("immutable-service", origStatefulSet.Spec.ServiceName)
@@ -800,8 +788,7 @@ func TestReconcileStatefulSet_ImmutableSpec(t *testing.T) {
 		origStatefulSet,
 		"rack0",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(err, "error occurred creating statefulset")
 
 	assert.Equal("immutable-service", modifiedStatefulSet.Spec.ServiceName)
@@ -817,8 +804,7 @@ func TestReconcileRacks_FirstRackAlreadyReconciled(t *testing.T) {
 		nil,
 		"rack0",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	desiredStatefulSet.Status.ReadyReplicas = 2
@@ -827,8 +813,7 @@ func TestReconcileRacks_FirstRackAlreadyReconciled(t *testing.T) {
 		nil,
 		"rack1",
 		rc.Datacenter,
-		1,
-		false)
+		1)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 	secondDesiredStatefulSet.Status.ReadyReplicas = 1
 
@@ -930,8 +915,7 @@ func TestReconcileRacks_UpdateConfig(t *testing.T) {
 		nil,
 		"rack0",
 		rc.Datacenter,
-		2,
-		false)
+		2)
 	assert.NoErrorf(t, err, "error occurred creating statefulset")
 
 	desiredStatefulSet.Status.ReadyReplicas = 2

--- a/tests/testdata/operator-1.1.0-oss-dc.yaml
+++ b/tests/testdata/operator-1.1.0-oss-dc.yaml
@@ -6,6 +6,8 @@ spec:
   clusterName: cluster1
   serverType: cassandra
   serverVersion: "3.11.6"
+  dockerImageRunsAsCassandra: true
+  serverImage: k8ssandra/cass-management-api:3.11.7-v0.1.25
   managementApiAuth:
     insecure: {}
   size: 1


### PR DESCRIPTION
**What this PR does**:
Uses defunct labels if they were used previously - always.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**


* [ ] Changes manually tested
* [x] Automated Tests added/updated
* [ ] Documentation added/updated
* [ ] CHANGELOG.md updated (not required for documentation PRs)
* [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)



┆Issue is synchronized with this [Jira Bug](https://k8ssandra.atlassian.net/browse/K8SSAND-529) by [Unito](https://www.unito.io)
