### PR TITLE
Fix-118: Check UID before deleting PVC

### DIFF
--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -24,6 +24,9 @@ const (
 	// DatacenterLabel is the operator's label for the datacenter name
 	DatacenterLabel = "cassandra.datastax.com/datacenter"
 
+	// DatacenterUID is the operator's label for datacenter UID
+	DatacenterUID = "cassandra.datastax.com/datacenterUID"
+
 	// SeedNodeLabel is the operator's label for the seed node state
 	SeedNodeLabel = "cassandra.datastax.com/seed-node"
 
@@ -496,6 +499,7 @@ func (dc *CassandraDatacenter) SetCondition(condition DatacenterCondition) {
 func (dc *CassandraDatacenter) GetDatacenterLabels() map[string]string {
 	labels := dc.GetClusterLabels()
 	labels[DatacenterLabel] = dc.Name
+	labels[DatacenterUID] = string(dc.UID)
 	return labels
 }
 

--- a/pkg/reconciliation/reconcile_datacenter.go
+++ b/pkg/reconciliation/reconcile_datacenter.go
@@ -98,6 +98,7 @@ func (rc *ReconciliationContext) listPVCs() (*corev1.PersistentVolumeClaimList, 
 
 	selector := map[string]string{
 		api.DatacenterLabel: rc.Datacenter.Name,
+		api.DatacenterUID:   string(rc.Datacenter.UID),
 	}
 
 	listOptions := &client.ListOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
1. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:


* Create a new label `DatacenterUID` -- the UID of the cassandra datacenter
* Label `DatacenterUID` to each pvc and check whether labeled `DatacenterUID` is the same as the UID of the current datacenter (which has a deletion timestamp) before deleting the pvc

**Which issue(s) this PR fixes**:
Fixes #118

**Checklist**


* [x] Changes manually tested
* [ ] Automated Tests added/updated
* [ ] Documentation added/updated
* [ ] CHANGELOG.md updated (not required for documentation PRs)
* [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)



┆Issue is synchronized with this [Jiraserver Task](https://k8ssandra.atlassian.net/browse/K8SSAND-774) by [Unito](https://www.unito.io)
┆Issue Number: K8SSAND-774
┆Priority: Medium
