### PR TITLE
Change install directory for Fossa CLI in license-check workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -9,24 +9,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Check Directory
-        run: |
-          pwd
-      - name: Move Up Directory
-        run: |
-          cd ..
-      - name: Check Parent Directory
-        run: |
-          pwd
-      - name: Check Child Directory Permissions
-        run: |
-          ls -al
       - name: Install Fossa CLI
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b .
-      - name: Check Child Directory Permissions
-        run: |
-          ls -al
       - name: Scan for dependencies and licenses
         run: |
           FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -9,9 +9,21 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Check Directory
+        run: |
+          pwd
+      - name: Move Up Directory
+        run: |
+          cd ..
+      - name: Check Parent Directory
+        run: |
+          pwd
+      - name: Check Child Directory Permissions
+        run: |
+          ls -al
       - name: Install Fossa CLI
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b <custom directory>
       - name: Scan for dependencies and licenses
         run: |
           FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} fossa analyze

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -23,7 +23,7 @@ jobs:
           ls -al
       - name: Install Fossa CLI
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b <custom directory>
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b .
       - name: Scan for dependencies and licenses
         run: |
           FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} fossa analyze

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install Fossa CLI
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b .
+      - name: Check Child Directory Permissions
+        run: |
+          ls -al
       - name: Scan for dependencies and licenses
         run: |
-          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} fossa analyze
+          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes issue where all of the sudden the Fossa CLI tool was failing to install during workflow actions because of permissions issues on their default install directory.

It now installs into the local working directory and executes from there.

Tested changes here:  https://github.com/jdonenine/cass-operator/runs/3124668353

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
