### PR TITLE
Update default memory request for server-config-init container (#150)

### DIFF
--- a/pkg/reconciliation/defaults.go
+++ b/pkg/reconciliation/defaults.go
@@ -5,5 +5,5 @@ var (
 	DefaultsLoggerContainer = buildResourceRequirements(100, 64)
 
 	// Provides reasonable defaults for the configuration container.
-	DefaultsConfigInitContainer = buildResourceRequirements(1000, 256)
+	DefaultsConfigInitContainer = buildResourceRequirements(1000, 300)
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes default memory request for server-config-init container from 256M to 300M.

**Which issue(s) this PR fixes**:
Fixes #150 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)    

