### PR TITLE
If TargetRef is set for additional seed IP, do not remove it

### DIFF
--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -5,7 +5,6 @@ package v1beta1
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/Jeffail/gabs"
 	"github.com/k8ssandra/cass-operator/pkg/serverconfig"
@@ -509,7 +508,7 @@ func (dc *CassandraDatacenter) GetSeedServiceName() string {
 }
 
 func (dc *CassandraDatacenter) GetAdditionalSeedsServiceName() string {
-	return dc.Spec.ClusterName + "-" + dc.Name + fmt.Sprintf("-additional-seed-service")
+	return dc.Spec.ClusterName + "-" + dc.Name + "-additional-seed-service"
 }
 
 func (dc *CassandraDatacenter) GetAllPodsServiceName() string {
@@ -547,23 +546,20 @@ func (dc *CassandraDatacenter) GetConfigAsJSON(config []byte) (string, error) {
 	// We use the cluster seed-service name here for the seed list as it will
 	// resolve to the seed nodes. This obviates the need to update the
 	// cassandra.yaml whenever the seed nodes change.
-	seeds := []string{dc.GetSeedServiceName()}
-	if len(dc.Spec.AdditionalSeeds) > 0 {
-		seeds = append(seeds, dc.GetAdditionalSeedsServiceName())
-	}
+	seeds := []string{dc.GetSeedServiceName(), dc.GetAdditionalSeedsServiceName()}
 
 	graphEnabled := 0
 	solrEnabled := 0
 	sparkEnabled := 0
 
 	if dc.Spec.ServerType == "dse" && dc.Spec.DseWorkloads != nil {
-		if dc.Spec.DseWorkloads.AnalyticsEnabled == true {
+		if dc.Spec.DseWorkloads.AnalyticsEnabled {
 			sparkEnabled = 1
 		}
-		if dc.Spec.DseWorkloads.GraphEnabled == true {
+		if dc.Spec.DseWorkloads.GraphEnabled {
 			graphEnabled = 1
 		}
-		if dc.Spec.DseWorkloads.SearchEnabled == true {
+		if dc.Spec.DseWorkloads.SearchEnabled {
 			solrEnabled = 1
 		}
 	}

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1803,7 +1803,13 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 
 	// if the DC has no ready seeds, label a pod as a seed before we start Cassandra on it
 	// and also consider additional seeds
-	labelSeedBeforeStart := readySeeds == 0 && len(rc.Datacenter.Spec.AdditionalSeeds) == 0
+
+	existingEndpoints, err := rc.GetAdditionalSeedEndpoint()
+	if err != nil {
+		return "", err
+	}
+
+	labelSeedBeforeStart := readySeeds == 0 && len(rc.Datacenter.Spec.AdditionalSeeds) == 0 && len(existingEndpoints.Subsets[0].Addresses) == 0
 
 	rackThatNeedsNode := ""
 	for rackName, readyCount := range rackReadyCount {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1804,12 +1804,12 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 	// if the DC has no ready seeds, label a pod as a seed before we start Cassandra on it
 	// and also consider additional seeds
 
-	existingEndpoints, err := rc.GetAdditionalSeedEndpoint()
-	if err != nil {
-		return "", err
+	externalSeedPoints := 0
+	if existingEndpoints, err := rc.GetAdditionalSeedEndpoint(); err == nil {
+		externalSeedPoints = len(existingEndpoints.Subsets[0].Addresses)
 	}
 
-	labelSeedBeforeStart := readySeeds == 0 && len(rc.Datacenter.Spec.AdditionalSeeds) == 0 && len(existingEndpoints.Subsets[0].Addresses) == 0
+	labelSeedBeforeStart := readySeeds == 0 && len(rc.Datacenter.Spec.AdditionalSeeds) == 0 && externalSeedPoints == 0
 
 	rackThatNeedsNode := ""
 	for rackName, readyCount := range rackReadyCount {


### PR DESCRIPTION
**What this PR does**:
If additional-seds service has a TargetRef set for a IP address, the modifications to AdditionalSeeds will not remove those addresses, but retain them (considering them as managed from the outside).  Also, always add the additional seeds to cass-config-builder since we always create the service.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
