### PR TITLE
Affinity labels defined at rack-level should have precedence over DC-level ones (fixes #162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## Unreleased
 * [CHANGE] #108 Integrate Fossa component/license scanning
+* [BUGFIX] #162 Affinity labels defined at rack-level should have precedence over DC-level ones
 
 ## v1.7.1
 * [BUGFIX] #103 Fix upgrade of StatefulSet, do not change service name

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -69,8 +69,8 @@ func rackNodeAffinitylabels(dc *api.CassandraDatacenter, rackName string) (map[s
 	racks := dc.GetRacks()
 	for _, rack := range racks {
 		if rack.Name == rackName {
-			nodeAffinityLabels = utils.MergeMap(emptyMapIfNil(rack.NodeAffinityLabels),
-				emptyMapIfNil(dc.Spec.NodeAffinityLabels))
+			nodeAffinityLabels = utils.MergeMap(emptyMapIfNil(dc.Spec.NodeAffinityLabels),
+				emptyMapIfNil(rack.NodeAffinityLabels))
 			if rack.Zone != "" {
 				if _, found := nodeAffinityLabels[zoneLabel]; found {
 					log.Error(nil,

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -58,12 +58,12 @@ func Test_newStatefulSetForCassandraDatacenter_rackNodeAffinitylabels(t *testing
 			ServerType:         "cassandra",
 			ServerVersion:      "3.11.7",
 			PodTemplateSpec:    &corev1.PodTemplateSpec{},
-			NodeAffinityLabels: map[string]string{"dclabel1": "dcvalue1", "dclabel2": "dcvalue2"},
+			NodeAffinityLabels: map[string]string{"label1": "dc", "label2": "dc"},
 			Racks: []api.Rack{
 				{
 					Name:               "rack1",
 					Zone:               "z1",
-					NodeAffinityLabels: map[string]string{"r1label1": "r1value1", "r1label2": "r1value2"},
+					NodeAffinityLabels: map[string]string{"label2": "rack1", "label3": "rack1"},
 				},
 			},
 		},
@@ -77,11 +77,10 @@ func Test_newStatefulSetForCassandraDatacenter_rackNodeAffinitylabels(t *testing
 		"should not have gotten error when getting NodeAffinitylabels of rack rack1")
 
 	expected := map[string]string{
-		"dclabel1": "dcvalue1",
-		"dclabel2": "dcvalue2",
-		"r1label1": "r1value1",
-		"r1label2": "r1value2",
-		zoneLabel:  "z1",
+		"label1":  "dc",
+		"label2":  "rack1",
+		"label3":  "rack1",
+		zoneLabel: "z1",
 	}
 
 	assert.Equal(t, expected, nodeAffinityLabels)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR changes the way DC labels are merged with rack labels.

**Which issue(s) this PR fixes**:
Fixes #162 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
