### PR TITLE
upgrade to 1.22 kind mage for running integration tests

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -136,7 +136,7 @@ jobs:
         uses: helm/kind-action@v1.1.0
         with:
           version: v0.11.1
-          node_image: kindest/node:v1.20.7
+          node_image: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
           cluster_name: kind
           config: tests/testdata/kind/kind_config_6_workers.yaml
       - name: Set up Docker Buildx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Upgrade the kind node image to 1.22 for integration tests.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
