### PR TITLE
Wait for cert-manager to install, output the error logs correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ endif
 
 cert-manager: ## Install cert-manager to the cluster
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
+	kubectl wait --for=condition=Established crd certificates.cert-manager.io
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.

--- a/tests/kustomize/deploy.go
+++ b/tests/kustomize/deploy.go
@@ -30,18 +30,17 @@ func runMake(namespace, command, dir string) error {
 	deploy := exec.Command("make", ns, command, kustDir)
 	var out bytes.Buffer
 	deploy.Stdout = &out
+	deploy.Stderr = &out
 
 	path, err := os.Getwd()
 	if err != nil {
-		o, _ := deploy.CombinedOutput()
-		fmt.Printf("Getwd error output:\n%s\n", string(o))
+		fmt.Printf("Getwd error output:\n%s\n", out.String())
 		return err
 	}
 
 	makeDir, err := os.Open(filepath.Join(path, "..", ".."))
 	if err != nil {
-		o, _ := deploy.CombinedOutput()
-		fmt.Printf("Getwd error output:\n%s\n", string(o))
+		fmt.Printf("os.Open error output:\n%s\n", out.String())
 		return err
 	}
 
@@ -49,8 +48,7 @@ func runMake(namespace, command, dir string) error {
 
 	err = deploy.Run()
 	if err != nil {
-		o, _ := deploy.CombinedOutput()
-		fmt.Printf("Getwd error output:\n%s\n", string(o))
+		fmt.Printf("Run error output:\n%s\n", out.String())
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Waits for the cert-manager CRDs after installation before proceeding with the rest of the installation (prevents some errors tests on faster machines).

Also, output logs correctly on exec.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
