### PR TITLE
Modify clusterName in service names to an allowed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## Unreleased
 * [CHANGE] #108 Integrate Fossa component/license scanning
+* [CHANGE] If clusterName includes characters not allowed in the serviceName, strip those chars from service name.
 * [BUGFIX] #162 Affinity labels defined at rack-level should have precedence over DC-level ones
 
 ## v1.7.1

--- a/pkg/reconciliation/construct_service_test.go
+++ b/pkg/reconciliation/construct_service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
@@ -53,4 +54,18 @@ func TestCassandraDatacenter_allPodsServiceLabels(t *testing.T) {
 	if !reflect.DeepEqual(wantLabels, gotLabels) {
 		t.Errorf("allPodsService labels = %v, want %v", gotLabels, wantLabels)
 	}
+}
+
+func TestServiceNameGeneration(t *testing.T) {
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dc1",
+		},
+		Spec: api.CassandraDatacenterSpec{
+			ClusterName: "NotCool_Bob",
+		},
+	}
+
+	service := newSeedServiceForCassandraDatacenter(dc)
+	assert.Equal(t, "notcool-bob-seed-service", service.Name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If the ClusterName includes characters that are not allowed in the service names, modify the serviceName to an allowed value. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/k8ssandra/k8ssandra/issues/1090

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
