### PR TITLE
Run cleanup in a background goroutine without retry [K8SSAND-940]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] #185 Add more app.kubernetes.io labels to all the managed resources
 * [BUGFIX] #185 introduced a regression which caused labels to be updated in StatefulSet when updating a version. Keep the original as these are not allowed to be modified.
 * [BUGFIX] #222 There were still occasions where clusterName was not an allowed value, cleaning them before creating StatefulSet
+* [BUGFIX] #186 Run cleanups in the background once per pod and poll its state instead of looping endlessly
 
 ## v1.8.0
 * [CHANGE] #178 If clusterName includes characters not allowed in the serviceName, strip those chars from service name.

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -115,7 +115,6 @@ func (f *FeatureSet) UnmarshalJSON(b []byte) error {
 
 // Supports returns true if the target pod's management-api supports certain feature
 func (f *FeatureSet) Supports(feature Feature) bool {
-	// TODO Or we could do a HEAD request here to the endpoint URL (define FeatureSet as struct instead of string)
 	_, found := f.Features[string(feature)]
 	return found
 }

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -707,7 +707,7 @@ func (client *NodeMgmtClient) JobDetails(pod *corev1.Pod, jobId string) (*JobDet
 		return nil, err
 	}
 
-	if err := json.Unmarshal(data, &job); err != nil {
+	if err := json.Unmarshal(data, job); err != nil {
 		return nil, err
 	}
 

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -157,6 +157,7 @@ func (client *NodeMgmtClient) CallMetadataEndpointsEndpoint(pod *corev1.Pod) (Ca
 		endpoint: "/api/v0/metadata/endpoints",
 		host:     podHost,
 		method:   http.MethodGet,
+		timeout:  60 * time.Second,
 	}
 
 	bytes, err := callNodeMgmtEndpoint(client, request, "")
@@ -195,6 +196,7 @@ func (client *NodeMgmtClient) CallCreateRoleEndpoint(pod *corev1.Pod, username s
 		endpoint: fmt.Sprintf("/api/v0/ops/auth/role?%s", postData.Encode()),
 		host:     podHost,
 		method:   http.MethodPost,
+		timeout:  60 * time.Second,
 	}
 	_, err = callNodeMgmtEndpoint(client, request, "")
 	return err
@@ -215,6 +217,7 @@ func (client *NodeMgmtClient) CallProbeClusterEndpoint(pod *corev1.Pod, consiste
 		endpoint: fmt.Sprintf("/api/v0/probes/cluster?consistency_level=%s&rf_per_dc=%d", consistencyLevel, rfPerDc),
 		host:     podHost,
 		method:   http.MethodGet,
+		timeout:  60 * time.Second,
 	}
 
 	_, err = callNodeMgmtEndpoint(client, request, "")
@@ -275,7 +278,6 @@ func (client *NodeMgmtClient) CallKeyspaceCleanupEndpoint(pod *corev1.Pod, jobs 
 		endpoint: "/api/v0/ops/keyspace/cleanup",
 		host:     podHost,
 		method:   http.MethodPost,
-		timeout:  time.Second * 20,
 		body:     body,
 	}
 
@@ -574,6 +576,7 @@ func (client *NodeMgmtClient) CallReloadSeedsEndpoint(pod *corev1.Pod) error {
 		endpoint: "/api/v0/ops/seeds/reload",
 		host:     podHost,
 		method:   http.MethodPost,
+		timeout:  60 * time.Second,
 	}
 
 	_, err = callNodeMgmtEndpoint(client, request, "")
@@ -595,6 +598,7 @@ func (client *NodeMgmtClient) CallDecommissionNodeEndpoint(pod *corev1.Pod) erro
 		endpoint: "/api/v0/ops/node/decommission",
 		host:     podHost,
 		method:   http.MethodPost,
+		timeout:  60 * time.Second,
 	}
 
 	_, err = callNodeMgmtEndpoint(client, request, "")
@@ -688,10 +692,6 @@ func callNodeMgmtEndpoint(client *NodeMgmtClient, request nodeMgmtRequest, conte
 		return nil, err
 	}
 	req.Close = true
-
-	if request.timeout == 0 {
-		request.timeout = 60 * time.Second
-	}
 
 	if request.timeout > 0 {
 		ctx, cancel := context.WithTimeout(context.Background(), request.timeout)

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -696,13 +696,17 @@ func (client *NodeMgmtClient) JobDetails(pod *corev1.Pod, jobId string) (*JobDet
 		method:   http.MethodGet,
 	}
 
+	job := &JobDetails{}
 	data, err := callNodeMgmtEndpoint(client, request, "")
 	if err != nil {
+		if re, ok := err.(*RequestError); ok && re.NotFound() {
+			// Job was not found, the request did succeed
+			return job, nil
+		}
 		client.Log.Error(err, "failed to fetch job details from management-api")
 		return nil, err
 	}
 
-	job := &JobDetails{}
 	if err := json.Unmarshal(data, &job); err != nil {
 		return nil, err
 	}

--- a/pkg/reconciliation/reconcile_fql_test.go
+++ b/pkg/reconciliation/reconcile_fql_test.go
@@ -25,6 +25,7 @@ var fqlEnabledConfig string = `{"cassandra-yaml": {
 
 var fullQueryIsSupported string = `{"cassandra_version": "4.0.1",
 	"features": [
+		"async_sstable_tasks",
 		"full_query_logging"
 	]
 }
@@ -38,17 +39,23 @@ func setupPodList(rc *ReconciliationContext) {
 
 	mockClient := &mocks.Client{}
 
+	pods := []corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sts-0",
+		},
+		Status: corev1.PodStatus{
+			PodIP: podIP,
+		},
+	}}
+
+	rc.dcPods = []*corev1.Pod{
+		&pods[0],
+	}
+
 	k8sMockClientList(mockClient, nil).
 		Run(func(args mock.Arguments) {
 			arg := args.Get(1).(*corev1.PodList)
-			arg.Items = []corev1.Pod{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pvc-1",
-				},
-				Status: corev1.PodStatus{
-					PodIP: podIP,
-				},
-			}}
+			arg.Items = pods
 		})
 
 	rc.Client = mockClient

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2146,7 +2146,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 					if details.Id == "" {
 						// This job was not found, pod most likely restarted. Let's retry..
 						delete(pod.Annotations, podJobIdAnnotation)
-						err = rc.Client.Update(rc.Ctx, pod)
+						err = rc.Client.Patch(rc.GetContext(), pod, podPatch)
 						if err != nil {
 							return result.Error(err)
 						}
@@ -2170,7 +2170,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 						continue
 					} else if details.Status == podJobWaiting {
 						// Job is still running or waiting
-						return result.RequeueSoon(2)
+						return result.RequeueSoon(1)
 					}
 				} else {
 					// This pod has finished since it has a status

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2111,7 +2111,14 @@ var (
 func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 	// We sort to ensure we process the pods in the same order
 	sort.Slice(rc.dcPods, func(i, j int) bool {
-		return rc.dcPods[i].UID < rc.dcPods[j].UID
+		rackI := rc.dcPods[i].Labels[api.RackLabel]
+		rackJ := rc.dcPods[j].Labels[api.RackLabel]
+
+		if rackI != rackJ {
+			return rackI < rackJ
+		}
+
+		return rc.dcPods[i].Name < rc.dcPods[j].Name
 	})
 
 	for idx, pod := range rc.dcPods {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2106,7 +2106,7 @@ const (
 )
 
 var (
-	jobRunner chan int
+	jobRunner chan int = make(chan int, 1)
 )
 
 func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
@@ -2209,6 +2209,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 			}
 
 			pod := pod
+
 			go func(targetPod *corev1.Pod) {
 				// Write value to the jobRunner to indicate we're running
 				jobRunner <- idx

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2150,7 +2150,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 						if err != nil {
 							return result.Error(err)
 						}
-						return result.RequeueSoon(2)
+						return result.RequeueSoon(1)
 					} else if details.Status == podJobError {
 						// Log the error, move on
 						rc.ReqLogger.Error(fmt.Errorf("cleanup failed: %s", details.Error), "Job failed to successfully complete the cleanup", "Pod", pod)
@@ -2170,7 +2170,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 						continue
 					} else if details.Status == podJobWaiting {
 						// Job is still running or waiting
-						return result.RequeueSoon(1)
+						return result.RequeueSoon(10)
 					}
 				} else {
 					// This pod has finished since it has a status
@@ -2179,7 +2179,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 			} else {
 				if len(jobRunner) > 0 {
 					// Something is still holding the worker
-					return result.RequeueSoon(2)
+					return result.RequeueSoon(10)
 				}
 
 				// Nothing is holding the job, has this pod finished or hasn't it ran anything?
@@ -2247,7 +2247,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 		}
 
 		// We have a job going on, return back later to check the status
-		return result.RequeueSoon(2)
+		return result.RequeueSoon(10)
 	}
 	return result.Continue()
 }

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1498,7 +1498,7 @@ func TestCleanupAfterScalingAsyncFeatures(t *testing.T) {
 	mockCallKeyspaceCleanup(mockHttpClient)
 
 	r := rc.cleanupAfterScaling()
-	if r != result.RequeueSoon(2) {
+	if r != result.RequeueSoon(10) {
 		t.Fatalf("expected result of result.RequeueSoon(2) but got %s", r)
 	}
 
@@ -1546,8 +1546,8 @@ func TestCleanupAfterScalingAsyncFeaturesMidCrash(t *testing.T) {
 	mockCallKeyspaceCleanup(mockHttpClient)
 
 	r := rc.cleanupAfterScaling()
-	if r != result.RequeueSoon(2) {
-		t.Fatalf("expected result of result.RequeueSoon(2) but got %s", r)
+	if r != result.RequeueSoon(10) {
+		t.Fatalf("expected result of result.RequeueSoon(10) but got %s", r)
 	}
 
 	mockFeaturesEnabled(mockHttpClient)
@@ -1557,8 +1557,8 @@ func TestCleanupAfterScalingAsyncFeaturesMidCrash(t *testing.T) {
 	mockNoJobDetailsResponse(mockHttpClient)
 
 	r = rc.cleanupAfterScaling()
-	if r != result.RequeueSoon(2) {
-		t.Fatalf("expected result of result.RequeueSoon(2) but got %s", r)
+	if r != result.RequeueSoon(1) {
+		t.Fatalf("expected result of result.RequeueSoon(1) but got %s", r)
 	}
 
 	// Job should still be done eventually
@@ -1607,7 +1607,7 @@ func TestCleanupAfterScalingNoAsyncFeatures(t *testing.T) {
 	}
 
 	r := rc.cleanupAfterScaling()
-	if r != result.RequeueSoon(2) {
+	if r != result.RequeueSoon(10) {
 		t.Fatalf("expected result of result.RequeueSoon(2) but got %s", r)
 	}
 
@@ -1685,7 +1685,7 @@ func mockCallKeyspaceCleanupEndpoint(mockHttpClient *mocks.HttpClient) {
 }
 
 func mockPodAnnotationsUpdate(rc *ReconciliationContext) {
-	k8sMockClientUpdate(rc.Client.(*mocks.Client), nil).
+	k8sMockClientPatch(rc.Client.(*mocks.Client), nil).
 		Run(func(args mock.Arguments) {
 			arg := args.Get(1).(*corev1.Pod)
 			rc.dcPods[0].Annotations = arg.Annotations

--- a/pkg/reconciliation/testing.go
+++ b/pkg/reconciliation/testing.go
@@ -203,6 +203,24 @@ func k8sMockClientUpdate(mockClient *mocks.Client, returnArg interface{}) *mock.
 		Once()
 }
 
+func k8sMockClientPatch(mockClient *mocks.Client, returnArg interface{}) *mock.Call {
+	return mockClient.On("Patch",
+		mock.MatchedBy(
+			func(ctx context.Context) bool {
+				return ctx != nil
+			}),
+		mock.MatchedBy(
+			func(obj runtime.Object) bool {
+				return obj != nil
+			}),
+		mock.MatchedBy(
+			func(patch client.Patch) bool {
+				return patch != nil
+			})).
+		Return(returnArg).
+		Once()
+}
+
 func k8sMockClientCreate(mockClient *mocks.Client, returnArg interface{}) *mock.Call {
 	return mockClient.On("Create",
 		mock.MatchedBy(

--- a/tests/scale_up/scale_up_suite_test.go
+++ b/tests/scale_up/scale_up_suite_test.go
@@ -61,7 +61,7 @@ var _ = Describe(testName, func() {
 			ns.ExecAndLog(step, k)
 
 			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionTrue))
-			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
 			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionFalse))
 
 			// Ensure that when 'ScaleUp' becomes 'false' that our pods are in fact up and running
@@ -69,21 +69,21 @@ var _ = Describe(testName, func() {
 
 			ns.WaitForDatacenterReady(dcName)
 
-			step = "scale up to 4 nodes"
-			json = "{\"spec\": {\"size\": 4}}"
-			k = kubectl.PatchMerge(dcResource, json)
-			ns.ExecAndLog(step, k)
+			// step = "scale up to 4 nodes"
+			// json = "{\"spec\": {\"size\": 4}}"
+			// k = kubectl.PatchMerge(dcResource, json)
+			// ns.ExecAndLog(step, k)
 
-			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
-			ns.WaitForDatacenterReady(dcName)
+			// ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
+			// ns.WaitForDatacenterReady(dcName)
 
-			step = "scale up to 5 nodes"
-			json = "{\"spec\": {\"size\": 5}}"
-			k = kubectl.PatchMerge(dcResource, json)
-			ns.ExecAndLog(step, k)
+			// step = "scale up to 5 nodes"
+			// json = "{\"spec\": {\"size\": 5}}"
+			// k = kubectl.PatchMerge(dcResource, json)
+			// ns.ExecAndLog(step, k)
 
-			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
-			ns.WaitForDatacenterReady(dcName)
+			// ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
+			// ns.WaitForDatacenterReady(dcName)
 
 			step = "check recorded host IDs"
 			nodeStatusesHostIds := ns.GetNodeStatusesHostIds(dcName)

--- a/tests/scale_up/scale_up_suite_test.go
+++ b/tests/scale_up/scale_up_suite_test.go
@@ -69,21 +69,21 @@ var _ = Describe(testName, func() {
 
 			ns.WaitForDatacenterReady(dcName)
 
-			// step = "scale up to 4 nodes"
-			// json = "{\"spec\": {\"size\": 4}}"
-			// k = kubectl.PatchMerge(dcResource, json)
-			// ns.ExecAndLog(step, k)
+			step = "scale up to 4 nodes"
+			json = "{\"spec\": {\"size\": 4}}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
 
-			// ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
-			// ns.WaitForDatacenterReady(dcName)
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
+			ns.WaitForDatacenterReady(dcName)
 
-			// step = "scale up to 5 nodes"
-			// json = "{\"spec\": {\"size\": 5}}"
-			// k = kubectl.PatchMerge(dcResource, json)
-			// ns.ExecAndLog(step, k)
+			step = "scale up to 5 nodes"
+			json = "{\"spec\": {\"size\": 5}}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
 
-			// ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
-			// ns.WaitForDatacenterReady(dcName)
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
+			ns.WaitForDatacenterReady(dcName)
 
 			step = "check recorded host IDs"
 			nodeStatusesHostIds := ns.GetNodeStatusesHostIds(dcName)

--- a/tests/testdata/default-single-rack-single-node-dc.yaml
+++ b/tests/testdata/default-single-rack-single-node-dc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster2
   serverType: cassandra
-  serverVersion: "3.11.10"
+  serverVersion: "4.0.1"
   managementApiAuth:
     insecure: {}
   size: 1
@@ -20,6 +20,6 @@ spec:
   racks:
     - name: r1
   config:
-    jvm-options:
+    jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Runs the cleanup process after ScalingUp in a goroutine. This executes and logs errors, but does not retry the cleanup process if it fails. The timeout is set to infinite.

Note, this means the ScalingUp process is marked as finished before the cleanup has completed.

**Which issue(s) this PR fixes**:
Fixes #186

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
