### PR TITLE
Add additional labels to all resources with managed-by label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] #202 Support fetching FeatureSet from management-api if available. Return RequestError with StatusCode when endpoint has bad status.
 * [ENHANCEMENT] #175 Add FQL reconciliation via parseFQLFromConfig and SetFullQueryLogging called from ReconcileAllRacks. CallIsFullQueryLogEnabledEndpoint and CallSetFullQueryLog functions to httphelper.
+* [ENHANCEMENT] #185 Add more app.kubernetes.io labels to all the managed resources
 
 ## v1.8.0
 * [CHANGE] #178 If clusterName includes characters not allowed in the serviceName, strip those chars from service name.

--- a/pkg/oplabels/labels.go
+++ b/pkg/oplabels/labels.go
@@ -3,14 +3,30 @@
 
 package oplabels
 
+import (
+	"fmt"
+
+	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+)
+
 const (
 	ManagedByLabel             = "app.kubernetes.io/managed-by"
 	ManagedByLabelValue        = "cass-operator"
 	ManagedByLabelDefunctValue = "cassandra-operator"
+	NameLabel                  = "app.kubernetes.io/name"
+	NameLabelValue             = "cassandra"
+	InstanceLabel              = "app.kubernetes.io/instance"
+	VersionLabel               = "app.kubernetes.io/version"
+	CreatedByLabel             = "app.kubernetes.io/created-by"
 )
 
-func AddManagedByLabel(m map[string]string) {
+func AddKubernetesLabels(m map[string]string, dc *api.CassandraDatacenter) {
 	m[ManagedByLabel] = ManagedByLabelValue
+	m[NameLabel] = NameLabelValue
+	m[VersionLabel] = dc.Spec.ServerVersion
+
+	instanceName := fmt.Sprintf("cassandra-%s", dc.Spec.ClusterName)
+	m[InstanceLabel] = instanceName
 }
 
 func AddDefunctManagedByLabel(m map[string]string) {

--- a/pkg/psp/networkpolicies.go
+++ b/pkg/psp/networkpolicies.go
@@ -27,7 +27,7 @@ type CheckNetworkPoliciesSPI interface {
 
 func newNetworkPolicyForCassandraDatacenter(dc *api.CassandraDatacenter) *networkingv1.NetworkPolicy {
 	labels := dc.GetDatacenterLabels()
-	oplabels.AddManagedByLabel(labels)
+	oplabels.AddKubernetesLabels(labels, dc)
 	selector := dc.GetDatacenterLabels()
 
 	ingressRule := networkingv1.NetworkPolicyIngressRule{}

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -589,7 +589,7 @@ func buildPodTemplateSpec(dc *api.CassandraDatacenter, nodeAffinityLabels map[st
 	// Labels
 
 	podLabels := dc.GetRackLabels(rackName)
-	oplabels.AddManagedByLabel(podLabels)
+	oplabels.AddKubernetesLabels(podLabels, dc)
 	podLabels[api.CassNodeState] = stateReadyToStart
 
 	if baseTemplate.Labels == nil {

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -778,6 +778,7 @@ func TestCassandraDatacenter_buildPodTemplateSpec_labels_merge(t *testing.T) {
 	got := spec.Labels
 
 	expected := dc.GetRackLabels("testrack")
+	oplabels.AddKubernetesLabels(expected, dc)
 	expected[api.CassNodeState] = stateReadyToStart
 	expected["app.kubernetes.io/managed-by"] = oplabels.ManagedByLabelValue
 	expected["abc"] = "123"

--- a/pkg/reconciliation/construct_service.go
+++ b/pkg/reconciliation/construct_service.go
@@ -112,7 +112,7 @@ func newSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.S
 	service.ObjectMeta.Name = dc.GetSeedServiceName()
 
 	labels := dc.GetClusterLabels()
-	oplabels.AddManagedByLabel(labels)
+	oplabels.AddKubernetesLabels(labels, dc)
 	service.ObjectMeta.Labels = labels
 
 	service.Spec.Selector = buildLabelSelectorForSeedService(dc)
@@ -129,7 +129,7 @@ func newSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.S
 // whether the additional seed pods are ready or not
 func newAdditionalSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.Service {
 	labels := dc.GetDatacenterLabels()
-	oplabels.AddManagedByLabel(labels)
+	oplabels.AddKubernetesLabels(labels, dc)
 	var service corev1.Service
 	service.ObjectMeta.Name = dc.GetAdditionalSeedsServiceName()
 	service.ObjectMeta.Namespace = dc.Namespace
@@ -148,7 +148,7 @@ func newAdditionalSeedServiceForCassandraDatacenter(dc *api.CassandraDatacenter)
 
 func newEndpointsForAdditionalSeeds(dc *api.CassandraDatacenter) (*corev1.Endpoints, error) {
 	labels := dc.GetDatacenterLabels()
-	oplabels.AddManagedByLabel(labels)
+	oplabels.AddKubernetesLabels(labels, dc)
 	endpoints := corev1.Endpoints{}
 	endpoints.ObjectMeta.Name = dc.GetAdditionalSeedsServiceName()
 	endpoints.ObjectMeta.Namespace = dc.Namespace
@@ -273,7 +273,7 @@ func newAllPodsServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev
 // inside the k8s cluster.
 func makeGenericHeadlessService(dc *api.CassandraDatacenter) *corev1.Service {
 	labels := dc.GetDatacenterLabels()
-	oplabels.AddManagedByLabel(labels)
+	oplabels.AddKubernetesLabels(labels, dc)
 	selector := dc.GetDatacenterLabels()
 	var service corev1.Service
 	service.ObjectMeta.Namespace = dc.Namespace

--- a/pkg/reconciliation/construct_service_test.go
+++ b/pkg/reconciliation/construct_service_test.go
@@ -4,6 +4,7 @@
 package reconciliation
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -38,11 +39,15 @@ func TestCassandraDatacenter_allPodsServiceLabels(t *testing.T) {
 			Name: "dc1",
 		},
 		Spec: api.CassandraDatacenterSpec{
-			ClusterName: "bob",
+			ClusterName:   "bob",
+			ServerVersion: "4.0.1",
 		},
 	}
 	wantLabels := map[string]string{
 		oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+		oplabels.InstanceLabel:  fmt.Sprintf("%s-%s", oplabels.NameLabelValue, dc.Spec.ClusterName),
+		oplabels.NameLabel:      oplabels.NameLabelValue,
+		oplabels.VersionLabel:   "4.0.1",
 		api.ClusterLabel:        "bob",
 		api.DatacenterLabel:     "dc1",
 		api.PromMetricsLabel:    "true",

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -105,12 +105,11 @@ func newStatefulSetForCassandraDatacenter(
 	pvcLabels := dc.GetRackLabels(rackName)
 	if useDefunctManagedByForPvc {
 		oplabels.AddDefunctManagedByLabel(pvcLabels)
-	} else {
-		oplabels.AddManagedByLabel(pvcLabels)
 	}
+	oplabels.AddKubernetesLabels(pvcLabels, dc)
 
 	statefulSetLabels := dc.GetRackLabels(rackName)
-	oplabels.AddManagedByLabel(statefulSetLabels)
+	oplabels.AddKubernetesLabels(statefulSetLabels, dc)
 
 	statefulSetSelectorLabels := dc.GetRackLabels(rackName)
 

--- a/pkg/reconciliation/constructor.go
+++ b/pkg/reconciliation/constructor.go
@@ -20,7 +20,7 @@ import (
 func newPodDisruptionBudgetForDatacenter(dc *api.CassandraDatacenter) *policyv1beta1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(int(dc.Spec.Size - 1))
 	labels := dc.GetDatacenterLabels()
-	oplabels.AddManagedByLabel(labels)
+	oplabels.AddKubernetesLabels(labels, dc)
 	selectorLabels := dc.GetDatacenterLabels()
 	pdb := &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1617,7 +1617,7 @@ func mergeInLabelsIfDifferent(existingLabels, newLabels map[string]string) (bool
 // resource. It will return the updated map and a boolean denoting whether the resource needs to be updated with the new labels.
 func shouldUpdateLabelsForClusterResource(resourceLabels map[string]string, dc *api.CassandraDatacenter) (bool, map[string]string) {
 	desired := dc.GetClusterLabels()
-	oplabels.AddManagedByLabel(desired)
+	oplabels.AddKubernetesLabels(desired, dc)
 	return mergeInLabelsIfDifferent(resourceLabels, desired)
 }
 
@@ -1625,7 +1625,7 @@ func shouldUpdateLabelsForClusterResource(resourceLabels map[string]string, dc *
 // resource. It will return the updated map and a boolean denoting whether the resource needs to be updated with the new labels.
 func shouldUpdateLabelsForRackResource(resourceLabels map[string]string, dc *api.CassandraDatacenter, rackName string) (bool, map[string]string) {
 	desired := dc.GetRackLabels(rackName)
-	oplabels.AddManagedByLabel(desired)
+	oplabels.AddKubernetesLabels(desired, dc)
 	return mergeInLabelsIfDifferent(resourceLabels, desired)
 }
 
@@ -1633,7 +1633,7 @@ func shouldUpdateLabelsForRackResource(resourceLabels map[string]string, dc *api
 // resource. It will return the updated map and a boolean denoting whether the resource needs to be updated with the new labels.
 func shouldUpdateLabelsForDatacenterResource(resourceLabels map[string]string, dc *api.CassandraDatacenter) (bool, map[string]string) {
 	desired := dc.GetDatacenterLabels()
-	oplabels.AddManagedByLabel(desired)
+	oplabels.AddKubernetesLabels(desired, dc)
 	return mergeInLabelsIfDifferent(resourceLabels, desired)
 }
 

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,7 +50,8 @@ func Test_validateLabelsForCluster(t *testing.T) {
 							Name: "exampleDC",
 						},
 						Spec: api.CassandraDatacenterSpec{
-							ClusterName: "exampleCluster",
+							ClusterName:   "exampleCluster",
+							ServerVersion: "4.0.1",
 						},
 					},
 				},
@@ -60,6 +60,9 @@ func Test_validateLabelsForCluster(t *testing.T) {
 			wantLabels: map[string]string{
 				api.ClusterLabel:        "exampleCluster",
 				oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+				oplabels.NameLabel:      oplabels.NameLabelValue,
+				oplabels.InstanceLabel:  fmt.Sprintf("%s-exampleCluster", oplabels.NameLabelValue),
+				oplabels.VersionLabel:   "4.0.1",
 			},
 		}, {
 			name: "Nil labels",
@@ -71,7 +74,8 @@ func Test_validateLabelsForCluster(t *testing.T) {
 							Name: "exampleDC",
 						},
 						Spec: api.CassandraDatacenterSpec{
-							ClusterName: "exampleCluster",
+							ClusterName:   "exampleCluster",
+							ServerVersion: "4.0.1",
 						},
 					},
 				},
@@ -80,6 +84,9 @@ func Test_validateLabelsForCluster(t *testing.T) {
 			wantLabels: map[string]string{
 				api.ClusterLabel:        "exampleCluster",
 				oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+				oplabels.NameLabel:      oplabels.NameLabelValue,
+				oplabels.InstanceLabel:  fmt.Sprintf("%s-exampleCluster", oplabels.NameLabelValue),
+				oplabels.VersionLabel:   "4.0.1",
 			},
 		},
 		{
@@ -88,6 +95,9 @@ func Test_validateLabelsForCluster(t *testing.T) {
 				resourceLabels: map[string]string{
 					api.ClusterLabel:        "exampleCluster",
 					oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+					oplabels.NameLabel:      oplabels.NameLabelValue,
+					oplabels.InstanceLabel:  fmt.Sprintf("%s-exampleCluster", oplabels.NameLabelValue),
+					oplabels.VersionLabel:   "4.0.1",
 				},
 				rc: &ReconciliationContext{
 					Datacenter: &api.CassandraDatacenter{
@@ -95,7 +105,8 @@ func Test_validateLabelsForCluster(t *testing.T) {
 							Name: "exampleDC",
 						},
 						Spec: api.CassandraDatacenterSpec{
-							ClusterName: "exampleCluster",
+							ClusterName:   "exampleCluster",
+							ServerVersion: "4.0.1",
 						},
 					},
 				},
@@ -104,6 +115,9 @@ func Test_validateLabelsForCluster(t *testing.T) {
 			wantLabels: map[string]string{
 				api.ClusterLabel:        "exampleCluster",
 				oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+				oplabels.NameLabel:      oplabels.NameLabelValue,
+				oplabels.InstanceLabel:  fmt.Sprintf("%s-exampleCluster", oplabels.NameLabelValue),
+				oplabels.VersionLabel:   "4.0.1",
 			},
 		}, {
 			name: "DC Label, No Cluster Label",
@@ -117,7 +131,8 @@ func Test_validateLabelsForCluster(t *testing.T) {
 							Name: "exampleDC",
 						},
 						Spec: api.CassandraDatacenterSpec{
-							ClusterName: "exampleCluster",
+							ClusterName:   "exampleCluster",
+							ServerVersion: "6.8.13",
 						},
 					},
 				},
@@ -127,6 +142,9 @@ func Test_validateLabelsForCluster(t *testing.T) {
 				api.DatacenterLabel:     "exampleDC",
 				api.ClusterLabel:        "exampleCluster",
 				oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+				oplabels.NameLabel:      oplabels.NameLabelValue,
+				oplabels.InstanceLabel:  fmt.Sprintf("%s-exampleCluster", oplabels.NameLabelValue),
+				oplabels.VersionLabel:   "6.8.13",
 			},
 		},
 	}
@@ -358,11 +376,11 @@ func TestReconcilePods_WithVolumes(t *testing.T) {
 			Name:      "cassandradatacenter-example-cluster-cassandradatacenter-example-default-sts-0",
 			Namespace: statefulSet.Namespace,
 		},
-		Spec: v1.PodSpec{
-			Volumes: []v1.Volume{{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
 				Name: "server-data",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "cassandra-data-example-cluster1-example-cassandradatacenter1-rack0-sts-0",
 					},
 				},
@@ -1194,7 +1212,8 @@ func Test_shouldUpdateLabelsForRackResource(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: api.CassandraDatacenterSpec{
-			ClusterName: clusterName,
+			ClusterName:   clusterName,
+			ServerVersion: "4.0.1",
 		},
 	}
 
@@ -1203,6 +1222,9 @@ func Test_shouldUpdateLabelsForRackResource(t *testing.T) {
 		api.DatacenterLabel:     dcName,
 		api.RackLabel:           rackName,
 		oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+		oplabels.NameLabel:      oplabels.NameLabelValue,
+		oplabels.InstanceLabel:  fmt.Sprintf("%s-%s", oplabels.NameLabelValue, clusterName),
+		oplabels.VersionLabel:   "4.0.1",
 	}
 
 	type args struct {
@@ -1284,6 +1306,9 @@ func Test_shouldUpdateLabelsForRackResource(t *testing.T) {
 					api.DatacenterLabel:     dcName,
 					api.RackLabel:           rackName,
 					oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+					oplabels.NameLabel:      oplabels.NameLabelValue,
+					oplabels.InstanceLabel:  fmt.Sprintf("%s-%s", oplabels.NameLabelValue, clusterName),
+					oplabels.VersionLabel:   "4.0.1",
 				},
 			},
 			want: result{
@@ -1298,6 +1323,9 @@ func Test_shouldUpdateLabelsForRackResource(t *testing.T) {
 					api.DatacenterLabel:     dcName,
 					api.RackLabel:           rackName,
 					oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+					oplabels.NameLabel:      oplabels.NameLabelValue,
+					oplabels.InstanceLabel:  fmt.Sprintf("%s-%s", oplabels.NameLabelValue, clusterName),
+					oplabels.VersionLabel:   "4.0.1",
 					"foo":                   "bar",
 				},
 			},


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new kubernetes labels to all managed resources:

app.kubernetes.io/name
app.kubernetes.io/instance
app.kubernetes.io/version

**Which issue(s) this PR fixes**:
Fixes #185

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
