### PR TITLE
fix: check both secrets when reconciling InternodeCredentialSecret

### DIFF
--- a/pkg/reconciliation/secrets.go
+++ b/pkg/reconciliation/secrets.go
@@ -192,8 +192,13 @@ func (rc *ReconciliationContext) keystoreCASecret() types.NamespacedName {
 
 func (rc *ReconciliationContext) retrieveInternodeCredentialSecretOrCreateDefault() (*corev1.Secret, error) {
 	secret, retrieveErr := rc.retrieveSecret(rc.keystoreCASecret())
-	if retrieveErr != nil {
-		if errors.IsNotFound(retrieveErr) {
+	_, retrieveBootStrappingErr := rc.retrieveSecret(types.NamespacedName{
+		Name:      fmt.Sprintf("%s-keystore", rc.Datacenter.Name),
+		Namespace: rc.Datacenter.Namespace,
+	})
+	if retrieveErr != nil || retrieveBootStrappingErr != nil {
+		if errors.IsNotFound(retrieveErr) && errors.IsNotFound(retrieveBootStrappingErr) {
+			// both secrets are not found
 			secret, err := rc.createInternodeCACredential()
 
 			if err == nil && secret == nil {
@@ -215,8 +220,21 @@ func (rc *ReconciliationContext) retrieveInternodeCredentialSecretOrCreateDefaul
 			if err != nil {
 				return nil, fmt.Errorf("Failed to create default superuser secret: %w", err)
 			}
-		} else {
+		} else if retrieveErr == nil && errors.IsNotFound(retrieveBootStrappingErr) {
+			// CACredential exists, but BootStrappingSecret is not found
+			var jksBlob []byte
+			jksBlob, err := utils.GenerateJKS(secret, rc.Datacenter.Name, rc.Datacenter.Name)
+			if err == nil {
+				err = rc.createCABootstrappingSecret(jksBlob)
+			}
+
+			if err != nil {
+				return nil, fmt.Errorf("Failed to create default superuser secret: %w", err)
+			}
+		} else if retrieveErr != nil {
 			return nil, retrieveErr
+		} else {
+			return nil, retrieveBootStrappingErr
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Check both CASecret and BootStrappingSecret when reconciling InternodeCredentialSecret
- Create both secrets if both of them are not present. Create CABootStrappingSecret based on CASecret if CASecret is present but CABootStrappingSecret is not present.

**Which issue(s) this PR fixes**:
Fixes #225 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
