### PR TITLE
Requeue should not happen instantly, fix upgrade_operator test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] #202 Support fetching FeatureSet from management-api if available. Return RequestError with StatusCode when endpoint has bad status.
 * [CHANGE] #213 Integration tests in Github Actions are now reusable across different workflows
+* [CHANGE] Prevent instant requeues, every requeue must wait at least 500ms.
 * [FEATURE] #193 Add new Management API endpoints to HTTP Helper: GetKeyspaceReplication, ListTables, CreateTable
 * [FEATURE] #175 Add FQL reconciliation via parseFQLFromConfig and SetFullQueryLogging called from ReconcileAllRacks. CallIsFullQueryLogEnabledEndpoint and CallSetFullQueryLog functions to httphelper.
 * [ENHANCEMENT] #185 Add more app.kubernetes.io labels to all the managed resources

--- a/controllers/cassandra/cassandradatacenter_controller.go
+++ b/controllers/cassandra/cassandradatacenter_controller.go
@@ -142,6 +142,13 @@ func (r *CassandraDatacenterReconciler) Reconcile(ctx context.Context, request c
 		logger.Error(err, "calculateReconciliationActions returned an error")
 		rc.Recorder.Eventf(rc.Datacenter, "Warning", "ReconcileFailed", err.Error())
 	}
+
+	// Prevent immediate requeue
+	if res.Requeue {
+		if res.RequeueAfter.Milliseconds() < 500 {
+			res.RequeueAfter = time.Duration(500 * time.Millisecond)
+		}
+	}
 	return res, err
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Current timeouts on upgrade_operator tests are not enough for some machines so the reconcile function is still going when the timeout hits. This adds another timeout after the upgrade process.

Also, prevent cass-operator from instantly requeueing. This reduces chatting with the server, since now it would requeue after 1ms, which isn't enough time for anything to have changed (and thus, another requeue is called). Make 500ms the minimum time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
