### PR TITLE
add annotation to tell operator to skip creating users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ```
 
 ## unreleased
-* [ENHANCEMENT] #235 Adding AdditionalLabels to add on all resources managed by the operator
+* [ENHANCEMENT] [#235](https://github.com/k8ssandra/cass-operator/issues/235) Adding AdditionalLabels to add on all resources managed by the operator
+* [ENHANCEMENT] [#244](https://github.com/k8ssandra/cass-operator/issues/244) Add ability to skip Casandra user creation
 
 ## v.1.9.0
 * [CHANGE] #202 Support fetching FeatureSet from management-api if available. Return RequestError with StatusCode when endpoint has bad status.

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -44,6 +44,11 @@ const (
 	// ConfigHashAnnotation is the operator's annotation for the hash of the ConfigSecret
 	ConfigHashAnnotation = "cassandra.datastax.com/config-hash"
 
+	// SkipUserCreationAnnotation tells the operator to skip creating any Cassandra users
+	// including the default superuser. This is for multi-dc deployments when adding a
+	// DC to an existing cluster where the superuser has already been created.
+	SkipUserCreationAnnotation = "cassandra.datastax.com/skip-user-creation"
+
 	// CassNodeState
 	CassNodeState = "cassandra.datastax.com/node-state"
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -893,6 +893,11 @@ func (rc *ReconciliationContext) UpdateSecretWatches() error {
 func (rc *ReconciliationContext) CreateUsers() result.ReconcileResult {
 	dc := rc.Datacenter
 
+	if val, found := dc.Annotations[api.SkipUserCreationAnnotation]; found && val == "true" {
+		rc.ReqLogger.Info(api.SkipUserCreationAnnotation + " is set, skipping CreateUser")
+		return result.Continue()
+	}
+
 	if dc.Spec.Stopped {
 		rc.ReqLogger.Info("cluster is stopped, skipping CreateUser")
 		return result.Continue()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds an annotation that tells cass-operator to altogether skip creating users.

**Which issue(s) this PR fixes**:
Fixes #244

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
