### PR TITLE
Add support for decommissioning an entire datacenter [K8SSAND-1057][K8SSAND-619]

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -99,6 +99,7 @@ jobs:
         - scale_up_stop_resume
         - seed_selection
         - config_fql
+        - decommission_dc
         # - stop_resume_scale_up # Odd insufficient CPU issues in kind+GHA
       # let other tests continue to run
       # even if one fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] Task scheduler support to allow creating tasks that run for each pod in the cluster. The tasks have their own reconciliation process and lifecycle distinct from CassandraDatacenter as well as their own API package.
 * [ENHANCEMENT] [#235](https://github.com/k8ssandra/cass-operator/issues/235) Adding AdditionalLabels to add on all resources managed by the operator
 * [ENHANCEMENT] [#244](https://github.com/k8ssandra/cass-operator/issues/244) Add ability to skip Cassandra user creation
-* [BUGFIX] [#254](https://github.com/k8ssandra/cass-operator/pull/254) Safely set annotation on datacenter in config secret
 * [ENHANCEMENT] [#257](https://github.com/k8ssandra/cass-operator/issues/257) Add management-api client method to list schema versions
+* [ENHANCEMENT] [#125](https://github.com/k8ssandra/cass-operator/issues/125) On delete, decommission the datacenter if running in multi-datacenter cluster.
+* [BUGFIX] [#254](https://github.com/k8ssandra/cass-operator/pull/254) Safely set annotation on datacenter in config secret
 
 ## v.1.9.0
 * [CHANGE] #202 Support fetching FeatureSet from management-api if available. Return RequestError with StatusCode when endpoint has bad status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#235](https://github.com/k8ssandra/cass-operator/issues/235) Adding AdditionalLabels to add on all resources managed by the operator
 * [ENHANCEMENT] [#244](https://github.com/k8ssandra/cass-operator/issues/244) Add ability to skip Cassandra user creation
 * [ENHANCEMENT] [#257](https://github.com/k8ssandra/cass-operator/issues/257) Add management-api client method to list schema versions
-* [ENHANCEMENT] [#125](https://github.com/k8ssandra/cass-operator/issues/125) On delete, decommission the datacenter if running in multi-datacenter cluster.
+* [ENHANCEMENT] [#125](https://github.com/k8ssandra/cass-operator/issues/125) On delete, allow decommission of the datacenter if running in multi-datacenter cluster.
 * [BUGFIX] [#254](https://github.com/k8ssandra/cass-operator/pull/254) Safely set annotation on datacenter in config secret
+* [BUGFIX] [#261](https://github.com/k8ssandra/cass-operator/issues/261) State of decommission can't be detected correctly if the RPC address is removed from endpoint state during decommission, but before it's finalized.
 
 ## v.1.9.0
 * [CHANGE] #202 Support fetching FeatureSet from management-api if available. Return RequestError with StatusCode when endpoint has bad status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#235](https://github.com/k8ssandra/cass-operator/issues/235) Adding AdditionalLabels to add on all resources managed by the operator
 * [ENHANCEMENT] [#244](https://github.com/k8ssandra/cass-operator/issues/244) Add ability to skip Cassandra user creation
 * [ENHANCEMENT] [#257](https://github.com/k8ssandra/cass-operator/issues/257) Add management-api client method to list schema versions
-* [ENHANCEMENT] [#125](https://github.com/k8ssandra/cass-operator/issues/125) On delete, allow decommission of the datacenter if running in multi-datacenter cluster.
+* [ENHANCEMENT] [#125](https://github.com/k8ssandra/cass-operator/issues/125) On delete, allow decommission of the datacenter if running in multi-datacenter cluster and cassandra.datastax.com/decommission-on-delete annotation is set on the CassandraDatacenter
 * [BUGFIX] [#254](https://github.com/k8ssandra/cass-operator/pull/254) Safely set annotation on datacenter in config secret
 * [BUGFIX] [#261](https://github.com/k8ssandra/cass-operator/issues/261) State of decommission can't be detected correctly if the RPC address is removed from endpoint state during decommission, but before it's finalized.
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -49,6 +49,11 @@ const (
 	// DC to an existing cluster where the superuser has already been created.
 	SkipUserCreationAnnotation = "cassandra.datastax.com/skip-user-creation"
 
+	// SkipDecommissionAnnotation allows to bypass decommission of the Datacenter in a multi-DC cluster when the
+	// CassandraDatacenter is deleted. This is incase the datacenter can't be correctly decommissioned or when
+	// tearing down a test environment.
+	SkipDecommissionAnnotation = "cassandra.datastax.com/skip-decommission"
+
 	// CassNodeState
 	CassNodeState = "cassandra.datastax.com/node-state"
 
@@ -327,6 +332,7 @@ const (
 	DatacenterResuming       DatacenterConditionType = "Resuming"
 	DatacenterRollingRestart DatacenterConditionType = "RollingRestart"
 	DatacenterValid          DatacenterConditionType = "Valid"
+	DatacenterDecommission   DatacenterConditionType = "Decommission"
 )
 
 type DatacenterCondition struct {

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -49,10 +49,9 @@ const (
 	// DC to an existing cluster where the superuser has already been created.
 	SkipUserCreationAnnotation = "cassandra.datastax.com/skip-user-creation"
 
-	// SkipDecommissionAnnotation allows to bypass decommission of the Datacenter in a multi-DC cluster when the
-	// CassandraDatacenter is deleted. This is incase the datacenter can't be correctly decommissioned or when
-	// tearing down a test environment.
-	SkipDecommissionAnnotation = "cassandra.datastax.com/skip-decommission"
+	// DecommissionOnDeleteAnnotation allows to decommissioning of the Datacenter in a multi-DC cluster when the
+	// CassandraDatacenter is deleted.
+	DecommissionOnDeleteAnnotation = "cassandra.datastax.com/decommission-on-delete"
 
 	// CassNodeState
 	CassNodeState = "cassandra.datastax.com/node-state"

--- a/go.sum
+++ b/go.sum
@@ -451,7 +451,6 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -29,11 +29,12 @@ const (
 	ReplacingNode                     string = "ReplacingNode"
 	StartingCassandraAndReplacingNode string = "StartingCassandraAndReplacingNode"
 	StartingCassandra                 string = "StartingCassandra"
+	DecommissionDatacenter            string = "DecommissionDatacenter"
 )
 
 type LoggingEventRecorder struct {
 	record.EventRecorder
-	ReqLogger logr.InfoLogger
+	ReqLogger logr.Logger
 }
 
 func (r *LoggingEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -60,6 +60,7 @@ type EndpointState struct {
 	SSTableVersion         string `json:"SSTABLE_VERSIONS,omitempty"`
 	HostID                 string `json:"HOST_ID,omitempty"`
 	IsAlive                string `json:"IS_ALIVE,omitempty"`
+	EndpointIP             string `json:"ENDPOINT_IP,omitempty"`
 	NativeTransportAddress string `json:"NATIVE_TRANSPORT_ADDRESS,omitempty"`
 	RpcAddress             string `json:"RPC_ADDRESS,omitempty"`
 	Status                 string `json:"STATUS,omitempty"`

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -79,7 +79,7 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 		lastPodSuffix := stsLastPodSuffix(maxReplicas)
 
 		if maxReplicas > desiredNodeCount {
-			logger.V(1).Info(fmt.Sprintf("reconcile_racks::DecommissionNodes::maxReplicas::%d > %d", maxReplicas, desiredNodeCount), "Rack", rackInfo.RackName)
+			logger.V(1).Info("reconcile_racks::DecommissionNodes::scaleDownRack", "Rack", rackInfo.RackName, "maxReplicas", maxReplicas, "desiredNodeCount", desiredNodeCount)
 
 			dcPatch := client.MergeFrom(dc.DeepCopy())
 			updated := false

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -158,6 +158,12 @@ func (rc *ReconciliationContext) DecommissionNodeOnRack(rackName string, epData 
 }
 
 func (rc *ReconciliationContext) callDecommission(pod *corev1.Pod) error {
+	if !isPodUp(pod) {
+		// The pod must be started before it can be decommissioned
+		rc.ReqLogger.V(1).Info("Error while trying to decommission, pod isn't running.", "Pod", pod)
+		return nil
+	}
+
 	features, err := rc.NodeMgmtClient.FeatureSet(pod)
 	if err != nil {
 		return err

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -7,9 +7,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-logr/logr"
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/pkg/events"
 	"github.com/k8ssandra/cass-operator/pkg/httphelper"
@@ -24,7 +25,7 @@ func (rc *ReconciliationContext) CalculateRackInfoForDecomm(currentSize int) ([]
 	// only worry about scaling 1 node at a time
 	desiredSize := currentSize - 1
 
-	if desiredSize < rackCount {
+	if desiredSize < rackCount && rc.Datacenter.Status.GetConditionStatus(api.DatacenterDecommission) != corev1.ConditionTrue {
 		return nil, fmt.Errorf("the number of nodes cannot be smaller than the number of racks")
 	}
 
@@ -54,7 +55,14 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 		}
 	}
 
-	if currentSize <= dc.Spec.Size {
+	targetSize := dc.Spec.Size
+
+	if rc.Datacenter.Status.GetConditionStatus(api.DatacenterDecommission) == corev1.ConditionTrue {
+		targetSize = 0
+	}
+
+	if currentSize <= targetSize {
+		logger.Info(fmt.Sprintf("reconcile_racks::DecommissionNodes::reached-target: %d <= %d", currentSize, dc.Spec.Size))
 		return result.Continue()
 	}
 
@@ -70,6 +78,8 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 		desiredNodeCount := int32(rackInfo.NodeCount)
 		maxReplicas := *statefulSet.Spec.Replicas
 		lastPodSuffix := stsLastPodSuffix(maxReplicas)
+
+		logger.Info(fmt.Sprintf("reconcile_racks::DecommissionNodes::maxReplicas::%d > %d", maxReplicas, desiredNodeCount))
 
 		if maxReplicas > desiredNodeCount {
 			dcPatch := client.MergeFrom(dc.DeepCopy())
@@ -110,6 +120,8 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 		}
 	}
 
+	logger.Info(fmt.Sprintf("reconcile_racks::DecommissionNodes::continue-after-decommrack: %d <= %d", currentSize, dc.Spec.Size))
+
 	return result.Continue()
 }
 
@@ -119,21 +131,20 @@ func (rc *ReconciliationContext) DecommissionNodeOnRack(rackName string, epData 
 		if podRack == rackName && strings.HasSuffix(pod.Name, lastPodSuffix) {
 			mgmtApiUp := isMgmtApiRunning(pod)
 			if !mgmtApiUp {
-				return fmt.Errorf("Management API is not up on node that we are trying to decommission")
+				return fmt.Errorf("management API is not up on node that we are trying to decommission")
 			}
 
 			if err := rc.EnsurePodsCanAbsorbDecommData(pod, epData); err != nil {
 				return err
 			}
 
-			if err := rc.NodeMgmtClient.CallDecommissionNodeEndpoint(pod); err != nil {
-				rc.ReqLogger.Info(fmt.Sprintf("Error from decommission attempt. This is only an attempt and can"+
-					" fail it will be retried later if decomission has not started. Error: %v", err))
+			if err := rc.callDecommission(pod); err != nil {
+				return err
 			}
 
 			rc.ReqLogger.Info("Marking node as decommissioning")
 			patch := client.MergeFrom(pod.DeepCopy())
-			pod.Labels[api.CassNodeState] = stateDecommissioning
+			metav1.SetMetaDataLabel(&pod.ObjectMeta, api.CassNodeState, stateDecommissioning)
 			if err := rc.Client.Patch(rc.Ctx, pod, patch); err != nil {
 				return err
 			}
@@ -146,7 +157,30 @@ func (rc *ReconciliationContext) DecommissionNodeOnRack(rackName string, epData 
 	}
 
 	// this shouldn't happen
-	return fmt.Errorf("Could not find pod to decommission on rack %s", rackName)
+	return fmt.Errorf("could not find pod to decommission on rack %s", rackName)
+}
+
+func (rc *ReconciliationContext) callDecommission(pod *corev1.Pod) error {
+	// features, err := rc.NodeMgmtClient.FeatureSet(pod)
+	// if err != nil {
+	// 	return err
+	// } else if features.Supports(httphelper.AsyncSSTableTasks) {
+	// 	if jobId, err := rc.NodeMgmtClient.CallDecommissionNode(pod, true); err != nil {
+	// 		return err
+	// 	} else {
+	// 		rc.ReqLogger.Info(fmt.Sprintf("Decommission requested, returned jobId: %s", jobId))
+	// 	}
+	// } else {
+	// 	// Fallback to older code
+	// 	pod := pod
+	// 	go func(pod *corev1.Pod) {
+	if err := rc.NodeMgmtClient.CallDecommissionNodeEndpoint(pod); err != nil {
+		rc.ReqLogger.Info(fmt.Sprintf("Error from decommission attempt. This is only an attempt and can fail. Error: %v", err))
+	}
+	// 	}(pod)
+	// }
+
+	return nil
 }
 
 // Wait for decommissioning nodes to finish before continuing to reconcile
@@ -157,14 +191,13 @@ func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.Cas
 
 	for _, pod := range rc.dcPods {
 		if pod.Labels[api.CassNodeState] == stateDecommissioning {
-			if !IsDoneDecommissioning(pod, epData) {
+			if !IsDoneDecommissioning(pod, epData, rc.ReqLogger) {
 				if !HasStartedDecommissioning(pod, epData) {
 					rc.ReqLogger.Info("Decommission has not started trying again")
-					if err := rc.NodeMgmtClient.CallDecommissionNodeEndpoint(pod); err != nil {
-						rc.ReqLogger.Info(fmt.Sprintf("Error from decomimssion attempt. This is only an attempt and can fail. Error: %v", err))
+					err := rc.callDecommission(pod)
+					if err != nil {
+						return result.Error(err)
 					}
-				} else {
-					rc.ReqLogger.Info("Node decommissioning, reconciling again soon")
 				}
 			} else {
 				rc.ReqLogger.Info("Node finished decommissioning")
@@ -172,9 +205,12 @@ func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.Cas
 					return res
 				}
 			}
+			// TODO Add event here to indicate decommissioning this node is still taking place?
 			return result.RequeueSoon(5)
 		}
 	}
+
+	rc.ReqLogger.Info("Nothing to decommission")
 
 	dcPatch := client.MergeFrom(rc.Datacenter.DeepCopy())
 	updated := false
@@ -189,6 +225,9 @@ func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.Cas
 			rc.ReqLogger.Error(err, "error patching datacenter status for scaling down finished")
 			return result.Error(err)
 		}
+		// Requeue after updating to ensure we verify previous steps with the new size
+		rc.ReqLogger.Info("Requeing after updating DatacenterScalingDown to False")
+		return result.RequeueSoon(0)
 	}
 
 	return result.Continue()
@@ -218,32 +257,43 @@ func (rc *ReconciliationContext) cleanUpAfterDecommissionedPod(pod *corev1.Pod) 
 	return nil
 }
 
-func HasStartedDecommissioning(pod *v1.Pod, epData httphelper.CassMetadataEndpoints) bool {
+func HasStartedDecommissioning(pod *corev1.Pod, epData httphelper.CassMetadataEndpoints) bool {
 	for idx := range epData.Entity {
 		ep := &epData.Entity[idx]
 		if ep.GetRpcAddress() == pod.Status.PodIP {
-			return strings.HasPrefix(ep.Status, "LEAVING")
+			return ep.HasStatus(httphelper.StatusLeaving)
 		}
 	}
 	return false
 }
 
-func IsDoneDecommissioning(pod *v1.Pod, epData httphelper.CassMetadataEndpoints) bool {
+func IsDoneDecommissioning(pod *corev1.Pod, epData httphelper.CassMetadataEndpoints, logger logr.Logger) bool {
 	for idx := range epData.Entity {
 		ep := &epData.Entity[idx]
 		if ep.GetRpcAddress() == pod.Status.PodIP {
-			return strings.HasPrefix(ep.Status, "LEFT")
+			return ep.HasStatus(httphelper.StatusLeft)
 		}
 	}
 
-	// If we got here, we could not find endpoint metadata on the node.
-	// This should mean that it no longer exists... but typically
-	// the endpoint data lingers for a while after it has been decommissioned
-	// so this scenario should be unlikely
+	logger.Info(fmt.Sprintf("It seems the pod is gone from the ring, considering it as done:\nPod Status IP: %v\nEntity Ring: %v", pod.Status.PodIP, epData.Entity))
+	// Gone from the ring completely?
 	return true
 }
 
-func (rc *ReconciliationContext) DeletePodPvcs(pod *v1.Pod) error {
+func isPodUp(pod *corev1.Pod) bool {
+	status := pod.Status
+	statuses := status.ContainerStatuses
+	ready := false
+	for _, status := range statuses {
+		if status.Name != "cassandra" {
+			continue
+		}
+		ready = status.Ready
+	}
+	return ready
+}
+
+func (rc *ReconciliationContext) DeletePodPvcs(pod *corev1.Pod) error {
 	for _, v := range pod.Spec.Volumes {
 		if v.PersistentVolumeClaim == nil {
 			continue
@@ -276,7 +326,7 @@ func (rc *ReconciliationContext) DeletePodPvcs(pod *v1.Pod) error {
 	return nil
 }
 
-func (rc *ReconciliationContext) RemoveDecommissionedPodFromSts(pod *v1.Pod) error {
+func (rc *ReconciliationContext) RemoveDecommissionedPodFromSts(pod *corev1.Pod) error {
 	podRack := pod.Labels[api.RackLabel]
 	var sts *appsv1.StatefulSet
 	for _, s := range rc.statefulSets {
@@ -288,14 +338,16 @@ func (rc *ReconciliationContext) RemoveDecommissionedPodFromSts(pod *v1.Pod) err
 
 	if sts == nil {
 		// Failed to find the statefulset for this pod
-		return fmt.Errorf("Failed to find matching statefulSet for pod rack: %s", podRack)
+		return fmt.Errorf("failed to find matching statefulSet for pod rack: %s", podRack)
 	}
 
 	maxReplicas := *sts.Spec.Replicas
 	lastPodSuffix := stsLastPodSuffix(maxReplicas)
 	if strings.HasSuffix(pod.Name, lastPodSuffix) {
+		rc.ReqLogger.Info(fmt.Sprintf("UpdateRackNodeCount in STS %s to %d", sts.Name, *sts.Spec.Replicas-1))
 		return rc.UpdateRackNodeCount(sts, *sts.Spec.Replicas-1)
 	} else {
+		rc.ReqLogger.Error(fmt.Errorf("pod does not match the last pod in the STS"), "Could not find last matching pod", "PodName", pod.Name, "lastPodSuffix", lastPodSuffix)
 		// Pod does not match the last pod in statefulSet
 		// This scenario should only happen if the pod
 		// has already been terminated
@@ -307,7 +359,7 @@ func stsLastPodSuffix(maxReplicas int32) string {
 	return fmt.Sprintf("sts-%v", maxReplicas-1)
 }
 
-func (rc *ReconciliationContext) EnsurePodsCanAbsorbDecommData(decommPod *v1.Pod, epData httphelper.CassMetadataEndpoints) error {
+func (rc *ReconciliationContext) EnsurePodsCanAbsorbDecommData(decommPod *corev1.Pod, epData httphelper.CassMetadataEndpoints) error {
 	podsUsedStorage, err := rc.GetUsedStorageForPods(epData)
 	if err != nil {
 		return err
@@ -326,12 +378,12 @@ func (rc *ReconciliationContext) EnsurePodsCanAbsorbDecommData(decommPod *v1.Pod
 
 		pvCapacity := serverDataPv.Spec.Capacity
 		if pvCapacity == nil {
-			return fmt.Errorf("Could not determine storage capacity when checking if scale-down attempt is valid")
+			return fmt.Errorf("could not determine storage capacity when checking if scale-down attempt is valid")
 		}
 
 		storage, ok := pvCapacity["storage"]
 		if !ok {
-			return fmt.Errorf("Could not determine storage capacity when checking if scale-down attempt is valid")
+			return fmt.Errorf("could not determine storage capacity when checking if scale-down attempt is valid")
 		}
 
 		total := storage.AsDec().UnscaledBig().Int64()
@@ -374,7 +426,7 @@ func (rc *ReconciliationContext) GetUsedStorageForPods(epData httphelper.CassMet
 		load, err := strconv.ParseFloat(data.Load, 64)
 		if err != nil {
 			rc.ReqLogger.Error(
-				fmt.Errorf("Failed to parse pod load reported from mgmt api."),
+				fmt.Errorf("failed to parse pod load reported from mgmt api"),
 				"pod", podName,
 				"Bytes reported by mgmt api", data.Load)
 			return nil, err
@@ -386,7 +438,7 @@ func (rc *ReconciliationContext) GetUsedStorageForPods(epData httphelper.CassMet
 	return podStorageMap, nil
 }
 
-func (rc *ReconciliationContext) getServerDataPv(pod *v1.Pod) (*corev1.PersistentVolume, error) {
+func (rc *ReconciliationContext) getServerDataPv(pod *corev1.Pod) (*corev1.PersistentVolume, error) {
 	pvcName := types.NamespacedName{
 		Name:      fmt.Sprintf("server-data-%s", pod.Name),
 		Namespace: rc.Datacenter.Namespace,
@@ -408,4 +460,38 @@ func (rc *ReconciliationContext) getServerDataPv(pod *v1.Pod) (*corev1.Persisten
 	}
 
 	return pv, nil
+}
+
+func (rc *ReconciliationContext) getClusterDatacenters(pods []*corev1.Pod) ([]string, error) {
+	// We need the result from at least one pod
+	clusterDcs := make(map[string]bool)
+	for _, pod := range pods {
+		if val, found := pod.GetAnnotations()[api.CassNodeState]; found && val == stateDecommissioning {
+			// Do not poll a node that is decommissioning
+			continue
+		}
+		if !isPodUp(pod) {
+			// cassandra container has shutdown for this pod
+			continue
+		}
+
+		metadata, err := rc.NodeMgmtClient.CallMetadataEndpointsEndpoint(pod)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ep := range metadata.Entity {
+			if ep.IsAlive == "true" && ep.HasStatus(httphelper.StatusNormal) {
+				clusterDcs[ep.Datacenter] = true
+			}
+		}
+		break
+	}
+
+	clusterDcList := make([]string, 0, len(clusterDcs))
+	for k := range clusterDcs {
+		clusterDcList = append(clusterDcList, k)
+	}
+
+	return clusterDcList, nil
 }

--- a/pkg/reconciliation/decommission_node_test.go
+++ b/pkg/reconciliation/decommission_node_test.go
@@ -47,6 +47,19 @@ func TestRetryDecommissionNode(t *testing.T) {
 		Return(res, nil).
 		Once()
 
+	resFeatureSet := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}
+
+	mockHttpClient.On("Do",
+		mock.MatchedBy(
+			func(req *http.Request) bool {
+				return req.URL.Path == "/api/v0/metadata/versions/features"
+			})).
+		Return(resFeatureSet, nil).
+		Once()
+
 	rc.NodeMgmtClient = httphelper.NodeMgmtClient{
 		Client:   mockHttpClient,
 		Log:      rc.ReqLogger,

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -57,8 +57,7 @@ func (rc *ReconciliationContext) CalculateRackInformation() error {
 	nodeCount := int(rc.Datacenter.Spec.Size)
 	racks := rc.Datacenter.GetRacks()
 	rackCount := len(racks)
-
-	if nodeCount < rackCount {
+	if nodeCount < rackCount && rc.Datacenter.GetDeletionTimestamp() == nil {
 		return fmt.Errorf("the number of nodes cannot be smaller than the number of racks")
 	}
 
@@ -545,7 +544,7 @@ func (rc *ReconciliationContext) checkSeedLabels() (int, error) {
 func (rc *ReconciliationContext) CheckPodsReady(endpointData httphelper.CassMetadataEndpoints) result.ReconcileResult {
 	rc.ReqLogger.Info("reconcile_racks::CheckPodsReady")
 
-	if rc.Datacenter.Spec.Stopped {
+	if rc.Datacenter.Spec.Stopped || rc.Datacenter.GetDeletionTimestamp() != nil {
 		return result.Continue()
 	}
 
@@ -898,7 +897,7 @@ func (rc *ReconciliationContext) CreateUsers() result.ReconcileResult {
 		return result.Continue()
 	}
 
-	if dc.Spec.Stopped {
+	if dc.Spec.Stopped || rc.Datacenter.GetDeletionTimestamp() != nil {
 		rc.ReqLogger.Info("cluster is stopped, skipping CreateUser")
 		return result.Continue()
 	}
@@ -912,6 +911,9 @@ func (rc *ReconciliationContext) CreateUsers() result.ReconcileResult {
 
 	// make sure the default superuser secret exists
 	_, err = rc.retrieveSuperuserSecretOrCreateDefault()
+	if err != nil {
+		rc.ReqLogger.Error(err, "Failed to verify superuser secret status")
+	}
 
 	users := rc.GetUsers()
 
@@ -981,6 +983,12 @@ func (rc *ReconciliationContext) UpdateCassandraNodeStatus(force bool) error {
 		nodeStatus, ok := dc.Status.NodeStatuses[pod.Name]
 		if !ok {
 			nodeStatus = api.CassandraNodeStatus{}
+		}
+
+		if metav1.HasLabel(pod.ObjectMeta, api.CassNodeState) {
+			if pod.Labels[api.CassNodeState] == stateDecommissioning {
+				continue
+			}
 		}
 
 		if pod.Status.PodIP != "" && isMgmtApiRunning(pod) {
@@ -1109,7 +1117,6 @@ func (rc *ReconciliationContext) UpdateStatusForUserActions() error {
 
 func (rc *ReconciliationContext) UpdateStatus() result.ReconcileResult {
 	dc := rc.Datacenter
-	status := rc.Datacenter.Status.DeepCopy()
 	oldDc := rc.Datacenter.DeepCopy()
 
 	err := rc.UpdateCassandraNodeStatus(false)
@@ -1122,7 +1129,7 @@ func (rc *ReconciliationContext) UpdateStatus() result.ReconcileResult {
 		return result.Error(err)
 	}
 
-	status = &api.CassandraDatacenterStatus{}
+	status := &api.CassandraDatacenterStatus{}
 	dc.Status.DeepCopyInto(status)
 	oldDc.Status.DeepCopyInto(&dc.Status)
 
@@ -1974,8 +1981,8 @@ func isServerReady(pod *corev1.Pod) bool {
 
 func (rc *ReconciliationContext) refreshSeeds() error {
 	rc.ReqLogger.Info("reconcile_racks::refreshSeeds")
-	if rc.Datacenter.Spec.Stopped {
-		rc.ReqLogger.Info("cluster is stopped, skipping refreshSeeds")
+	if rc.Datacenter.Spec.Stopped || rc.Datacenter.GetDeletionTimestamp() != nil {
+		rc.ReqLogger.Info("cluster is stopped/deleted, skipping refreshSeeds")
 		return nil
 	}
 
@@ -2333,6 +2340,9 @@ func (rc *ReconciliationContext) fixMissingPVC() (bool, error) {
 
 // ReconcileAllRacks determines if a rack needs to be reconciled.
 func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
+	rc.ReqLogger.Info("reconciliationContext::reconcileAllRacks")
+	rc.ReqLogger.Info(fmt.Sprintf("reconciliationContext::reconcileAllRacks:target size: %d", rc.Datacenter.Spec.Size))
+
 	if recResult := rc.CheckForInvalidState(); recResult.Completed() {
 		return recResult.Output()
 	}
@@ -2359,6 +2369,20 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
+	rc.ReqLogger.Info(fmt.Sprintf("Going to CheckDecommissionNodes with target size: %d", rc.Datacenter.Spec.Size))
+
+	if recResult := rc.CheckRackCreation(); recResult.Completed() {
+		return recResult.Output()
+	}
+
+	if recResult := rc.CheckDecommissioningNodes(endpointData); recResult.Completed() {
+		return recResult.Output()
+	}
+
+	if recResult := rc.DecommissionNodes(endpointData); recResult.Completed() {
+		return recResult.Output()
+	}
+
 	if recResult := rc.CheckSuperuserSecretCreation(); recResult.Completed() {
 		return recResult.Output()
 	}
@@ -2371,15 +2395,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	if recResult := rc.CheckRackCreation(); recResult.Completed() {
-		return recResult.Output()
-	}
-
 	if recResult := rc.CheckRackLabels(); recResult.Completed() {
-		return recResult.Output()
-	}
-
-	if recResult := rc.CheckDecommissioningNodes(endpointData); recResult.Completed() {
 		return recResult.Output()
 	}
 
@@ -2401,6 +2417,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		// }
 	}
 
+	// TODO CheckRackScale is updating our StatefulSet at the wrong time
 	if recResult := rc.CheckRackScale(); recResult.Completed() {
 		return recResult.Output()
 	}
@@ -2418,10 +2435,6 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 	}
 
 	if recResult := rc.CheckDcPodDisruptionBudget(); recResult.Completed() {
-		return recResult.Output()
-	}
-
-	if recResult := rc.DecommissionNodes(endpointData); recResult.Completed() {
 		return recResult.Output()
 	}
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2341,7 +2341,6 @@ func (rc *ReconciliationContext) fixMissingPVC() (bool, error) {
 // ReconcileAllRacks determines if a rack needs to be reconciled.
 func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 	rc.ReqLogger.Info("reconciliationContext::reconcileAllRacks")
-	rc.ReqLogger.Info(fmt.Sprintf("reconciliationContext::reconcileAllRacks:target size: %d", rc.Datacenter.Spec.Size))
 
 	if recResult := rc.CheckForInvalidState(); recResult.Completed() {
 		return recResult.Output()
@@ -2369,9 +2368,15 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	rc.ReqLogger.Info(fmt.Sprintf("Going to CheckDecommissionNodes with target size: %d", rc.Datacenter.Spec.Size))
+	if recResult := rc.CheckConfigSecret(); recResult.Completed() {
+		return recResult.Output()
+	}
 
 	if recResult := rc.CheckRackCreation(); recResult.Completed() {
+		return recResult.Output()
+	}
+
+	if recResult := rc.CheckRackLabels(); recResult.Completed() {
 		return recResult.Output()
 	}
 
@@ -2388,14 +2393,6 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 	}
 
 	if recResult := rc.CheckInternodeCredentialCreation(); recResult.Completed() {
-		return recResult.Output()
-	}
-
-	if recResult := rc.CheckConfigSecret(); recResult.Completed() {
-		return recResult.Output()
-	}
-
-	if recResult := rc.CheckRackLabels(); recResult.Completed() {
 		return recResult.Output()
 	}
 

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -9,10 +9,11 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
-	"github.com/pavel-v-chernykh/keystore-go"
-	corev1 "k8s.io/api/core/v1"
 	"math/big"
 	"time"
+
+	"github.com/pavel-v-chernykh/keystore-go"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func setupKey() (*big.Int, time.Time, *rsa.PrivateKey, string, time.Time, error) {
@@ -108,7 +109,6 @@ func GenerateJKS(ca *corev1.Secret, podname, dcname string) (jksblob []byte, err
 	if derBytes, err = x509.CreateCertificate(rand.Reader, &newCert, ca_certificate, &priv.PublicKey, ca_key); err == nil {
 		asn1_bytes, err := rsa2pkcs8(priv)
 		buffer := bytes.NewBufferString("")
-		fmt.Printf("Creating keystore")
 		store := keystore.KeyStore{
 			fmt.Sprintf("%s.%s.cassdc", podname, ca.ObjectMeta.Namespace): &keystore.PrivateKeyEntry{
 				Entry:   keystore.Entry{CreationDate: time.Now()},

--- a/tests/config_change_condition/config_change_condition_suite_test.go
+++ b/tests/config_change_condition/config_change_condition_suite_test.go
@@ -55,7 +55,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterReady(dcName)
 
 			step = "change the config"
-			json := "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity_in_ms\": 256000}, \"jvm-options\": {\"garbage_collector\": \"CMS\"}}}}"
+			json := "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity_in_ms\": 256000}, \"jvm-server-options\": {\"garbage_collector\": \"CMS\"}}}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 

--- a/tests/decommission_dc/decommission_dc_suite_test.go
+++ b/tests/decommission_dc/decommission_dc_suite_test.go
@@ -58,7 +58,6 @@ func findDatacenters(nodeName string) []string {
 	re := regexp.MustCompile(`Datacenter:.*`)
 	k := kubectl.ExecOnPod(nodeName, "-c", "cassandra", "--", "nodetool", "status")
 	output := ns.OutputPanic(k)
-	fmt.Printf("OUTPUT: %s\n", output)
 	dcLines := re.FindAllString(output, -1)
 	dcs := make([]string, 0, len(dcLines))
 	for _, dcLine := range dcLines {
@@ -141,11 +140,6 @@ var _ = Describe(testName, func() {
 			podNames = ns.GetDatacenterReadyPodNames(dc1Name)
 			Expect(len(podNames)).To(Equal(2))
 			dcs = findDatacenters(podNames[0])
-			if len(dcs) > 1 {
-				fmt.Printf("There are these DCs: %v\n", dcs)
-				By(fmt.Sprintf("There are these DCs: %v\n", dcs))
-			}
-
 			Expect(len(dcs)).To(Equal(1))
 
 			// Delete the remaining DC and expect it to finish correctly (it should not be decommissioned - that will hang the process and fail)

--- a/tests/decommission_dc/decommission_dc_suite_test.go
+++ b/tests/decommission_dc/decommission_dc_suite_test.go
@@ -1,0 +1,229 @@
+package decommission_dc
+
+/*
+	Create DC1, wait for it
+
+	Create DC2 that starts with additional seeds set to the dc1's seed-service
+
+	Verify DC1<->DC2 see each other
+
+	Delete DC2, wait for it to complete
+
+	Check that DC1 has no longer any DC2 linkage (the DC was correctly decommissioned)
+
+	TODO Should we add scale up?
+*/
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8ssandra/cass-operator/tests/kustomize"
+	ginkgo_util "github.com/k8ssandra/cass-operator/tests/util/ginkgo"
+	"github.com/k8ssandra/cass-operator/tests/util/kubectl"
+)
+
+var (
+	testName  = "Delete DC and verify it is correctly decommissioned in multi-dc cluster"
+	namespace = "test-decommission-dc"
+	dc1Name   = "dc1"
+	dc2Name   = "dc2"
+	dc1Yaml   = "../testdata/default-single-rack-2-node-dc1.yaml"
+	dc2Yaml   = "../testdata/default-single-rack-2-node-dc.yaml"
+	dc1Label  = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc1Name)
+	dc2Label  = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc2Name)
+	seedLabel = "cassandra.datastax.com/seed-node=true"
+	// dcLabel   = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)
+	ns = ginkgo_util.NewWrapper(testName, namespace)
+)
+
+func TestLifecycle(t *testing.T) {
+	AfterSuite(func() {
+		logPath := fmt.Sprintf("%s/aftersuite", ns.LogDir)
+		kubectl.DumpAllLogs(logPath).ExecV()
+		fmt.Printf("\n\tPost-run logs dumped at: %s\n\n", logPath)
+		ns.Terminate()
+		kustomize.Undeploy(namespace)
+	})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, testName)
+}
+
+func findDatacenters(nodeName string) []string {
+	re := regexp.MustCompile(`Datacenter:.*`)
+	k := kubectl.ExecOnPod(nodeName, "-c", "cassandra", "--", "nodetool", "status")
+	output := ns.OutputPanic(k)
+	fmt.Printf("OUTPUT: %s\n", output)
+	dcLines := re.FindAllString(output, -1)
+	dcs := make([]string, 0, len(dcLines))
+	for _, dcLine := range dcLines {
+		dcParts := strings.Split(dcLine, ": ")
+		dcs = append(dcs, strings.TrimSpace(dcParts[1]))
+	}
+
+	return dcs
+}
+
+var _ = Describe(testName, func() {
+	Context("when in a new cluster", func() {
+		Specify("the operator runs decommission correctly when dc is deleted in multi-dc env", func() {
+			By("deploy cass-operator with kustomize")
+			err := kustomize.Deploy(namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			ns.WaitForOperatorReady()
+
+			step := "creating the first datacenter resource with 1 rack/1 node"
+			k := kubectl.ApplyFiles(dc1Yaml)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterReady(dc1Name)
+
+			By("get seed node IP address")
+			json := "jsonpath={.items[0].status.podIP}"
+			k = kubectl.Get("pods").
+				WithLabel(seedLabel).
+				FormatOutput(json)
+
+			podIP, _, err := ns.ExecVCapture(k)
+			Expect(err).ToNot(HaveOccurred())
+
+			step = "creating the second datacenter resource with 1 rack/1 node"
+			k = kubectl.ApplyFiles(dc2Yaml)
+			ns.ExecAndLog(step, k)
+
+			// Add annotation to indicate we don't want the superuser created in dc2
+			step = "annotate dc2 to prevent user creation"
+			k = kubectl.Annotate("cassdc", dc2Name, "cassandra.datastax.com/skip-user-creation", "true")
+			ns.ExecAndLog(step, k)
+
+			dcResource := fmt.Sprintf("CassandraDatacenter/%s", dc2Name)
+			step = "add seed node IP as additional seed for the new datacenter"
+			json = fmt.Sprintf(`
+			{
+				"spec": {
+					"additionalSeeds": ["%s"]
+				}
+			}`, podIP)
+
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterReady(dc2Name)
+
+			// We need to verify that reconciliation has stopped for both dcs
+			ns.ExpectDoneReconciling(dc1Name)
+			ns.ExpectDoneReconciling(dc2Name)
+
+			podNames := ns.GetDatacenterReadyPodNames(dc1Name)
+			Expect(len(podNames)).To(Equal(2))
+			dcs := findDatacenters(podNames[0])
+			Expect(len(dcs)).To(Equal(2))
+
+			// Time to remove the dc2 and verify it has been correctly cleaned up
+			step = "deleting the dc2"
+			k = kubectl.DeleteFromFiles(dc2Yaml)
+			ns.ExecAndLog(step, k)
+
+			step = "checking that the dc2 no longer exists"
+			json = "jsonpath={.items}"
+			k = kubectl.Get("CassandraDatacenter").
+				WithLabel(dc2Label).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "[]", 300)
+
+			// Verify nodetool status has only a single Datacenter
+			podNames = ns.GetDatacenterReadyPodNames(dc1Name)
+			Expect(len(podNames)).To(Equal(2))
+			dcs = findDatacenters(podNames[0])
+			if len(dcs) > 1 {
+				fmt.Printf("There are these DCs: %v\n", dcs)
+				By(fmt.Sprintf("There are these DCs: %v\n", dcs))
+			}
+
+			Expect(len(dcs)).To(Equal(1))
+
+			// Delete the remaining DC and expect it to finish correctly (it should not be decommissioned - that will hang the process and fail)
+			step = "deleting the dc1"
+			k = kubectl.DeleteFromFiles(dc1Yaml)
+			ns.ExecAndLog(step, k)
+
+			step = "checking that the dc1 no longer exists"
+			json = "jsonpath={.items}"
+			k = kubectl.Get("CassandraDatacenter").
+				WithLabel(dc1Label).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "[]", 300)
+
+			step = "checking that no dc stateful sets remain"
+			json = "jsonpath={.items}"
+			k = kubectl.Get("statefulsets").
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "[]", 300)
+
+			// Get seed-node Pod: "cassandra.datastax.com/seed-node"
+			// kubectl get pods -l cassandra.datastax.com/seed-node=true --output=jsonpath='{.items[*].status.podIP}'
+
+			/*
+				Parse the datacenter lines and verify there's two
+
+				➜  cass-operator git:(decommission_dc) ✗ kubectl exec -i -t -c cassandra cluster2-dc1-r1-sts-0 -- nodetool status
+				Datacenter: dc1
+				===============
+				Status=Up/Down
+				|/ State=Normal/Leaving/Joining/Moving
+				--  Address     Load       Owns (effective)  Host ID                               Token                 Rack
+				UN  10.244.2.3  97.09 KiB  100.0%            11e24d4a-a85f-4429-b701-3865c80bf887  3537893417023478360   r1
+
+				Datacenter: dc2
+				===============
+				Status=Up/Down
+				|/ State=Normal/Leaving/Joining/Moving
+				--  Address     Load       Owns (effective)  Host ID                               Token                 Rack
+				UN  10.244.6.3  68.72 KiB  100.0%            008e6938-3934-4ac2-9d03-2cd070f1cf1f  -8131327229031358013  r1
+
+				➜  cass-operator git:(decommission_dc) ✗
+
+				➜  cass-operator git:(decommission_dc) ✗ kubectl exec -i -t -c cassandra cluster2-dc2-r1-sts-0 -- nodetool decommission
+				nodetool: Unsupported operation: Not enough live nodes to maintain replication factor in keyspace system_distributed (RF = 3, N = 2). Perform a forceful decommission to ignore.
+			*/
+			/*
+							After decommission:
+				➜  cass-operator git:(decommission_dc) ✗ kubectl exec -i -t -c cassandra cluster2-dc1-r1-sts-0 -- nodetool status
+				Datacenter: dc1
+				===============
+				Status=Up/Down
+				|/ State=Normal/Leaving/Joining/Moving
+				--  Address     Load        Owns (effective)  Host ID                               Token                Rack
+				UN  10.244.2.3  107.68 KiB  100.0%            11e24d4a-a85f-4429-b701-3865c80bf887  3537893417023478360  r1
+
+				➜  cass-operator git:(decommission_dc) ✗
+			*/
+			/*
+				Incorrect deletion:
+
+				➜  cass-operator git:(decommission_dc) ✗ kubectl exec -i -t -c cassandra cluster2-dc1-r1-sts-0 -- nodetool status
+				Datacenter: dc1
+				===============
+				Status=Up/Down
+				|/ State=Normal/Leaving/Joining/Moving
+				--  Address     Load        Owns (effective)  Host ID                               Token                Rack
+				UN  10.244.2.3  112.79 KiB  100.0%            11e24d4a-a85f-4429-b701-3865c80bf887  3537893417023478360  r1
+
+				Datacenter: dc2
+				===============
+				Status=Up/Down
+				|/ State=Normal/Leaving/Joining/Moving
+				--  Address     Load        Owns (effective)  Host ID                               Token                Rack
+				DN  10.244.6.6  78.45 KiB   100.0%            fcdf813e-5861-4363-86f0-12e894b6e957  5934102370350368596  r1
+
+				➜  cass-operator git:(decommission_dc) ✗
+			*/
+		})
+	})
+})

--- a/tests/decommission_dc/decommission_dc_suite_test.go
+++ b/tests/decommission_dc/decommission_dc_suite_test.go
@@ -124,6 +124,10 @@ var _ = Describe(testName, func() {
 			dcs := findDatacenters(podNames[0])
 			Expect(len(dcs)).To(Equal(2))
 
+			step = "annotate dc2 to do decommission on delete"
+			k = kubectl.Annotate("cassdc", dc2Name, "cassandra.datastax.com/decommission-on-delete", "true")
+			ns.ExecAndLog(step, k)
+
 			// Time to remove the dc2 and verify it has been correctly cleaned up
 			step = "deleting the dc2"
 			k = kubectl.DeleteFromFiles(dc2Yaml)

--- a/tests/scale_down_unbalanced_racks/scale_down_unbalanced_racks_suite_test.go
+++ b/tests/scale_down_unbalanced_racks/scale_down_unbalanced_racks_suite_test.go
@@ -61,15 +61,6 @@ var _ = Describe(testName, func() {
 			k = kubectl.PatchMerge("sts/cluster1-dc1-r2-sts", json)
 			ns.ExecAndLog(step, k)
 
-			// because we scale up the rack before scaling down the dc,
-			// the operator will wait to scale down until the extra rack
-			// nodes are  ready, so we can safetly update the dc size
-			// at this point
-			step = "scale down dc to 2 nodes"
-			json = "{\"spec\": {\"size\": 2}}"
-			k = kubectl.PatchMerge(dcResource, json)
-			ns.ExecAndLog(step, k)
-
 			extraPod := "cluster1-dc1-r2-sts-2"
 
 			step = "check that the extra pod is ready"
@@ -78,6 +69,11 @@ var _ = Describe(testName, func() {
 				WithFlag("field-selector", fmt.Sprintf("metadata.name=%s", extraPod)).
 				FormatOutput(json)
 			ns.WaitForOutputAndLog(step, k, "true", 600)
+
+			step = "scale down dc to 2 nodes"
+			json = "{\"spec\": {\"size\": 2}}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
 
 			// The rack with an extra node should get a decommission request
 			// first, despite being the last rack and the first rack also needing

--- a/tests/testdata/default-single-rack-2-node-dc1.yaml
+++ b/tests/testdata/default-single-rack-2-node-dc1.yaml
@@ -1,7 +1,7 @@
 apiVersion: cassandra.datastax.com/v1beta1
 kind: CassandraDatacenter
 metadata:
-  name: dc2
+  name: dc1
 spec:
   clusterName: cluster2
   serverType: cassandra

--- a/tests/testdata/default-two-rack-four-node-dc.yaml
+++ b/tests/testdata/default-two-rack-four-node-dc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster1
   serverType: cassandra
-  serverVersion: "3.11.10"
+  serverVersion: "3.11.11"
   managementApiAuth:
     insecure: {}
   size: 4

--- a/tests/util/ginkgo/lib.go
+++ b/tests/util/ginkgo/lib.go
@@ -252,7 +252,7 @@ func (ns *NsWrapper) GetNodeStatusesHostIds(dcName string) []string {
 }
 
 func (ns *NsWrapper) WaitForDatacenterReadyPodCount(dcName string, count int) {
-	ns.WaitForDatacenterReadyPodCountWithTimeout(dcName, count, 400)
+	ns.WaitForDatacenterReadyPodCountWithTimeout(dcName, count, 600)
 }
 
 func (ns *NsWrapper) WaitForDatacenterReadyPodCountWithTimeout(dcName string, count int, podCountTimeout int) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
In a multi-datacenter cluster, when deleting a CassandraDatacenter the cass-operator will run a decommission for all the remaining nodes in that datacenter. This ensures the cluster stays healthy and no ghost-nodes are left behind.

Still some rough edges (unit tests are probably failing, there's too many unnecessary logging lines when something really isn't going wrong and the decommission is using the old api/v0 method at this point only).

**Which issue(s) this PR fixes**:
Fixes #125 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
