### PR TITLE
Safely set annotation on datacenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] Task scheduler support to allow creating tasks that run for each pod in the cluster. The tasks have their own reconciliation process and lifecycle distinct from CassandraDatacenter as well as their own API package.
 * [ENHANCEMENT] [#235](https://github.com/k8ssandra/cass-operator/issues/235) Adding AdditionalLabels to add on all resources managed by the operator
 * [ENHANCEMENT] [#244](https://github.com/k8ssandra/cass-operator/issues/244) Add ability to skip Cassandra user creation
+* [BUGFIX] [#254](https://github.com/k8ssandra/cass-operator/pull/254) Safely set annotation on datacenter
 
 ## v.1.9.0
 * [CHANGE] #202 Support fetching FeatureSet from management-api if available. Return RequestError with StatusCode when endpoint has bad status.

--- a/pkg/reconciliation/reconcile_configsecret.go
+++ b/pkg/reconciliation/reconcile_configsecret.go
@@ -105,7 +105,7 @@ func (rc *ReconciliationContext) updateConfigHashAnnotation(secret *corev1.Secre
 	b64Hash := base64.StdEncoding.EncodeToString(hashBytes)
 
 	patch := client.MergeFrom(rc.Datacenter.DeepCopy())
-	rc.Datacenter.Annotations[api.ConfigHashAnnotation] = b64Hash
+	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.ConfigHashAnnotation, b64Hash)
 
 	return rc.Client.Patch(rc.Ctx, rc.Datacenter, patch)
 }


### PR DESCRIPTION
**What this PR does**:

While setting any annotation, the user must initialize the Annotations
map if it isn't already. The helper `metav1.SetMetadataAnnotation` takes
care of this.

**Which issue(s) this PR fixes**:
N/A
The `updateConfigHashAnnotation` function panics when it encounters a datacenter without any annotations. This PR should fix that.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
