### PR TITLE
If TTL is set 0, never delete the completed CassandraTask [K8SSAND-1228]

### DIFF
--- a/apis/control/v1alpha1/cassandratask_types.go
+++ b/apis/control/v1alpha1/cassandratask_types.go
@@ -44,8 +44,8 @@ type CassandraTaskSpec struct {
 	// +optional
 	RestartPolicy corev1.RestartPolicy `json:"restartPolicy,omitempty"`
 
-	// TTLSecondsAfterFinished defines how long the completed job will kept before being cleaned up. If not set,
-	// the task will not be cleaned up by the cass-operator.
+	// TTLSecondsAfterFinished defines how long the completed job will kept before being cleaned up. If set to 0
+	// the task will not be cleaned up by the cass-operator. If unset, the default time (86400s) is used.
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 

--- a/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
@@ -133,8 +133,9 @@ spec:
                 type: string
               ttlSecondsAfterFinished:
                 description: TTLSecondsAfterFinished defines how long the completed
-                  job will kept before being cleaned up. If not set, the task will
-                  not be cleaned up by the cass-operator.
+                  job will kept before being cleaned up. If set to 0 the task will
+                  not be cleaned up by the cass-operator. If unset, the default time
+                  (86400s) is used.
                 format: int32
                 type: integer
             type: object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If TTL is set to 0 in CassandraTask, do not delete it (ever). If left empty, keep the old default TTL behavior. Part of https://github.com/k8ssandra/k8ssandra-operator/issues/373

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
