### PR TITLE
Strip potential password from nodeMgmtClient error [K8SSAND-1253]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#244](https://github.com/k8ssandra/cass-operator/issues/244) Add ability to skip Cassandra user creation
 * [ENHANCEMENT] [#257](https://github.com/k8ssandra/cass-operator/issues/257) Add management-api client method to list schema versions
 * [ENHANCEMENT] [#125](https://github.com/k8ssandra/cass-operator/issues/125) On delete, allow decommission of the datacenter if running in multi-datacenter cluster and cassandra.datastax.com/decommission-on-delete annotation is set on the CassandraDatacenter
+* [BUGFIX] [#272](https://github.com/k8ssandra/cass-operator/issues/272) Strip password (if it has one) from CreateRole
 * [BUGFIX] [#254](https://github.com/k8ssandra/cass-operator/pull/254) Safely set annotation on datacenter in config secret
 * [BUGFIX] [#261](https://github.com/k8ssandra/cass-operator/issues/261) State of decommission can't be detected correctly if the RPC address is removed from endpoint state during decommission, but before it's finalized.
 

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -868,7 +868,6 @@ func callNodeMgmtEndpoint(client *NodeMgmtClient, request nodeMgmtRequest, conte
 
 	req, err := http.NewRequest(request.method, url, reqBody)
 	if err != nil {
-		client.Log.Error(err, "unable to create request for Node Management Endpoint")
 		return nil, err
 	}
 	req.Close = true
@@ -885,7 +884,6 @@ func callNodeMgmtEndpoint(client *NodeMgmtClient, request nodeMgmtRequest, conte
 
 	res, err := client.Client.Do(req)
 	if err != nil {
-		client.Log.Error(err, "unable to perform request to Node Management Endpoint")
 		return nil, err
 	}
 

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -280,8 +280,12 @@ func (client *NodeMgmtClient) CallCreateRoleEndpoint(pod *corev1.Pod, username s
 		method:   http.MethodPost,
 		timeout:  60 * time.Second,
 	}
-	_, err = callNodeMgmtEndpoint(client, request, "")
-	return err
+	if _, err = callNodeMgmtEndpoint(client, request, ""); err != nil {
+		// The error could include a password, strip it
+		strippedErrMsg := strings.ReplaceAll(err.Error(), password, "******")
+		return fmt.Errorf(strippedErrMsg)
+	}
+	return nil
 }
 
 func (client *NodeMgmtClient) CallProbeClusterEndpoint(pod *corev1.Pod, consistencyLevel string, rfPerDc int) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
In certain errors, the http.Client could return the full URL when calling an endpoint. This could include a password in case of create role. Replace the password with "*****". 

**Which issue(s) this PR fixes**:
Fixes #272 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
