### PR TITLE
Change ImageRegistry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#278](https://github.com/k8ssandra/cass-operator/issues/278) ImageRegistry json key was incorrect in the definition type. Fixed from "imageRegistryOverride" to "imageRegistry"
+
 ## v1.10.0
 * [CHANGE] [#271](https://github.com/k8ssandra/cass-operator/pull/271) Admission webhook's FailPolicy is set to Fail instead of Ignored
 * [FEATURE] [#243](https://github.com/k8ssandra/cass-operator/pull/243) Task scheduler support to allow creating tasks that run for each pod in the cluster. The tasks have their own reconciliation process and lifecycle distinct from CassandraDatacenter as well as their own API package.

--- a/apis/config/v1beta1/imageconfig_types.go
+++ b/apis/config/v1beta1/imageconfig_types.go
@@ -35,7 +35,7 @@ type ImageConfig struct {
 
 	DefaultImages *DefaultImages `json:"defaults,omitempty"`
 
-	ImageRegistry string `json:"imageRegistryOverride,omitempty"`
+	ImageRegistry string `json:"imageRegistry,omitempty"`
 
 	ImagePullSecret corev1.LocalObjectReference `json:"imagePullSecret,omitempty"`
 

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 
 	configv1beta1 "github.com/k8ssandra/cass-operator/apis/config/v1beta1"
 )
@@ -45,8 +47,8 @@ func TestCassandraOverride(t *testing.T) {
 	assert.Equal(customImageName, cassImage)
 }
 
-func TestImageConfigParsing(t *testing.T) {
-	assert := assert.New(t)
+func TestDefaultImageConfigParsing(t *testing.T) {
+	assert := require.New(t)
 	imageConfigFile := filepath.Join("..", "..", "config", "manager", "image_config.yaml")
 	err := ParseImageConfig(imageConfigFile)
 	assert.NoError(err, "imageConfig parsing should succeed")
@@ -63,6 +65,38 @@ func TestImageConfigParsing(t *testing.T) {
 	path, err := GetCassandraImage("dse", "6.8.17")
 	assert.NoError(err)
 	assert.Equal("datastax/dse-server:6.8.17-ubi7", path)
+}
+
+func TestImageConfigParsing(t *testing.T) {
+	assert := require.New(t)
+	imageConfigFile := filepath.Join("..", "..", "tests", "testdata", "image_config_parsing.yaml")
+	err := ParseImageConfig(imageConfigFile)
+	assert.NoError(err, "imageConfig parsing should succeed")
+
+	// Verify some default values are set
+	assert.NotNil(GetImageConfig())
+	assert.NotNil(GetImageConfig().Images)
+	assert.True(strings.HasPrefix(GetImageConfig().Images.SystemLogger, "k8ssandra/system-logger:"))
+	assert.True(strings.HasPrefix(GetImageConfig().Images.ConfigBuilder, "datastax/cass-config-builder:"))
+
+	assert.Equal("k8ssandra/cass-management-api", GetImageConfig().DefaultImages.CassandraImageComponent.Repository)
+	assert.Equal("datastax/dse-server", GetImageConfig().DefaultImages.DSEImageComponent.Repository)
+
+	assert.Equal("localhost:5000", GetImageConfig().ImageRegistry)
+	assert.Equal(v1.PullAlways, GetImageConfig().ImagePullPolicy)
+	assert.Equal("my-secret-pull-registry", GetImageConfig().ImagePullSecret.Name)
+
+	path, err := GetCassandraImage("dse", "6.8.17")
+	assert.NoError(err)
+	assert.Equal("localhost:5000/datastax/dse-server:6.8.17-ubi7", path)
+
+	path, err = GetCassandraImage("dse", "6.8.999")
+	assert.NoError(err)
+	assert.Equal("localhost:5000/datastax/dse-server-prototype:latest", path)
+
+	path, err = GetCassandraImage("cassandra", "4.0.0")
+	assert.NoError(err)
+	assert.Equal("localhost:5000/k8ssandra/cassandra-ubi:latest", path)
 }
 
 func TestDefaultRepositories(t *testing.T) {

--- a/tests/testdata/image_config_parsing.yaml
+++ b/tests/testdata/image_config_parsing.yaml
@@ -1,0 +1,22 @@
+apiVersion: config.k8ssandra.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: image-config
+images:
+  system-logger: "k8ssandra/system-logger:latest"
+  config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
+  cassandra:
+    "4.0.0": "k8ssandra/cassandra-ubi:latest"
+  dse:
+    "6.8.999": "datastax/dse-server-prototype:latest"
+imageRegistry: "localhost:5000"
+imagePullPolicy: Always
+imagePullSecret:
+  name: my-secret-pull-registry
+defaults:
+  # Note, postfix is ignored if repository is not set
+  cassandra:
+    repository: "k8ssandra/cass-management-api"
+  dse:
+    repository: "datastax/dse-server"
+    suffix: "-ubi7"


### PR DESCRIPTION
…rride, fixes #278. Add tests to verify the parsing of all parameters is done from a file correctly

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
In our examples, the ImageConfig.ImageRegistry is set to JSON key ``imageRegistry``. However, the JSON parsing tried to read this information from ``imageRegistryOverride`` which is incorrect. Added also a test that reads from testdata a test imageConfig with all the properties set and compares them.

**Which issue(s) this PR fixes**:
Fixes #278

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
