### PR TITLE
Fix release build-args, add act exclusions for testing purposes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,24 +28,36 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to DockerHub
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Set git parsed values
+        if: ${{ !env.ACT }}
         id: vars
         shell: bash
         run: |
           echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
           echo ::set-output name=tag_name::${GITHUB_REF#refs/tags/}
           echo "TARGET_VERSION=$(echo ${GITHUB_REF#refs/tags/} | awk '{print substr($0,2)}')" >> $GITHUB_ENV
+      - name: Set git parsed values for act
+        if: ${{ env.ACT }}
+        id: vars
+        shell: bash
+        run: |
+          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
+          echo ::set-output name=tag_name::$(git describe --abbrev=0 --tags)
+          echo "TARGET_VERSION=$(echo $(git describe --abbrev=0 --tags) | awk '{print substr($0,2)}')" >> $GITHUB_ENV
       - name: Build and push
         id: docker_build_system-logger
         uses: docker/build-push-action@v2
         with:
           file: logger.Dockerfile
+          build-args: |
+            VERSION=${{ env.TARGET_VERSION }}
           context: .
-          push: true
+          push: ${{ !env.ACT }}
           tags: k8ssandra/system-logger:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -55,12 +67,15 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile
+          build-args: |
+            VERSION=${{ env.TARGET_VERSION }}
           context: .
-          push: true
+          push: ${{ !env.ACT }}
           tags: k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Create bundle and catalog files
+        if: ${{ !env.ACT }}
         run: |
           make IMG=k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}} VERSION=${{ env.TARGET_VERSION }} bundle bundle-build bundle-push catalog-build catalog-push


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The release build did not have enough build-args when running in the GHA (only Makefile had these changes). Adds the VERSION field to the build-args.

Also, add act checks to ensure the workflow can be tested with ``act -j release_cass_operator``.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
