### PR TITLE
Update PodDisruptionBudget from v1beta1 to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [CHANGE] [#183](https://github.com/k8ssandra/cass-operator/issues/183) Move from PodDisruptionBudget v1beta1 to v1 (min. Kubernetes version 1.21)
 * [CHANGE] [#264](https://github.com/k8ssandra/cass-operator/issues/264) Generate PodTemplateSpec in CassandraDatacenter with metadata
 
 ## v1.10.1

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ spec:
 
 ## Requirements
 
-- Kubernetes cluster, 1.17 or newer.
+- Kubernetes cluster, 1.21 or newer. For Openshift, version 4.8 or newer.
 
 ## Contributing
 

--- a/controllers/cassandra/cassandradatacenter_controller.go
+++ b/controllers/cassandra/cassandradatacenter_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/k8ssandra/cass-operator/pkg/reconciliation"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -182,7 +182,7 @@ func (r *CassandraDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error
 		WithLogger(log).
 		For(&api.CassandraDatacenter{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.StatefulSet{}, builder.WithPredicates(managedByCassandraOperatorPredicate)).
-		Owns(&policyv1beta1.PodDisruptionBudget{}, builder.WithPredicates(managedByCassandraOperatorPredicate)).
+		Owns(&policyv1.PodDisruptionBudget{}, builder.WithPredicates(managedByCassandraOperatorPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(managedByCassandraOperatorPredicate))
 
 	configSecretMapFn := func(mapObj client.Object) []reconcile.Request {

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -7,7 +7,7 @@ and managing Cassandra or DSE in a Kubernetes cluster.
 
 ## Prerequisites
 
-1. A Kubernetes cluster. We support versions above 1.17
+1. A Kubernetes cluster. We support versions 1.21 and newer
 2. The ability to download images from Docker Hub from within the Kubernetes
    cluster. If that isn't possible, a private registry must be configured.
 

--- a/pkg/reconciliation/constructor.go
+++ b/pkg/reconciliation/constructor.go
@@ -10,26 +10,26 @@ import (
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/utils"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Create a PodDisruptionBudget object for the Datacenter
-func newPodDisruptionBudgetForDatacenter(dc *api.CassandraDatacenter) *policyv1beta1.PodDisruptionBudget {
+func newPodDisruptionBudgetForDatacenter(dc *api.CassandraDatacenter) *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(int(dc.Spec.Size - 1))
 	labels := dc.GetDatacenterLabels()
 	oplabels.AddOperatorLabels(labels, dc)
 	selectorLabels := dc.GetDatacenterLabels()
-	pdb := &policyv1beta1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        dc.Name + "-pdb",
 			Namespace:   dc.Namespace,
 			Labels:      labels,
 			Annotations: map[string]string{},
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -12,7 +12,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1442,7 +1442,7 @@ func (rc *ReconciliationContext) CheckDcPodDisruptionBudget() result.ReconcileRe
 	}
 
 	// Check if the budget already exists
-	currentBudget := &policyv1beta1.PodDisruptionBudget{}
+	currentBudget := &policyv1.PodDisruptionBudget{}
 	err := rc.Client.Get(
 		ctx,
 		types.NamespacedName{

--- a/tests/additional_seeds/additional_seeds_suite_test.go
+++ b/tests/additional_seeds/additional_seeds_suite_test.go
@@ -214,9 +214,12 @@ func getAdditionalSeedEndpointResourceAddresses() ([]interface{}, error) {
 	// Should be addresses and then go through them in the later check
 	jsonpath := "jsonpath={.subsets[0].addresses}"
 	k := kubectl.Get(additionalSeedEndpointResource).FormatOutput(jsonpath)
-	output := ns.OutputPanic(k)
+	output, err := ns.Output(k)
+	if err != nil {
+		return nil, err
+	}
 	ips := []interface{}{}
-	err := json.Unmarshal([]byte(output), &ips)
+	err = json.Unmarshal([]byte(output), &ips)
 	return ips, err
 }
 

--- a/tests/upgrade_operator/upgrade_operator_suite_test.go
+++ b/tests/upgrade_operator/upgrade_operator_suite_test.go
@@ -108,6 +108,11 @@ var _ = Describe(testName, func() {
 
 			ns.ExpectDoneReconciling(dcName)
 
+			// Verify PodDisruptionBudget is available (1.11 updates from v1beta1 -> v1)
+			json = "jsonpath={.items[].metadata.name}"
+			k = kubectl.Get("poddisruptionbudgets").WithLabel("cassandra.datastax.com/datacenter").FormatOutput(json)
+			ns.WaitForOutputContains(k, "dc1-pdb", 20)
+
 			// Update Cassandra version to ensure we can still do changes
 			step = "perform cassandra upgrade"
 			json = "{\"spec\": {\"serverVersion\": \"3.11.11\"}}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates PodDisruptionBudget from v1beta1 (deprecated) to v1. Bumps the required Kubernetes version to 1.21

**Which issue(s) this PR fixes**:
Fixes #183 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
