### PR TITLE
Support Cassandra 4.x.x versions, not just 4.0.x / 3.11.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] [#264](https://github.com/k8ssandra/cass-operator/issues/264) Generate PodTemplateSpec in CassandraDatacenter with metadata
 * [CHANGE] [#183](https://github.com/k8ssandra/cass-operator/issues/183) Move from PodDisruptionBudget v1beta1 to v1 (min. Kubernetes version 1.21)
+* [ENHANCEMENT] [#313](https://github.com/k8ssandra/cass-operator/issues/313) Add support for Cassandra 4.x.x versions instead of only 4.0.x
 * [ENHANCEMENT] [#292](https://github.com/k8ssandra/cass-operator/issues/292) Update to Go 1.17 with updates to dependencies: Kube 1.23.4 and controller-runtime 0.11.1 
 
 ## v1.10.3

--- a/apis/cassandra/v1beta1/webhook_test.go
+++ b/apis/cassandra/v1beta1/webhook_test.go
@@ -74,14 +74,27 @@ func Test_ValidateSingleDatacenter(t *testing.T) {
 			errString: "",
 		},
 		{
-			name: "Cassandra valid",
+			name: "Cassandra 4.0.x must be valid",
 			dc: &CassandraDatacenter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "exampleDC",
 				},
 				Spec: CassandraDatacenterSpec{
 					ServerType:    "cassandra",
-					ServerVersion: "4.0.0",
+					ServerVersion: "4.0.3",
+				},
+			},
+			errString: "",
+		},
+		{
+			name: "Cassandra 4.1 must be valid",
+			dc: &CassandraDatacenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exampleDC",
+				},
+				Spec: CassandraDatacenterSpec{
+					ServerType:    "cassandra",
+					ServerVersion: "4.1.0",
 				},
 			},
 			errString: "",
@@ -244,7 +257,9 @@ func Test_ValidateSingleDatacenter(t *testing.T) {
 					t.Errorf("ValidateSingleDatacenter() err = %v, want %v", err, tt.errString)
 				}
 			} else {
-				if !strings.HasSuffix(err.Error(), tt.errString) {
+				if tt.errString == "" {
+					t.Errorf("ValidateSingleDatacenter() err = %v, should be valid", err)
+				} else if !strings.HasSuffix(err.Error(), tt.errString) {
 					t.Errorf("ValidateSingleDatacenter() err = %v, want suffix %v", err, tt.errString)
 				}
 			}
@@ -752,7 +767,9 @@ func Test_ValidateDatacenterFieldChanges(t *testing.T) {
 					t.Errorf("ValidateDatacenterFieldChanges() err = %v, want %v", err, tt.errString)
 				}
 			} else {
-				if !strings.HasSuffix(err.Error(), tt.errString) {
+				if tt.errString == "" {
+					t.Errorf("ValidateDatacenterFieldChanges() err = %v, should be valid", err)
+				} else if !strings.HasSuffix(err.Error(), tt.errString) {
 					t.Errorf("ValidateDatacenterFieldChanges() err = %v, want suffix %v", err, tt.errString)
 				}
 			}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -24,7 +24,7 @@ var (
 
 const (
 	ValidDseVersionRegexp      = "6\\.8\\.\\d+"
-	ValidOssVersionRegexp      = "(3\\.11\\.\\d+)|(4\\.0\\.\\d+)"
+	ValidOssVersionRegexp      = "(3\\.11\\.\\d+)|(4\\.\\d+\\.\\d+)"
 	DefaultCassandraRepository = "k8ssandra/cass-management-api"
 	DefaultDSERepository       = "datastax/dse-server"
 )

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -111,5 +111,13 @@ func TestDefaultRepositories(t *testing.T) {
 	path, err = GetCassandraImage("dse", "6.8.17")
 	assert.NoError(err)
 	assert.Equal("datastax/dse-server:6.8.17", path)
+}
 
+func TestOssValidVersions(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(IsOssVersionSupported("4.0.0"))
+	assert.True(IsOssVersionSupported("4.1.0"))
+	assert.False(IsOssVersionSupported("4.0"))
+	assert.False(IsOssVersionSupported("4.1"))
+	assert.False(IsOssVersionSupported("6.8.0"))
 }


### PR DESCRIPTION
…the webhook_test for errorString validation.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes webhook_test_suite's error parsing to detect errors correctly when the string should've been valid. Also, modify support regexp for Cassandra 4.x.x versions instead of 4.0.x

**Which issue(s) this PR fixes**:
Fixes #313 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
