### PR TITLE
Verify the ReplaceNodes pod names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#313](https://github.com/k8ssandra/cass-operator/issues/313) Add support for Cassandra 4.x.x versions instead of only 4.0.x
 * [ENHANCEMENT] [#292](https://github.com/k8ssandra/cass-operator/issues/292) Update to Go 1.17 with updates to dependencies: Kube 1.23.4 and controller-runtime 0.11.1 
 * [BUGFIX] [#322](https://github.com/k8ssandra/cass-operator/pull/322) Add missing requeue if decommissioned pods haven't been removed yet
+* [BUGFIX] [#315](https://github.com/k8ssandra/cass-operator/pull/315) Validate podnames in the ReplaceNodes before moving them to NodeReplacements
 
 ## v1.10.3
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1085,7 +1085,7 @@ func (rc *ReconciliationContext) startReplacePodsIfReplacePodsSpecified() error 
 		}
 
 		if len(dc.Status.NodeReplacements) > 0 {
-			podNamesString := strings.Join(dc.Spec.ReplaceNodes, ", ")
+			podNamesString := strings.Join(dc.Status.NodeReplacements, ", ")
 
 			_ = rc.setCondition(
 				api.NewDatacenterCondition(api.DatacenterReplacingNodes, corev1.ConditionTrue))

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1589,7 +1589,7 @@ func TestNodereplacements(t *testing.T) {
 	assert.Equal(0, len(rc.Datacenter.Status.NodeReplacements))
 	assert.Equal(0, len(rc.Datacenter.Spec.ReplaceNodes))
 
-	rc.Datacenter.Spec.ReplaceNodes = []string{"dc1-default-sts-3"} // Does not exists
+	rc.Datacenter.Spec.ReplaceNodes = []string{"dc1-default-sts-3"} // Does not exist
 	err = rc.startReplacePodsIfReplacePodsSpecified()
 	assert.NoError(err)
 	assert.Equal(0, len(rc.Datacenter.Status.NodeReplacements))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Whenever user sets pod names to the Spec.ReplaceNodes, instead of blindly trusting the input, verify that the pod actually exists in our managed dc before moving it to the NodeReplacements.

**Which issue(s) this PR fixes**:
Fixes #315

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
