### PR TITLE
Fix the case when cluster names contain spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#345](https://github.com/k8ssandra/cass-operator/issues/345) Cluster names with spaces will prevent DC deployment
 ## v1.11.0
 
 * [CHANGE] [#183](https://github.com/k8ssandra/cass-operator/issues/183) Move from PodDisruptionBudget v1beta1 to v1 (changes min. required Kubernetes version to 1.21)

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -540,7 +540,7 @@ func (dc *CassandraDatacenter) GetDatacenterLabels() map[string]string {
 // GetClusterLabels returns a new map with the cluster label key and cluster name value
 func (dc *CassandraDatacenter) GetClusterLabels() map[string]string {
 	return map[string]string{
-		ClusterLabel: dc.Spec.ClusterName,
+		ClusterLabel: strings.ReplaceAll(dc.Spec.ClusterName, " ", ""),
 	}
 }
 

--- a/pkg/oplabels/labels.go
+++ b/pkg/oplabels/labels.go
@@ -5,6 +5,7 @@ package oplabels
 
 import (
 	"fmt"
+	"strings"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 )
@@ -25,7 +26,7 @@ func AddOperatorLabels(m map[string]string, dc *api.CassandraDatacenter) {
 	m[NameLabel] = NameLabelValue
 	m[VersionLabel] = dc.Spec.ServerVersion
 
-	instanceName := fmt.Sprintf("cassandra-%s", dc.Spec.ClusterName)
+	instanceName := fmt.Sprintf("cassandra-%s", strings.ReplaceAll(dc.Spec.ClusterName, " ", ""))
 	m[InstanceLabel] = instanceName
 
 	if len(dc.Spec.AdditionalLabels) != 0 {

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -67,6 +67,30 @@ func Test_validateLabelsForCluster(t *testing.T) {
 				oplabels.VersionLabel:   "4.0.1",
 			},
 		}, {
+			name: "Cluster name with spaces",
+			args: args{
+				resourceLabels: make(map[string]string),
+				rc: &ReconciliationContext{
+					Datacenter: &api.CassandraDatacenter{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "exampleDC",
+						},
+						Spec: api.CassandraDatacenterSpec{
+							ClusterName:   "Example Cluster",
+							ServerVersion: "4.0.1",
+						},
+					},
+				},
+			},
+			want: true,
+			wantLabels: map[string]string{
+				api.ClusterLabel:        "ExampleCluster",
+				oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+				oplabels.NameLabel:      oplabels.NameLabelValue,
+				oplabels.InstanceLabel:  fmt.Sprintf("%s-ExampleCluster", oplabels.NameLabelValue),
+				oplabels.VersionLabel:   "4.0.1",
+			},
+		}, {
 			name: "Nil labels",
 			args: args{
 				resourceLabels: nil,

--- a/tests/testdata/smoke-test-oss.yaml
+++ b/tests/testdata/smoke-test-oss.yaml
@@ -3,7 +3,7 @@ kind: CassandraDatacenter
 metadata:
   name: dc2
 spec:
-  clusterName: cluster2
+  clusterName: cluster 2
   serverType: cassandra
   serverVersion: "4.0.0"
   managementApiAuth:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Removes spaces from cluster names that have some when using that name in labels for services.

**Which issue(s) this PR fixes**:
Fixes #345

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
