### PR TITLE
feat: Added labels to easily find secrets what created for cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [BUGFIX] [#330](https://github.com/k8ssandra/cass-operator/issues/330) Apply correct updates to Service labels and annotations through additionalServiceConfig (they are now validated and don't allow reserved prefixes).
 
+* [CHANGE] [#359](https://github.com/k8ssandra/cass-operator/pull/359) All secrets have base labels with information about cluster
+
 ## v1.11.0
 
 * [CHANGE] [#183](https://github.com/k8ssandra/cass-operator/issues/183) Move from PodDisruptionBudget v1beta1 to v1 (changes min. required Kubernetes version to 1.21)

--- a/pkg/reconciliation/secrets.go
+++ b/pkg/reconciliation/secrets.go
@@ -142,6 +142,9 @@ func (rc *ReconciliationContext) retrieveSuperuserSecretOrCreateDefault() (*core
 }
 
 func (rc *ReconciliationContext) createInternodeCACredential() (*corev1.Secret, error) {
+	labels := make(map[string]string)
+	oplabels.AddOperatorLabels(labels, rc.Datacenter)
+
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -150,6 +153,7 @@ func (rc *ReconciliationContext) createInternodeCACredential() (*corev1.Secret, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rc.keystoreCASecret().Name,
 			Namespace: rc.keystoreCASecret().Namespace,
+			Labels:    labels,
 		},
 	}
 	if keypem, certpem, err := utils.GetNewCAandKey(fmt.Sprintf("%s-ca-keystore", rc.Datacenter.Name), rc.Datacenter.Namespace); err == nil {
@@ -172,6 +176,8 @@ func (rc *ReconciliationContext) createCABootstrappingSecret(jksBlob []byte) err
 	if err == nil { // This secret already exists, nothing to do
 		return nil
 	}
+	labels := make(map[string]string)
+	oplabels.AddOperatorLabels(labels, rc.Datacenter)
 
 	secret := &corev1.Secret{
 
@@ -182,6 +188,7 @@ func (rc *ReconciliationContext) createCABootstrappingSecret(jksBlob []byte) err
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-keystore", rc.Datacenter.Name),
 			Namespace: rc.Datacenter.Namespace,
+			Labels:    labels,
 		},
 	}
 	secret.Data = map[string][]byte{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Right now cass-operator create 3 secret per cluster
- ${nameCluster}-superuser
- ${Datacenter.Name}-keystore
- ${Datacenter.Name}-ca-keystore

and only one ${nameCluster}-superuser has base labels and so, I can't find all the secrets created for a cluster with a command like `kubectl get secret -l 'k8ssandra.io/cluster-name=my-cluster'`. My cases - I want to delete all secrets after deleting a cluster (right now I generate a name but using a label would be easy)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
