### PR TITLE
Create health condition for degraded status / quorum issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ```
 
 ## unreleased
+* [ENHANCEMENT] []() If Datacenter is degraded (replacing nodes, scaling, rolling restart etc) or cluster quorum reports unhealthy state, change Status Condition DatacenterHealthy to False.
 * [BUGFIX] [#355](https://github.com/k8ssandra/cass-operator/issues/335) Cleanse label values derived from cluster name, which can contain illegal chars. Include app.kubernetes.io/created-by label. 
-
 * [BUGFIX] [#330](https://github.com/k8ssandra/cass-operator/issues/330) Apply correct updates to Service labels and annotations through additionalServiceConfig (they are now validated and don't allow reserved prefixes).
 
 ## v1.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ```
 
 ## unreleased
-* [ENHANCEMENT] []() If Datacenter is degraded (replacing nodes, scaling, rolling restart etc) or cluster quorum reports unhealthy state, change Status Condition DatacenterHealthy to False.
+* [ENHANCEMENT] [#360](https://github.com/k8ssandra/cass-operator/pull/360) If Datacenter quorum reports unhealthy state, change Status Condition DatacenterHealthy to False (DBPE-2283)
 * [BUGFIX] [#355](https://github.com/k8ssandra/cass-operator/issues/335) Cleanse label values derived from cluster name, which can contain illegal chars. Include app.kubernetes.io/created-by label. 
 * [BUGFIX] [#330](https://github.com/k8ssandra/cass-operator/issues/330) Apply correct updates to Service labels and annotations through additionalServiceConfig (they are now validated and don't allow reserved prefixes).
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ lint: ## Run golangci-lint against code.
 	golangci-lint run ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet lint envtest ## Run tests.
 	# Old unit tests first - these use mocked client / fakeclient
 	go test ./pkg/... -coverprofile cover-pkg.out
 	# Then the envtest ones

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -328,6 +328,7 @@ const (
 	DatacenterRollingRestart DatacenterConditionType = "RollingRestart"
 	DatacenterValid          DatacenterConditionType = "Valid"
 	DatacenterDecommission   DatacenterConditionType = "Decommission"
+	DatacenterHealthy        DatacenterConditionType = "Healthy"
 )
 
 type DatacenterCondition struct {

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -328,7 +328,10 @@ const (
 	DatacenterRollingRestart DatacenterConditionType = "RollingRestart"
 	DatacenterValid          DatacenterConditionType = "Valid"
 	DatacenterDecommission   DatacenterConditionType = "Decommission"
-	DatacenterHealthy        DatacenterConditionType = "Healthy"
+
+	// DatacenterHealthy indicates if QUORUM can be reached from all deployed nodes.
+	// If this check fails, certain operations such as scaling up will not proceed.
+	DatacenterHealthy DatacenterConditionType = "Healthy"
 )
 
 type DatacenterCondition struct {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1307,6 +1307,8 @@ func (rc *ReconciliationContext) deleteStuckNodes() (bool, error) {
 	return false, nil
 }
 
+// isClusterHealthy does a LOCAL_QUORUM query to the Cassandra pods and returns true if all the pods were able to
+// respond without error.
 func (rc *ReconciliationContext) isClusterHealthy() bool {
 	pods := FilterPodListByCassNodeState(rc.clusterPods, stateStarted)
 
@@ -1319,32 +1321,6 @@ func (rc *ReconciliationContext) isClusterHealthy() bool {
 	}
 
 	return true
-}
-
-func (rc *ReconciliationContext) isClusterDegraded() bool {
-	dc := rc.Datacenter
-	status := false
-	if corev1.ConditionFalse == dc.GetConditionStatus(api.DatacenterReady) || corev1.ConditionTrue == dc.GetConditionStatus(api.DatacenterResuming) {
-		status = true
-	} else {
-		// Okay, we are ready, but we might be in some sort of degraded state too
-		degradedWhenTrue := []api.DatacenterConditionType{
-			api.DatacenterReplacingNodes,
-			api.DatacenterScalingUp,
-			api.DatacenterUpdating,
-			api.DatacenterResuming,
-			api.DatacenterRollingRestart,
-			api.DatacenterDecommission,
-		}
-		for _, condition := range degradedWhenTrue {
-			if corev1.ConditionTrue == dc.GetConditionStatus(condition) {
-				status = true
-				break
-			}
-		}
-	}
-
-	return status
 }
 
 // labelSeedPods iterates over all pods for a statefulset and makes sure the right number of

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2398,10 +2398,6 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	if recResult := rc.UpdateHealth(); recResult.Completed() {
-		return recResult.Output()
-	}
-
 	if recResult := rc.CheckConfigSecret(); recResult.Completed() {
 		return recResult.Output()
 	}

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -623,12 +623,16 @@ func (rc *ReconciliationContext) CheckPodsReady(endpointData httphelper.CassMeta
 
 	// step 3 - get all nodes up
 	// if the cluster isn't healthy, that's ok, but go back to step 1
-	if !rc.isClusterHealthy() {
+	clusterHealthy := rc.isClusterHealthy()
+	if err := rc.updateHealth(clusterHealthy); err != nil {
+		return result.Error(err)
+	}
+
+	if !clusterHealthy {
 		rc.ReqLogger.Info(
 			"cluster isn't healthy",
 		)
-		// FIXME this is one spot I've seen get spammy, should we raise this number?
-		return result.RequeueSoon(2)
+		return result.RequeueSoon(5)
 	}
 
 	needsMoreNodes, err := rc.startAllNodes(endpointData)
@@ -1161,11 +1165,11 @@ func (rc *ReconciliationContext) UpdateStatus() result.ReconcileResult {
 	return result.Continue()
 }
 
-func (rc *ReconciliationContext) UpdateHealth() result.ReconcileResult {
+func (rc *ReconciliationContext) updateHealth(healthy bool) error {
 	updated := false
 	dcPatch := client.MergeFrom(rc.Datacenter.DeepCopy())
 
-	if rc.isClusterDegraded() || !rc.isClusterHealthy() {
+	if !healthy {
 		updated = rc.setCondition(
 			api.NewDatacenterCondition(
 				api.DatacenterHealthy, corev1.ConditionFalse))
@@ -1178,11 +1182,11 @@ func (rc *ReconciliationContext) UpdateHealth() result.ReconcileResult {
 	if updated {
 		err := rc.Client.Status().Patch(rc.Ctx, rc.Datacenter, dcPatch)
 		if err != nil {
-			return result.Error(err)
+			return err
 		}
 	}
 
-	return result.Continue()
+	return nil
 }
 
 func hasBeenXMinutes(x int, sinceTime time.Time) bool {

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1635,23 +1635,3 @@ func TestNodereplacements(t *testing.T) {
 	assert.Equal(1, len(rc.Datacenter.Status.NodeReplacements))
 	assert.Equal(0, len(rc.Datacenter.Spec.ReplaceNodes))
 }
-
-func TestDatacenterHealthyStatus(t *testing.T) {
-	assert := assert.New(t)
-	rc, _, cleanupMockScr := setupTest()
-	defer cleanupMockScr()
-
-	mockClient := &mocks.Client{}
-	rc.Client = mockClient
-	k8sMockClientStatus(rc.Client.(*mocks.Client), mockClient).Times(2)
-	k8sMockClientPatch(mockClient, nil).Twice()
-
-	r := rc.UpdateHealth()
-	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
-	assert.Equal(rc.Datacenter.GetConditionStatus(api.DatacenterHealthy), corev1.ConditionTrue)
-
-	rc.Datacenter.Status.SetCondition(*api.NewDatacenterCondition(api.DatacenterReplacingNodes, corev1.ConditionTrue))
-	r = rc.UpdateHealth()
-	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
-	assert.Equal(rc.Datacenter.GetConditionStatus(api.DatacenterHealthy), corev1.ConditionFalse)
-}

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1635,3 +1635,23 @@ func TestNodereplacements(t *testing.T) {
 	assert.Equal(1, len(rc.Datacenter.Status.NodeReplacements))
 	assert.Equal(0, len(rc.Datacenter.Spec.ReplaceNodes))
 }
+
+func TestDatacenterHealthyStatus(t *testing.T) {
+	assert := assert.New(t)
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+
+	mockClient := &mocks.Client{}
+	rc.Client = mockClient
+	k8sMockClientStatus(rc.Client.(*mocks.Client), mockClient).Times(2)
+	k8sMockClientPatch(mockClient, nil).Twice()
+
+	r := rc.UpdateHealth()
+	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
+	assert.Equal(rc.Datacenter.GetConditionStatus(api.DatacenterHealthy), corev1.ConditionTrue)
+
+	rc.Datacenter.Status.SetCondition(*api.NewDatacenterCondition(api.DatacenterReplacingNodes, corev1.ConditionTrue))
+	r = rc.UpdateHealth()
+	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
+	assert.Equal(rc.Datacenter.GetConditionStatus(api.DatacenterHealthy), corev1.ConditionFalse)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
In case CassandraDatacenter is under some operation that degrades the cluster or QUORUM health check fails, update Condition on the Status to indicate this. This is to make user aware that certain other operations are not going to be successful.

**Which issue(s) this PR fixes**:
Fixes #376

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
