### PR TITLE
Allow custom Cassandra DC name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 * [BUGFIX] [#355](https://github.com/k8ssandra/cass-operator/issues/335) Cleanse label values derived from cluster name, which can contain illegal chars. Include app.kubernetes.io/created-by label. 
-
 * [BUGFIX] [#330](https://github.com/k8ssandra/cass-operator/issues/330) Apply correct updates to Service labels and annotations through additionalServiceConfig (they are now validated and don't allow reserved prefixes).
+* [ENHANCEMENT] [#362](https://github.com/k8ssandra/cass-operator/issues/362) Allow custom Casandra DC name instead of using the CassandraDatacenter name.
 
 ## v1.11.0
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -671,7 +671,12 @@ func (dc *CassandraDatacenter) GetConfigAsJSON(config []byte) (string, error) {
 			return "", errors.Wrap(err, "Error parsing Spec.Config for CassandraDatacenter resource")
 		}
 
-		if err := modelParsed.Merge(configParsed); err != nil {
+		collisionFn := func(dest, src interface{}) interface{} {
+			// Allow overrides of modelValues, e.g., the dc name.
+			return src
+		}
+
+		if err := modelParsed.MergeFn(configParsed, collisionFn); err != nil {
 			return "", errors.Wrap(err, "Error merging Spec.Config for CassandraDatacenter resource")
 		}
 	}

--- a/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -1,0 +1,90 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"github.com/Jeffail/gabs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGetConfigAsJSON(t *testing.T) {
+	type test struct {
+		name string
+		dc   *CassandraDatacenter
+		want string
+	}
+
+	tests := []test{
+		{
+			name: "custom DC name",
+			dc: &CassandraDatacenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "dc1",
+				},
+				Spec: CassandraDatacenterSpec{
+					Size:          1,
+					ServerType:    "cassandra",
+					ServerVersion: "4.0.4",
+					ClusterName:   "test",
+					Config:        json.RawMessage(`{"datacenter-info": {"name": "dev1"}}`),
+				},
+			},
+			want: `{
+              "cassandra-yaml": {},
+              "cluster-info": {
+                "name": "test",
+                "seeds": "test-seed-service,test-dc1-additional-seed-service"
+              },
+              "datacenter-info": {
+                "name": "dev1",
+                "graph-enabled": 0,
+                "solr-enabled": 0,
+                "spark-enabled": 0
+              }
+            }`,
+		},
+		{
+			name: "default DC name",
+			dc: &CassandraDatacenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "dc1",
+				},
+				Spec: CassandraDatacenterSpec{
+					Size:          1,
+					ServerType:    "cassandra",
+					ServerVersion: "4.0.4",
+					ClusterName:   "test",
+				},
+			},
+			want: `{
+              "cassandra-yaml": {},
+              "cluster-info": {
+                "name": "test",
+                "seeds": "test-seed-service,test-dc1-additional-seed-service"
+              },
+              "datacenter-info": {
+                "name": "dc1",
+                "graph-enabled": 0,
+                "solr-enabled": 0,
+                "spark-enabled": 0
+              }
+            }`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.dc.GetConfigAsJSON(tc.dc.Spec.Config)
+			require.NoError(t, err, "failed to parse CassandraDatacenter config into JSON")
+			expected, err := gabs.ParseJSON([]byte(tc.want))
+			require.NoError(t, err, "failed to parse tc.want into gabs.Container")
+			actual, err := gabs.ParseJSON([]byte(got))
+			require.NoError(t, err, "failed to parse got into gabs.Container")
+			assert.Equal(t, expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allows custom Cassandra DC name. Needed to avoid naming collisions in k8ssandra-operator.

**Which issue(s) this PR fixes**:
Fixes #362

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
