### PR TITLE
Replace all invalid characters from rackNames when used in Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#398](https://github.com/k8ssandra/cass-operator/issues/398) Update to go1.18 builds, update to use Kubernetes 1.24 envtest + dependencies, operator-sdk 1.23, controller-gen 0.9.2, Kustomize 4.5.7, controller-runtime 0.12.2
 * [ENHANCEMENT] [#383](https://github.com/k8ssandra/cass-operator/pull/383) Add UpgradeSSTables, Compaction and Scrub to management-api client. Improve CassandraTasks to have the ability to validate input parameters, filter target pods and do processing outside of pods.
 * [BUGFIX] [#327](https://github.com/k8ssandra/cass-operator/issues/327) Replace node done through CassandraTask can replace a node that's stuck in the Starting state.
-
+* [BUGFIX] [#404](https://github.com/k8ssandra/cass-operator/issues/404) Filter unallowed values from the rackname when used in Kubernetes resources
 
 ## v1.12.0
 
@@ -30,7 +30,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#360](https://github.com/k8ssandra/cass-operator/pull/360) If Datacenter quorum reports unhealthy state, change Status Condition DatacenterHealthy to False (DBPE-2283)
 * [ENHANCEMENT] [#317](https://github.com/k8ssandra/cass-operator/issues/317) Add ability for users to define CDC settings which will cause an agent to start within the Cassandra JVM and pass mutation events from Cassandra back to a Pulsar broker. (Tested on OSS Cassandra 4.x only.)
 * [ENHANCEMENT] [#369](https://github.com/k8ssandra/cass-operator/issues/369) Add configurable timeout for liveness / readiness and drain when mutual auth is used and a default timeout for all wget execs (required with mutual auth)
-* [BUGFIX] [#355](https://github.com/k8ssandra/cass-operator/issues/335) Cleanse label values derived from cluster name, which can contain illegal chars. Include app.kubernetes.io/created-by label. 
+* [BUGFIX] [#335](https://github.com/k8ssandra/cass-operator/issues/335) Cleanse label values derived from cluster name, which can contain illegal chars. Include app.kubernetes.io/created-by label. 
 * [BUGFIX] [#330](https://github.com/k8ssandra/cass-operator/issues/330) Apply correct updates to Service labels and annotations through additionalServiceConfig (they are now validated and don't allow reserved prefixes).
 * [BUGFIX] [#368](https://github.com/k8ssandra/cass-operator/issues/368) Do not fetch endpointStatus from pods that have not started
 * [BUGFIX] [#364](https://github.com/k8ssandra/cass-operator/issues/364) Do not log any errors if we fail to get endpoint states from nodes.

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -559,12 +559,12 @@ func (dc *CassandraDatacenter) GetClusterLabels() map[string]string {
 const (
 	dns1035LabelFmt     string = "[a-z]([-a-z0-9]*[a-z0-9])?"
 	dns1123SubdomainFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
-	labelFmt            string = "(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
+	dns1123LabelFmt     string = "(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
 )
 
 var dns1035LabelRegexp = regexp.MustCompile(dns1035LabelFmt)
 var dns1123SubdomainRegexp = regexp.MustCompile(dns1123SubdomainFmt)
-var dns1123LabelRegexp = regexp.MustCompile(labelFmt)
+var dns1123LabelRegexp = regexp.MustCompile(dns1123LabelFmt)
 
 // CleanLabelValue a valid label must be an empty string or consist of alphanumeric characters,
 // '-', '_' or '.', and must start and end with an alphanumeric.

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -474,7 +474,7 @@ func (dc *CassandraDatacenter) GetServerImage() string {
 // GetRackLabels ...
 func (dc *CassandraDatacenter) GetRackLabels(rackName string) map[string]string {
 	labels := dc.GetDatacenterLabels()
-	labels[RackLabel] = rackName
+	labels[RackLabel] = CleanLabelValue(rackName)
 	return labels
 }
 
@@ -555,23 +555,44 @@ func (dc *CassandraDatacenter) GetClusterLabels() map[string]string {
 	}
 }
 
-// apimachinery validation does not expose this, copied here
-const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+// apimachinery validation does not expose these, copied here
+const (
+	dns1035LabelFmt     string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+	dns1123SubdomainFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+	labelFmt            string = "(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
+)
 
-var whitelistRegex = regexp.MustCompile(`(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`)
+var dns1035LabelRegexp = regexp.MustCompile(dns1035LabelFmt)
+var dns1123SubdomainRegexp = regexp.MustCompile(dns1123SubdomainFmt)
+var dns1123LabelRegexp = regexp.MustCompile(labelFmt)
 
 // CleanLabelValue a valid label must be an empty string or consist of alphanumeric characters,
 // '-', '_' or '.', and must start and end with an alphanumeric.
 // Note: we apply a prefix of "cassandra-" to the cluster name value used as label name.
 // As such, empty string isn't a valid case.
 func CleanLabelValue(value string) string {
-	regexpResult := whitelistRegex.FindAllString(strings.Replace(value, " ", "", -1), -1)
+	regexpResult := dns1123LabelRegexp.FindAllString(strings.Replace(value, " ", "", -1), -1)
 	return strings.Join(regexpResult, "")
+}
+
+func CleanupSubdomain(input string) string {
+	if len(validation.IsDNS1123Subdomain(input)) > 0 {
+		r := dns1123SubdomainRegexp
+
+		// Invalid domain name, Kubernetes will reject this. Try to modify it to a suitable string
+		input = strings.ToLower(input)
+		input = strings.ReplaceAll(input, "_", "-")
+		validParts := r.FindAllString(input, -1)
+
+		return strings.Join(validParts, "")
+	}
+
+	return input
 }
 
 func CleanupForKubernetes(input string) string {
 	if len(validation.IsDNS1035Label(input)) > 0 {
-		r := regexp.MustCompile(dns1035LabelFmt)
+		r := dns1035LabelRegexp
 
 		// Invalid domain name, Kubernetes will reject this. Try to modify it to a suitable string
 		input = strings.ToLower(input)

--- a/pkg/oplabels/labels.go
+++ b/pkg/oplabels/labels.go
@@ -29,7 +29,7 @@ func AddOperatorLabels(m map[string]string, dc *api.CassandraDatacenter) {
 
 	if len(dc.Spec.AdditionalLabels) != 0 {
 		for key, value := range dc.Spec.AdditionalLabels {
-			m[key] = value
+			m[key] = api.CleanLabelValue(value)
 		}
 	}
 }

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -27,7 +27,7 @@ func newNamespacedNameForStatefulSet(
 	dc *api.CassandraDatacenter,
 	rackName string) types.NamespacedName {
 
-	name := api.CleanupForKubernetes(dc.Spec.ClusterName) + "-" + dc.Name + "-" + rackName + "-sts"
+	name := api.CleanupForKubernetes(dc.Spec.ClusterName) + "-" + dc.Name + "-" + api.CleanupSubdomain(rackName) + "-sts"
 	ns := dc.Namespace
 
 	return types.NamespacedName{

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -451,7 +451,7 @@ func Test_newStatefulSetForCassandraPodSecurityContext(t *testing.T) {
 	}
 }
 
-func TestValidName(t *testing.T) {
+func TestValidSubdomainNames(t *testing.T) {
 	assert := assert.New(t)
 	dc := &api.CassandraDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
@@ -485,7 +485,7 @@ func TestValidName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		typedName := newNamespacedNameForStatefulSet(dc, tt.name)
-		assert.Equal(typedName.Name, tt.expected)
+		assert.Equal(tt.expected, typedName.Name)
 	}
 }
 


### PR DESCRIPTION
… labels or resource names.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If rackName contains characters or structure that's not accepted by the Kubernetes (in label values or in constructed resource names), remove those invalid characters.

While for new clusters it makes more sense to reject them, we have to reserve them for older ones migrating to Kubernetes.

**Which issue(s) this PR fixes**:
Fixes #404 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
