### PR TITLE
Update Docker registry to new default

### DIFF
--- a/.github/actions/run-integ-test/action.yml
+++ b/.github/actions/run-integ-test/action.yml
@@ -12,6 +12,10 @@ inputs:
   serverImage:
     description: "Override server image used in the test file"
     required: false
+  GITHUB_TOKEN:
+    description: "GitHub Token (used by Helm action)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -48,6 +52,8 @@ runs:
     - name: Install Helm
       uses: azure/setup-helm@v3
       id: install_helm
+      with:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     - name: Download cass-operator image
       uses: actions/download-artifact@v2
       with:
@@ -66,9 +72,9 @@ runs:
     - name: Load image on the nodes of the cluster
       shell: bash
       run: |
-        kind load docker-image --name=kind k8ssandra/cass-operator:latest
-        kind load docker-image --name=kind k8ssandra/system-logger:latest
+        kind load docker-image --name=kind artifacts.k8ssandra.io/k8ssandra/images/cass-operator:latest
+        kind load docker-image --name=kind artifacts.k8ssandra.io/k8ssandra/images/system-logger:latest
     - name: Run integration test ( ${{ inputs.integration_test }} )
       shell: bash
       run: |
-        IMG=k8ssandra/cass-operator:latest make integ-test
+        IMG=artifacts.k8ssandra.io/k8ssandra/images/cass-operator:latest make integ-test

--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -29,7 +29,8 @@ jobs:
           file: Dockerfile
           context: .
           push: false
-          tags: k8ssandra/cass-operator:latest
+          tags: |
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator:latest
           platforms: linux/amd64
           outputs: type=docker,dest=/tmp/k8ssandra-cass-operator.tar
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -39,7 +40,8 @@ jobs:
         with:
           file: logger.Dockerfile
           push: false
-          tags: k8ssandra/system-logger:latest
+          tags: |
+            artifacts.k8ssandra.io/k8ssandra/images/system-logger:latest
           outputs: type=docker,dest=/tmp/k8ssandra-system-logger.tar
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -137,9 +139,9 @@ jobs:
         - "4.0.3"
         include:
           - version: 3.11.7
-            serverImage: k8ssandra/cass-management-api:3.11.7-v0.1.24 # k8ssandra 1.1
+            serverImage: artifacts.k8ssandra.io/k8ssandra/images/cass-management-api:3.11.7-v0.1.24 # k8ssandra 1.1
           - version: 4.0.0
-            serverImage: k8ssandra/cass-management-api:4.0.0-v0.1.28 # k8ssandra 1.3
+            serverImage: artifacts.k8ssandra.io/k8ssandra/images/cass-management-api:4.0.0-v0.1.28 # k8ssandra 1.3
       fail-fast: true
     runs-on: ubuntu-latest
     env:
@@ -157,6 +159,7 @@ jobs:
       - uses: ./.github/actions/run-integ-test
         with:
           integration_test: smoke_test_oss
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/operatorBuildAndDeploy.yml
+++ b/.github/workflows/operatorBuildAndDeploy.yml
@@ -56,11 +56,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: testing
     if: github.ref == 'refs/heads/master'
+    # Add "id-token" with the intended permissions.
+    permissions:
+        contents: 'read'
+        id-token: 'write'
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+            workload_identity_provider: 'projects/945064329182/locations/global/workloadIdentityPools/github-pool/providers/github'
+            service_account: 'gh-actions@k8ssandra.iam.gserviceaccount.com'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -73,20 +84,33 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      # Log in to Google Cloud Artifact Registry
+      - name: Login to GCP Artifact Registry
+        uses: 'docker/login-action@v1'
+        with:
+          registry: 'artifacts.k8ssandra.io'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
       - name: Set git parsed values
         id: vars
         run: |
           echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
           echo ::set-output name=tag_name::${GITHUB_REF#refs/tags/}
           echo ::set-output name=version::$(make version)
-      - name: Build and push
+      - name: Build and Push - Cass Operator
         id: docker_build_cass_operator
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: k8ssandra/cass-operator:${{ steps.vars.outputs.sha_short }}, k8ssandra/cass-operator:latest, k8ssandra/cass-operator:${{ steps.vars.outputs.version }}
+          tags: |
+            k8ssandra/cass-operator:${{ steps.vars.outputs.sha_short }}
+            k8ssandra/cass-operator:latest
+            k8ssandra/cass-operator:${{ steps.vars.outputs.version }}
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator:${{ steps.vars.outputs.sha_short }}
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator:latest
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator:${{ steps.vars.outputs.version }}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -96,13 +120,17 @@ jobs:
         with:
           file: logger.Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: k8ssandra/system-logger:${{ steps.vars.outputs.sha_short }}, k8ssandra/system-logger:latest
+          tags: |
+            k8ssandra/system-logger:${{ steps.vars.outputs.sha_short }}
+            k8ssandra/system-logger:latest
+            artifacts.k8ssandra.io/k8ssandra/images/system-logger:${{ steps.vars.outputs.sha_short }}
+            artifacts.k8ssandra.io/k8ssandra/images/system-logger:latest
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Create bundle
         run: |
-          make IMG=k8ssandra/cass-operator:${{ steps.vars.outputs.version }} VERSION=${{ steps.vars.outputs.version }} CHANNEL=dev bundle
+          make VERSION=${{ steps.vars.outputs.version }} CHANNEL=dev bundle
       - name: Build and push cass-operator-bundle
         id: docker_build_cass-operator_bundle
         uses: docker/build-push-action@v2
@@ -112,7 +140,9 @@ jobs:
             VERSION=${{ steps.vars.outputs.version }}
           context: .
           push: ${{ !env.ACT }}
-          tags: k8ssandra/cass-operator-bundle:v${{ steps.vars.outputs.version }}
+          tags: |
+            k8ssandra/cass-operator-bundle:v${{ steps.vars.outputs.version }}
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator-bundle:v${{ steps.vars.outputs.version }}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
           go-version: 1.18
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          workload_identity_provider: 'projects/945064329182/locations/global/workloadIdentityPools/github-pool/providers/github'
+          service_account: 'gh-actions@k8ssandra.iam.gserviceaccount.com'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
       - name: Cache Docker layers
         uses: actions/cache@v2
         if: ${{ !env.ACT }}
@@ -34,6 +41,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      # Log in to Google Cloud Artifact Registry
+      - name: Login to GCP Artifact Registry
+        uses: 'docker/login-action@v1'
+        with:
+          registry: 'artifacts.k8ssandra.io'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
       - name: Set git parsed values
         id: vars
         shell: bash
@@ -50,7 +64,9 @@ jobs:
             VERSION=${{ env.TARGET_VERSION }}
           context: .
           load: true
-          tags: k8ssandra/system-logger:${{ steps.vars.outputs.tag_name}}
+          tags: |
+            k8ssandra/system-logger:${{ steps.vars.outputs.tag_name}}
+            artifacts.k8ssandra.io/k8ssandra/images/system-logger:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -63,7 +79,9 @@ jobs:
             VERSION=${{ env.TARGET_VERSION }}
           context: .
           load: true
-          tags: k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}}
+          tags: |
+            k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}}
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -76,7 +94,9 @@ jobs:
             VERSION=${{ env.TARGET_VERSION }}
           context: .
           push: ${{ !env.ACT }}
-          tags: k8ssandra/system-logger:${{ steps.vars.outputs.tag_name}}
+          tags: |
+            k8ssandra/system-logger:${{ steps.vars.outputs.tag_name}}
+            artifacts.k8ssandra.io/k8ssandra/images/system-logger:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -89,7 +109,9 @@ jobs:
             VERSION=${{ env.TARGET_VERSION }}
           context: .
           push: ${{ !env.ACT }}
-          tags: k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}}
+          tags: |
+            k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}}
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -98,8 +120,8 @@ jobs:
         if: ${{ !env.ACT }}
         # The double docker login is a workaround for RH's odd login issues
         run: |
-          docker tag k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}} scan.connect.redhat.com/ospid-18783bca-8f79-459c-aa0b-bda4e71c6ec3/cass-operator:${{ steps.vars.outputs.tag_name}}
-          docker tag k8ssandra/system-logger:${{ steps.vars.outputs.tag_name}} scan.connect.redhat.com/ospid-6138f998fb33d420b79f0af9/system-logger:${{ steps.vars.outputs.tag_name}}
+          docker tag artifacts.k8ssandra.io/k8ssandra/images/cass-operator:${{ steps.vars.outputs.tag_name}} scan.connect.redhat.com/ospid-18783bca-8f79-459c-aa0b-bda4e71c6ec3/cass-operator:${{ steps.vars.outputs.tag_name}}
+          docker tag artifacts.k8ssandra.io/k8ssandra/images/system-logger:${{ steps.vars.outputs.tag_name}} scan.connect.redhat.com/ospid-6138f998fb33d420b79f0af9/system-logger:${{ steps.vars.outputs.tag_name}}
           docker login -u unused scan.connect.redhat.com -p ${{ secrets.CASS_OPERATOR_CONNECT_SECRET }}
           docker push scan.connect.redhat.com/ospid-18783bca-8f79-459c-aa0b-bda4e71c6ec3/cass-operator:${{ steps.vars.outputs.tag_name}}
           docker login -u unused scan.connect.redhat.com -p ${{ secrets.SYSTEM_LOGGER_CONNECT_SECRET }}
@@ -126,7 +148,7 @@ jobs:
         shell: bash
         if: ${{ !env.ACT }} # Act does not have yq
         run: |
-          make IMG=k8ssandra/cass-operator:${{ steps.vars.outputs.tag_name}} VERSION=${{ env.TARGET_VERSION }} bundle
+          make VERSION=${{ env.TARGET_VERSION }} bundle
       - name: Build and push cass-operator-bundle
         id: docker_build_cass-operator_bundle
         if: ${{ !env.ACT }}
@@ -138,7 +160,9 @@ jobs:
           context: .
           load: true
           push: ${{ !env.ACT }}
-          tags: k8ssandra/cass-operator-bundle:${{ steps.vars.outputs.tag_name}}
+          tags: |
+            k8ssandra/cass-operator-bundle:${{ steps.vars.outputs.tag_name}}
+            artifacts.k8ssandra.io/k8ssandra/images/cass-operator-bundle:${{ steps.vars.outputs.tag_name}}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#354](https://github.com/k8ssandra/cass-operator/issues/354) Remove oldDefunctLabel support since we recreate StS. Fix #335 created-by value to match expected value.
 * [CHANGE] [#385](https://github.com/k8ssandra/cass-operator/issues/385) Deprecate CassandraDatacenter's RollingRestartRequested. Use CassandraTask instead.
 * [CHANGE] [#397](https://github.com/k8ssandra/cass-operator/issues/397) Remove direct dependency to k8s.io/kubernetes
+* [CHANGE] [#414](https://github.com/k8ssandra/cass-operator/issues/414) Use new artifacts.k8ssandra.io repository for pulling images.
 * [FEATURE] [#384](https://github.com/k8ssandra/cass-operator/issues/384) Add a new CassandraTask operation "replacenode" that removes the existing PVCs from the pod, deletes the pod and starts a replacement process.
 * [FEATURE] [#387](https://github.com/k8ssandra/cass-operator/issues/387) Add a new CassandraTask operation "upgradesstables" that allows to do SSTable upgrades after Cassandra version upgrade.
 * [ENHANCEMENT] [#385](https://github.com/k8ssandra/cass-operator/issues/385) Add rolling restart as a CassandraTask action.

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -3,7 +3,7 @@ kind: ImageConfig
 metadata:
   name: image-config
 images:
-  system-logger: "k8ssandra/system-logger:latest"
+  system-logger: "artifacts.k8ssandra.io/k8ssandra/images/system-logger:latest"
   config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
@@ -16,7 +16,7 @@ images:
 defaults:
   # Note, postfix is ignored if repository is not set
   cassandra:
-    repository: "k8ssandra/cass-management-api"
+    repository: "artifacts.k8ssandra.io/k8ssandra/images/cass-management-api"
   dse:
     repository: "datastax/dse-server"
     suffix: "-ubi7"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: k8ssandra/cass-operator
-  newTag: v1.13.0-dev.0bb3086-20220819
+  newName: artifacts.k8ssandra.io/k8ssandra/images/cass-operator
+  newTag: latest

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -25,7 +25,7 @@ var (
 const (
 	ValidDseVersionRegexp      = "6\\.8\\.\\d+"
 	ValidOssVersionRegexp      = "(3\\.11\\.\\d+)|(4\\.\\d+\\.\\d+)"
-	DefaultCassandraRepository = "k8ssandra/cass-management-api"
+	DefaultCassandraRepository = "artifacts.k8ssandra.io/k8ssandra/images/cass-management-api"
 	DefaultDSERepository       = "datastax/dse-server"
 )
 

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -36,7 +36,7 @@ func TestCassandraOverride(t *testing.T) {
 
 	cassImage, err := GetCassandraImage("cassandra", "4.0.0")
 	assert.NoError(err, "getting Cassandra image should succeed")
-	assert.Equal("k8ssandra/cass-management-api:4.0.0", cassImage)
+	assert.Equal("artifacts.k8ssandra.io/k8ssandra/images/cass-management-api:4.0.0", cassImage)
 
 	imageConfig.Images.CassandraVersions = map[string]string{
 		"4.0.0": customImageName,
@@ -56,10 +56,10 @@ func TestDefaultImageConfigParsing(t *testing.T) {
 	// Verify some default values are set
 	assert.NotNil(GetImageConfig())
 	assert.NotNil(GetImageConfig().Images)
-	assert.True(strings.HasPrefix(GetImageConfig().Images.SystemLogger, "k8ssandra/system-logger:"))
+	assert.True(strings.HasPrefix(GetImageConfig().Images.SystemLogger, "artifacts.k8ssandra.io/k8ssandra/images/system-logger:"))
 	assert.True(strings.HasPrefix(GetImageConfig().Images.ConfigBuilder, "datastax/cass-config-builder:"))
 
-	assert.Equal("k8ssandra/cass-management-api", GetImageConfig().DefaultImages.CassandraImageComponent.Repository)
+	assert.Equal("artifacts.k8ssandra.io/k8ssandra/images/cass-management-api", GetImageConfig().DefaultImages.CassandraImageComponent.Repository)
 	assert.Equal("datastax/dse-server", GetImageConfig().DefaultImages.DSEImageComponent.Repository)
 
 	path, err := GetCassandraImage("dse", "6.8.17")
@@ -76,10 +76,10 @@ func TestImageConfigParsing(t *testing.T) {
 	// Verify some default values are set
 	assert.NotNil(GetImageConfig())
 	assert.NotNil(GetImageConfig().Images)
-	assert.True(strings.HasPrefix(GetImageConfig().Images.SystemLogger, "k8ssandra/system-logger:"))
+	assert.True(strings.HasPrefix(GetImageConfig().Images.SystemLogger, "artifacts.k8ssandra.io/k8ssandra/images/system-logger:"))
 	assert.True(strings.HasPrefix(GetImageConfig().Images.ConfigBuilder, "datastax/cass-config-builder:"))
 
-	assert.Equal("k8ssandra/cass-management-api", GetImageConfig().DefaultImages.CassandraImageComponent.Repository)
+	assert.Equal("artifacts.k8ssandra.io/k8ssandra/images/cass-management-api", GetImageConfig().DefaultImages.CassandraImageComponent.Repository)
 	assert.Equal("datastax/dse-server", GetImageConfig().DefaultImages.DSEImageComponent.Repository)
 
 	assert.Equal("localhost:5000", GetImageConfig().ImageRegistry)
@@ -106,7 +106,7 @@ func TestDefaultRepositories(t *testing.T) {
 
 	path, err := GetCassandraImage("cassandra", "4.0.1")
 	assert.NoError(err)
-	assert.Equal("k8ssandra/cass-management-api:4.0.1", path)
+	assert.Equal("artifacts.k8ssandra.io/k8ssandra/images/cass-management-api:4.0.1", path)
 
 	path, err = GetCassandraImage("dse", "6.8.17")
 	assert.NoError(err)

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -993,7 +993,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "cassandra",
 				serverVersion: "3.11.10",
 			},
-			want:      "k8ssandra/cass-management-api:3.11.10",
+			want:      "artifacts.k8ssandra.io/k8ssandra/images/cass-management-api:3.11.10",
 			errString: "",
 		},
 		{

--- a/scripts/post-release-process.sh
+++ b/scripts/post-release-process.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-IMG=k8ssandra/cass-operator:latest
+IMG=artifacts.k8ssandra.io/k8ssandra/images/cass-operator:latest
 KUSTOMIZE=$(pwd)/bin/kustomize
 
 # Add new ## unreleased after the tagging (post-release-process.sh)
@@ -12,4 +12,4 @@ gawk -i inplace  '/##/ && ++c==1 { print "## unreleased\n"; print; next }1' CHAN
 cd config/manager && $KUSTOMIZE edit set image controller=$IMG && cd -
 
 # Return config/manager/image_config.yaml to :latest
-LOG_IMG=k8ssandra/system-logger:latest yq eval -i '.images.system-logger = env(LOG_IMG)' config/manager/image_config.yaml
+LOG_IMG=artifacts.k8ssandra.io/k8ssandra/images/system-logger:latest yq eval -i '.images.system-logger = env(LOG_IMG)' config/manager/image_config.yaml

--- a/scripts/pre-release-process.sh
+++ b/scripts/pre-release-process.sh
@@ -8,7 +8,7 @@ fi
 TAG=$1
 PREVTAG=$2
 #PREVTAG=$(git describe --abbrev=0 --tags)
-IMG=k8ssandra/cass-operator:${TAG}
+IMG=artifacts.k8ssandra.io/k8ssandra/images/cass-operator:${TAG}
 
 # Ensure kustomize is installed
 make kustomize
@@ -25,4 +25,4 @@ sed -i -e "s/$PREVTAG/$TAG/g" README.md
 cd config/manager && $KUSTOMIZE edit set image controller=$IMG && cd -
 
 # Modify config/manager/image_config.yaml to have proper version for server-system-logger
-LOG_IMG=k8ssandra/system-logger:${TAG} yq eval -i '.images.system-logger = env(LOG_IMG)' config/manager/image_config.yaml
+LOG_IMG=artifacts.k8ssandra.io/k8ssandra/images/system-logger:${TAG} yq eval -i '.images.system-logger = env(LOG_IMG)' config/manager/image_config.yaml

--- a/tests/testdata/cass-operator-1.7.1-manifests.yaml
+++ b/tests/testdata/cass-operator-1.7.1-manifests.yaml
@@ -6786,7 +6786,7 @@ spec:
           value: cass-operator
         - name: SKIP_VALIDATING_WEBHOOK
           value: "FALSE"
-        image: k8ssandra/cass-operator:v1.7.1
+          image: artifacts.k8ssandra.io/k8ssandra/images/cass-operator:v1.7.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/testdata/image_config_parsing.yaml
+++ b/tests/testdata/image_config_parsing.yaml
@@ -3,7 +3,7 @@ kind: ImageConfig
 metadata:
   name: image-config
 images:
-  system-logger: "k8ssandra/system-logger:latest"
+  system-logger: "artifacts.k8ssandra.io/k8ssandra/images/system-logger:latest"
   config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
   cassandra:
     "4.0.0": "k8ssandra/cassandra-ubi:latest"
@@ -16,7 +16,7 @@ imagePullSecret:
 defaults:
   # Note, postfix is ignored if repository is not set
   cassandra:
-    repository: "k8ssandra/cass-management-api"
+    repository: "artifacts.k8ssandra.io/k8ssandra/images/cass-management-api"
   dse:
     repository: "datastax/dse-server"
     suffix: "-ubi7"


### PR DESCRIPTION
**What this PR does**:

Updates the registry coordinates to refer to the new Google Artifact Registry
GHA writes images to us-docker.pkg.dev/k8ssandra/images
Tests and defaults refer to us-docker.pkg.dev/k8ssandra/images
Makefile updates for new repository locations

Fixes #414 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
