### PR TITLE
fix address comparison for ipv6 cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#447](https://github.com/k8ssandra/cass-operator/issues/447) Update Github actions to remove all deprecated features (set-outputs, node v12 actions)
 * [CHANGE] [#448](https://github.com/k8ssandra/cass-operator/issues/448) Update to operator-sdk 1.25.1, update to go 1.19, update to Kubernetes 1.25, remove amd64 restriction on local builds (cass-operator and system-logger will be built for aarch64 also)
 * [FEATURE] [#441](https://github.com/k8ssandra/cass-operator/issues/441) Implement a CassandraTask for moving single-token nodes
+* [BUGFIX] [#410](https://github.com/k8ssandra/cass-operator/issues/410) Fix installation in IPv6 only environment
 
 ## v1.13.1
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"net"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -927,7 +928,7 @@ func (rc *ReconciliationContext) CreateUsers() result.ReconcileResult {
 
 func findHostIdForIpFromEndpointsData(endpointsData []httphelper.EndpointState, ip string) string {
 	for _, data := range endpointsData {
-		if data.GetRpcAddress() == ip {
+		if net.ParseIP(data.GetRpcAddress()).Equal(net.ParseIP(ip)) {
 			return data.HostID
 		}
 	}

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1955,3 +1955,25 @@ func TestStartOneNodePerRack(t *testing.T) {
 		})
 	}
 }
+
+func TestFindHostIdForIpFromEndpointsData(t *testing.T) {
+	endpoints := []httphelper.EndpointState{
+			{
+					HostID:     "1",
+					RpcAddress: "127.0.0.1",
+			},
+			{
+					HostID:     "2",
+					RpcAddress: "::1",
+			},
+			{
+					HostID:     "3",
+					RpcAddress: "2001:0DB8:0:0:8:800:200C:417A",
+			},
+	}
+
+	assert.Equal(t, "1", findHostIdForIpFromEndpointsData(endpoints, "127.0.0.1"))
+	assert.Equal(t, "2", findHostIdForIpFromEndpointsData(endpoints, "0:0:0:0:0:0:0:1"))
+	assert.Equal(t, "3", findHostIdForIpFromEndpointsData(endpoints, "2001:0DB8::8:800:200C:417A"))
+	assert.Equal(t, "", findHostIdForIpFromEndpointsData(endpoints, "192.168.1.0"))
+}


### PR DESCRIPTION
**What this PR does**:
fixes address comparison in findHostIdForIpFromEndpointsData to work properly for ipv6.

**Which issue(s) this PR fixes**:
Fixes #410 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
