### PR TITLE
Allow a developer to build the cass-operator images for different target architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ COPY pkg/ pkg/
 
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# Default the GOARCH to amd64, but allow for overide to a different arch at build time
+ARG ARCH=amd64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o manager main.go
 
 # Build the UBI image
 FROM redhat/ubi8-micro:latest

--- a/logger.Dockerfile
+++ b/logger.Dockerfile
@@ -1,6 +1,8 @@
 FROM redhat/ubi8-micro:latest
 
 ARG VERSION
+# Default the tini download to amd64, but allow for overide to a different arch at build time
+ARG TINI_BIN=tini
 
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="system-logger"
@@ -12,7 +14,7 @@ LABEL description="Sidecar to output Cassandra system logs to stdout"
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN} /sbin/tini
 ADD https://raw.githubusercontent.com/krallin/tini/master/LICENSE /licenses/LICENSE
 RUN chmod +x /sbin/tini
 COPY ./LICENSE.txt /licenses/


### PR DESCRIPTION
**What this PR does**:
This PR enables a developer to build the cass-operator and system-logger container images for a different target architecture.

**Which issue(s) this PR fixes**:
Addresses [#693](https://github.com/k8ssandra/k8ssandra-operator/issues/693) for developers willing to build images from code and push to their own container registry

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)