### PR TITLE
Use recently released DSE 6.8.28

### DIFF
--- a/tests/testdata/smoke-test-dse.yaml
+++ b/tests/testdata/smoke-test-dse.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster2
   serverType: dse
-  serverVersion: "6.8.26"
+  serverVersion: "6.8.28"
   managementApiAuth:
     insecure: {}
   size: 1


### PR DESCRIPTION
**What this PR does**:

Update the version of DSE used in smoke testing to the recently released 6.8.28

This supersedes #435.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
