### PR TITLE
Modify startOneNodeRack behavior with 0 target size StS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#291](https://github.com/k8ssandra/cass-operator/issues/291) Update Ginkgo to v2 (maintain current features, nothing additional from v2)
+* [BUGFIX] [#437](https://github.com/k8ssandra/cass-operator/issues/437) Fix startOneNodeRack to not loop forever in case of StS with size 0 (such as decommission of DC)
 
 ## v1.13.0
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -610,7 +610,7 @@ func (rc *ReconciliationContext) CheckPodsReady(endpointData httphelper.CassMeta
 		return result.Error(err)
 	}
 
-	if !clusterHealthy {
+	if !clusterHealthy && !(rc.Datacenter.Status.GetConditionStatus(api.DatacenterDecommission) == corev1.ConditionTrue) {
 		rc.ReqLogger.Info(
 			"cluster isn't healthy",
 		)

--- a/tests/decommission_dc/decommission_dc_suite_test.go
+++ b/tests/decommission_dc/decommission_dc_suite_test.go
@@ -19,7 +19,7 @@ var (
 	namespace = "test-decommission-dc"
 	dc1Name   = "dc1"
 	dc2Name   = "dc2"
-	dc1Yaml   = "../testdata/default-two-rack-two-node-dc1.yaml"
+	dc1Yaml   = "../testdata/default-two-rack-two-node-dc.yaml"
 	dc2Yaml   = "../testdata/default-two-rack-two-node-dc2.yaml"
 	dc1Label  = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc1Name)
 	dc2Label  = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc2Name)

--- a/tests/testdata/default-two-rack-two-node-dc2.yaml
+++ b/tests/testdata/default-two-rack-two-node-dc2.yaml
@@ -1,4 +1,4 @@
-ßapiVersion: cassandra.datastax.com/v1beta1
+apiVersion: cassandra.datastax.com/v1beta1
 kind: CassandraDatacenter
 metadata:
   name: dc2

--- a/tests/testdata/default-two-rack-two-node-dc2.yaml
+++ b/tests/testdata/default-two-rack-two-node-dc2.yaml
@@ -1,7 +1,7 @@
-apiVersion: cassandra.datastax.com/v1beta1
+ßapiVersion: cassandra.datastax.com/v1beta1
 kind: CassandraDatacenter
 metadata:
-  name: dc1
+  name: dc2
 spec:
   clusterName: cluster1
   serverType: cassandra
@@ -25,5 +25,5 @@ spec:
       initial_heap_size: "512m"
       max_heap_size: "512m"
       additional-jvm-opts:
-        - "-Dcassandra.system_distributed_replication_dc_names=dc1"
+        - "-Dcassandra.system_distributed_replication_dc_names=dc2"
         - "-Dcassandra.system_distributed_replication_per_dc=1"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Modify decommission test to use 2 racks per dc (and Cassandra 4.0.6)
* Modify startOneNodeRack to skip StatefulSets which have 0 target nodes, such as during decommission

**Which issue(s) this PR fixes**:
Fixes #437

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
