### PR TITLE
Bump config builder to v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#291](https://github.com/k8ssandra/cass-operator/issues/291) Update Ginkgo to v2 (maintain current features, nothing additional from v2)
+* [UPGRADE] Update cass-config-builder to 1.0.5.
 
 ## v1.13.0
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:v1.13.0"
-  config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0.5-ubi7"
   imageRegistry: "localhost:5000"
 defaults:
   cassandra:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0.5-ubi7"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -281,7 +281,7 @@ func Test_newStatefulSetForCassandraDatacenterWithAdditionalVolumes(t *testing.T
 		assert.Equal(t, "/var/log/cassandra", got.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].MountPath)
 
 		assert.Equal(t, "server-config-init", got.Spec.Template.Spec.InitContainers[1].Name)
-		assert.Equal(t, "datastax/cass-config-builder:1.0.4-ubi7", got.Spec.Template.Spec.InitContainers[1].Image)
+		assert.Equal(t, "datastax/cass-config-builder:1.0.5-ubi7", got.Spec.Template.Spec.InitContainers[1].Image)
 		assert.Equal(t, 1, len(got.Spec.Template.Spec.InitContainers[1].VolumeMounts))
 		assert.Equal(t, "server-config", got.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].Name)
 		assert.Equal(t, "/config", got.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].MountPath)

--- a/tests/testdata/image_config_parsing.yaml
+++ b/tests/testdata/image_config_parsing.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0.5-ubi7"
   cassandra:
     "4.0.0": "k8ssandra/cassandra-ubi:latest"
   dse:


### PR DESCRIPTION
**What this PR does**:

Bumps config-builder image to 1.0.5 (just released today).

**Which issue(s) this PR fixes**:
No issue.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
