### PR TITLE
Deprecate old cred-storage-mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [BUGFIX] [#431](https://github.com/k8ssandra/cass-operator/issues/431) Fix a bug where the restartTask would not provide success counts for restarted pods.
 * [BUGFIX] [#444](https://github.com/k8ssandra/cass-operator/issues/444) Update cass-config-builder to 1.0.5. Update the target tag of cass-config-builder to :1.0 to allow future updates in 1.0.x without rolling restarts.
 * [BUGFIX] [#437](https://github.com/k8ssandra/cass-operator/issues/437) Fix startOneNodeRack to not loop forever in case of StS with size 0 (such as decommission of DC)
+* [CHANGE] [#442](https://github.com/k8ssandra/cass-operator/issues/442) Do not mount encryption-cred-storage or create internode CAs if not needed. Recommended approach is to use cert-manager instead of this old legacy method.
 
 ## v1.13.0
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Jeffail/gabs"
+	"github.com/Jeffail/gabs/v2"
 	"github.com/k8ssandra/cass-operator/pkg/serverconfig"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -864,6 +864,38 @@ func (dc *CassandraDatacenter) DeploymentSupportsFQL() bool {
 	}
 
 	return true
+}
+
+func (dc *CassandraDatacenter) LegacyInternodeEnabled() bool {
+	config, err := gabs.ParseJSON(dc.Spec.Config)
+	if err != nil {
+		return false
+	}
+
+	hasOldKeyStore := func(gobContainer map[string]*gabs.Container) bool {
+		if gobContainer == nil {
+			return false
+		}
+
+		if keystorePath, found := gobContainer["keystore"]; found {
+			if strings.HasPrefix(keystorePath.Data().(string), "/etc/encryption") {
+				return true
+			}
+		}
+		return false
+	}
+
+	if config.Exists("cassandra-yaml.client_encryption_options") || config.Exists("cassandra-yaml.server_encryption_options") {
+		// Now verify the mount is correct also..
+		serverContainer := config.Path("cassandra-yaml.server_encryption_options").ChildrenMap()
+		clientContainer := config.Path("cassandra-yaml.server_encryption_options").ChildrenMap()
+
+		if hasOldKeyStore(clientContainer) || hasOldKeyStore(serverContainer) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func SplitRacks(nodeCount, rackCount int) []int {

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -878,17 +878,16 @@ func (dc *CassandraDatacenter) LegacyInternodeEnabled() bool {
 		}
 
 		if keystorePath, found := gobContainer["keystore"]; found {
-			if strings.HasPrefix(keystorePath.Data().(string), "/etc/encryption") {
+			if strings.TrimSpace(keystorePath.Data().(string)) == "/etc/encryption/node-keystore.jks" {
 				return true
 			}
 		}
 		return false
 	}
 
-	if config.Exists("cassandra-yaml.client_encryption_options") || config.Exists("cassandra-yaml.server_encryption_options") {
-		// Now verify the mount is correct also..
+	if config.Exists("cassandra-yaml", "client_encryption_options") || config.Exists("cassandra-yaml", "server_encryption_options") {
 		serverContainer := config.Path("cassandra-yaml.server_encryption_options").ChildrenMap()
-		clientContainer := config.Path("cassandra-yaml.server_encryption_options").ChildrenMap()
+		clientContainer := config.Path("cassandra-yaml.client_encryption_options").ChildrenMap()
 
 		if hasOldKeyStore(clientContainer) || hasOldKeyStore(serverContainer) {
 			return true

--- a/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -1,0 +1,66 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+   cassandra-yaml:
+     server_encryption_options:
+       internode_encryption: all
+       keystore: /etc/encryption/node-keystore.jks
+       keystore_password: dc2
+       truststore: /etc/encryption/node-keystore.jks
+       truststore_password: dc2
+*/
+
+var internodeEnabledAll = `
+{
+	"cassandra-yaml": {
+	  "server_encryption_options": {
+		"internode_encryption": "all",
+        "keystore": "/etc/encryption/node-keystore.jks",
+        "keystore_password": "dc2",
+        "truststore": "/etc/encryption/node-keystore.jks",
+        "truststore_password": "dc2"
+	  }
+	}
+}
+`
+
+var internodeSomethingElse = `
+{
+	"cassandra-yaml": {
+	  "server_encryption_options": {
+		"internode_encryption": "all",
+        "keystore": "/etc/encryption/cert-manager.jks",
+        "keystore_password": "aaaaaa",
+        "truststore": "/etc/encryption/cert-manager.jks",
+        "truststore_password": "bbbbb"
+	  }
+	}
+}
+`
+
+func TestLegacyInternodeEnabled(t *testing.T) {
+	dc := CassandraDatacenter{
+		Spec: CassandraDatacenterSpec{
+			Config: json.RawMessage(internodeEnabledAll),
+		},
+	}
+
+	assert.True(t, dc.LegacyInternodeEnabled())
+}
+
+func TestLegacyInternodeDisabled(t *testing.T) {
+	dc := CassandraDatacenter{
+		Spec: CassandraDatacenterSpec{
+			Config: json.RawMessage(internodeSomethingElse),
+		},
+	}
+
+	assert.False(t, dc.LegacyInternodeEnabled())
+}

--- a/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -7,16 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-/*
-   cassandra-yaml:
-     server_encryption_options:
-       internode_encryption: all
-       keystore: /etc/encryption/node-keystore.jks
-       keystore_password: dc2
-       truststore: /etc/encryption/node-keystore.jks
-       truststore_password: dc2
-*/
-
 var internodeEnabledAll = `
 {
 	"cassandra-yaml": {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/k8ssandra/cass-operator
 go 1.19
 
 require (
-	github.com/Jeffail/gabs v1.4.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.1.2
@@ -22,6 +21,7 @@ require (
 )
 
 require (
+	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/onsi/ginkgo/v2 v2.2.0
 	go.uber.org/zap v1.21.0
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
-github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
+github.com/Jeffail/gabs/v2 v2.6.1 h1:wwbE6nTQTwIMsMxzi6XFQQYRZ6wDc1mSdxoAN+9U4Gk=
+github.com/Jeffail/gabs/v2 v2.6.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -128,7 +128,7 @@ func newStatefulSetForCassandraDatacenter(
 
 	nsName := newNamespacedNameForStatefulSet(dc, rackName)
 
-	template, err := buildPodTemplateSpec(dc, nodeAffinityLabels, rackName, legacyInternodeMount(sts))
+	template, err := buildPodTemplateSpec(dc, nodeAffinityLabels, rackName, legacyInternodeMount(dc, sts))
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,11 @@ func newStatefulSetForCassandraDatacenter(
 	return result, nil
 }
 
-func legacyInternodeMount(sts *appsv1.StatefulSet) bool {
+func legacyInternodeMount(dc *api.CassandraDatacenter, sts *appsv1.StatefulSet) bool {
+	if dc.LegacyInternodeEnabled() {
+		return true
+	}
+
 	if sts != nil {
 		for _, vol := range sts.Spec.Template.Spec.Volumes {
 			if vol.Name == "encryption-cred-storage" {

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +58,7 @@ func Test_newStatefulSetForCassandraDatacenter(t *testing.T) {
 
 func Test_newStatefulSetForCassandraDatacenter_additionalLabels(t *testing.T) {
 	dc := &api.CassandraDatacenter{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "dc1",
 		},
 		Spec: api.CassandraDatacenterSpec{
@@ -258,18 +257,16 @@ func Test_newStatefulSetForCassandraDatacenterWithAdditionalVolumes(t *testing.T
 		assert.Equal(t, "cassandra-commitlogs", got.Spec.VolumeClaimTemplates[2].Name)
 		assert.Equal(t, customCassandraCommitLogsStorageClass, *got.Spec.VolumeClaimTemplates[2].Spec.StorageClassName)
 
-		assert.Equal(t, 2, len(got.Spec.Template.Spec.Volumes))
+		assert.Equal(t, 1, len(got.Spec.Template.Spec.Volumes))
 		assert.Equal(t, "server-config", got.Spec.Template.Spec.Volumes[0].Name)
-		assert.Equal(t, "encryption-cred-storage", got.Spec.Template.Spec.Volumes[1].Name)
 
 		assert.Equal(t, 2, len(got.Spec.Template.Spec.Containers))
 
-		assert.Equal(t, 5, len(got.Spec.Template.Spec.Containers[0].VolumeMounts))
+		assert.Equal(t, 4, len(got.Spec.Template.Spec.Containers[0].VolumeMounts))
 		assert.Equal(t, "server-logs", got.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
 		assert.Equal(t, "cassandra-commitlogs", got.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name)
 		assert.Equal(t, "server-data", got.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name)
-		assert.Equal(t, "encryption-cred-storage", got.Spec.Template.Spec.Containers[0].VolumeMounts[3].Name)
-		assert.Equal(t, "server-config", got.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name)
+		assert.Equal(t, "server-config", got.Spec.Template.Spec.Containers[0].VolumeMounts[3].Name)
 
 		assert.Equal(t, 2, len(got.Spec.Template.Spec.Containers[1].VolumeMounts))
 		assert.Equal(t, 2, len(got.Spec.Template.Spec.InitContainers))

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -117,6 +117,10 @@ func (rc *ReconciliationContext) CheckSuperuserSecretCreation() result.Reconcile
 func (rc *ReconciliationContext) CheckInternodeCredentialCreation() result.ReconcileResult {
 	rc.ReqLogger.Info("reconcile_racks::CheckInternodeCredentialCreation")
 
+	if !rc.Datacenter.LegacyInternodeEnabled() {
+		return result.Continue()
+	}
+
 	_, err := rc.retrieveInternodeCredentialSecretOrCreateDefault()
 	if err != nil {
 		rc.ReqLogger.Error(err, "error retrieving InternodeCredential for CassandraDatacenter.")
@@ -1774,7 +1778,7 @@ func (rc *ReconciliationContext) startCassandra(endpointData httphelper.CassMeta
 		if hostId != "" {
 			replaceAddress, err = FindIpForHostId(endpointData, hostId)
 			if err != nil {
-				return fmt.Errorf("Failed to start replace of cassandra node %s for pod %s due to error: %w", hostId, pod.Name, err)
+				return fmt.Errorf("failed to start replace of cassandra node %s for pod %s due to error: %w", hostId, pod.Name, err)
 			}
 		}
 	}
@@ -2287,7 +2291,7 @@ func (rc *ReconciliationContext) CheckClearActionConditions() result.ReconcileRe
 func (rc *ReconciliationContext) CheckForInvalidState() result.ReconcileResult {
 	cond, isSet := rc.Datacenter.GetCondition(api.DatacenterValid)
 	if isSet && cond.Status == corev1.ConditionFalse {
-		err := fmt.Errorf("Datacenter %s is not in a valid state: %s", rc.Datacenter.Name, cond.Message)
+		err := fmt.Errorf("datacenter %s is not in a valid state: %s", rc.Datacenter.Name, cond.Message)
 		return result.Error(err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Do not add encryption-cred-storage for new datacenters, if no /etc/encryption is requested in cassandra-yaml configs. But also do not remove it from existing ones to prevent unnecessary rolling restart.

**Which issue(s) this PR fixes**:
Fixes #442 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
