### PR TITLE
Use tag 1.0 for cass-config-builder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:v1.13.0"
-  config-builder: "datastax/cass-config-builder:1.0.5-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0-ubi7"
   imageRegistry: "localhost:5000"
 defaults:
   cassandra:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0.5-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0-ubi7"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/docs/ingress/kong/sni-ingress/README.md
+++ b/docs/ingress/kong/sni-ingress/README.md
@@ -13,7 +13,7 @@ When leveraging a single endpoint ingress / load balancer we lose the ability to
     # Import images from the local Docker daemon
     k3d load image --cluster k3s-default \
       datastax/cass-operator:1.3.0 \
-      datastax/cass-config-builder:1.0.0-ubi7 \
+      datastax/cass-config-builder:1.0-ubi7 \
       datastax/dse-server:6.8.4-ubi7 \
       datastax/cassandra:3.11.6-ubi7
     ```

--- a/docs/ingress/traefik/load-balancing/README.md
+++ b/docs/ingress/traefik/load-balancing/README.md
@@ -13,7 +13,7 @@ When leveraging a single endpoint ingress / load balancer we lose the ability to
    # Import images from the local Docker daemon
    k3d i datastax/cass-operator:1.2.0
    k3d i datastax/cassandra:3.11.6-ubi7
-   k3d i datastax/cass-config-builder:1.0.0-ubi7
+   k3d i datastax/cass-config-builder:1.0-ubi7
    ```
 
 1. Install Traefik with Helm

--- a/docs/ingress/traefik/mtls-load-balancing/README.md
+++ b/docs/ingress/traefik/mtls-load-balancing/README.md
@@ -13,7 +13,7 @@ When leveraging a single endpoint ingress / load balancer we lose the ability to
    # Import images from the local Docker daemon
    k3d i datastax/cass-operator:1.2.0
    k3d i datastax/cassandra:3.11.6-ubi7
-   k3d i datastax/cass-config-builder:1.0.0-ubi7
+   k3d i datastax/cass-config-builder:1.0-ubi7
    ```
 
 1. Install Traefik with Helm

--- a/docs/ingress/traefik/mtls-sni/README.md
+++ b/docs/ingress/traefik/mtls-sni/README.md
@@ -11,7 +11,7 @@ When leveraging a single endpoint ingress / load balancer we naturally remove th
    # Import images from the local Docker daemon
    k3d i datastax/cass-operator:1.2.0
    k3d i datastax/cassandra:3.11.6-ubi7
-   k3d i datastax/cass-config-builder:1.0.0-ubi7
+   k3d i datastax/cass-config-builder:1.0-ubi7
    ```
 
 1. Install Traefik with Helm

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -281,7 +281,7 @@ func Test_newStatefulSetForCassandraDatacenterWithAdditionalVolumes(t *testing.T
 		assert.Equal(t, "/var/log/cassandra", got.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].MountPath)
 
 		assert.Equal(t, "server-config-init", got.Spec.Template.Spec.InitContainers[1].Name)
-		assert.Equal(t, "datastax/cass-config-builder:1.0.5-ubi7", got.Spec.Template.Spec.InitContainers[1].Image)
+		assert.Equal(t, "datastax/cass-config-builder:1.0-ubi7", got.Spec.Template.Spec.InitContainers[1].Image)
 		assert.Equal(t, 1, len(got.Spec.Template.Spec.InitContainers[1].VolumeMounts))
 		assert.Equal(t, "server-config", got.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].Name)
 		assert.Equal(t, "/config", got.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].MountPath)

--- a/tests/testdata/image_config_parsing.yaml
+++ b/tests/testdata/image_config_parsing.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0.5-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0-ubi7"
   cassandra:
     "4.0.0": "k8ssandra/cassandra-ubi:latest"
   dse:


### PR DESCRIPTION
**What this PR does**:

Uses cass-config-builder 1.0 tag so that we get the latest 1.0 release and don't have to manually update frequently. 

For users who wish to use a pinned patch version this can be changed via the ImageConfig structures.

**Which issue(s) this PR fixes**:
No issue.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
