### PR TITLE
When task completes, set the running status to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#448](https://github.com/k8ssandra/cass-operator/issues/448) Update to operator-sdk 1.25.1, update to go 1.19, update to Kubernetes 1.25, remove amd64 restriction on local builds (cass-operator and system-logger will be built for aarch64 also)
 * [FEATURE] [#441](https://github.com/k8ssandra/cass-operator/issues/441) Implement a CassandraTask for moving single-token nodes
 * [BUGFIX] [#410](https://github.com/k8ssandra/cass-operator/issues/410) Fix installation in IPv6 only environment
+* [BUGFIX] [#455](https://github.com/k8ssandra/cass-operator/issues/455) After task had completed, the running state would still say true
 
 ## v1.13.1
 

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cassandradatacenters.cassandra.datastax.com
 spec:

--- a/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: cassandratasks.control.k8ssandra.io
 spec:

--- a/controllers/control/cassandratask_controller.go
+++ b/controllers/control/cassandratask_controller.go
@@ -352,6 +352,7 @@ JobDefinition:
 		cassTask.Status.Active = 0
 		cassTask.Status.CompletionTime = &timeNow
 		SetCondition(&cassTask, api.JobComplete, corev1.ConditionTrue)
+		SetCondition(&cassTask, api.JobRunning, corev1.ConditionFalse)
 
 		// Requeue for deletion later
 		deletionTime := calculateDeletionTime(&cassTask)
@@ -388,7 +389,8 @@ func (r *CassandraTaskReconciler) HasCondition(task api.CassandraTask, condition
 
 func SetCondition(task *api.CassandraTask, condition api.JobConditionType, status corev1.ConditionStatus) bool {
 	existing := false
-	for _, cond := range task.Status.Conditions {
+	for i := 0; i < len(task.Status.Conditions); i++ {
+		cond := task.Status.Conditions[i]
 		if cond.Type == condition {
 			if cond.Status == status {
 				// Already correct status
@@ -397,6 +399,7 @@ func SetCondition(task *api.CassandraTask, condition api.JobConditionType, statu
 			cond.Status = status
 			cond.LastTransitionTime = metav1.Now()
 			existing = true
+			task.Status.Conditions[i] = cond
 			break
 		}
 	}

--- a/controllers/control/cassandratask_controller_test.go
+++ b/controllers/control/cassandratask_controller_test.go
@@ -258,6 +258,16 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 					// verifyPodsHaveAnnotations(testNamespaceName, string(task.UID))
 					Expect(completedTask.Status.Succeeded).To(BeNumerically(">=", 1))
+
+					Expect(len(completedTask.Status.Conditions)).To(Equal(2))
+					for _, cond := range completedTask.Status.Conditions {
+						switch cond.Type {
+						case api.JobComplete:
+							Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+						case api.JobRunning:
+							Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+						}
+					}
 				})
 			})
 			It("Runs a UpgradeSSTables task against the datacenter pods", func() {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -5,11 +5,11 @@ package reconciliation
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
-	"net"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1958,18 +1958,18 @@ func TestStartOneNodePerRack(t *testing.T) {
 
 func TestFindHostIdForIpFromEndpointsData(t *testing.T) {
 	endpoints := []httphelper.EndpointState{
-			{
-					HostID:     "1",
-					RpcAddress: "127.0.0.1",
-			},
-			{
-					HostID:     "2",
-					RpcAddress: "::1",
-			},
-			{
-					HostID:     "3",
-					RpcAddress: "2001:0DB8:0:0:8:800:200C:417A",
-			},
+		{
+			HostID:     "1",
+			RpcAddress: "127.0.0.1",
+		},
+		{
+			HostID:     "2",
+			RpcAddress: "::1",
+		},
+		{
+			HostID:     "3",
+			RpcAddress: "2001:0DB8:0:0:8:800:200C:417A",
+		},
 	}
 
 	assert.Equal(t, "1", findHostIdForIpFromEndpointsData(endpoints, "127.0.0.1"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
After the job completes, the running status is left to True. It should be False.

**Which issue(s) this PR fixes**:
Fixes #455 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
