### PR TITLE
Verify the CI is in clean state after manifests generate, as well as …

### DIFF
--- a/.github/workflows/operatorBuildAndDeploy.yml
+++ b/.github/workflows/operatorBuildAndDeploy.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Verify manifests and dirty state
         run: |
           make manifests generate
+          git update-index -q --really-refresh
           git diff-files --quiet
       - name: Unit Tests
         run: |

--- a/.github/workflows/operatorBuildAndDeploy.yml
+++ b/.github/workflows/operatorBuildAndDeploy.yml
@@ -36,6 +36,10 @@ jobs:
           only-new-issues: ${{ github.event_name == 'pull_request' }}
           skip-pkg-cache: true
           skip-build-cache: true
+      - name: Verify manifests and dirty state
+        run: |
+          make manifests generate
+          git diff-files --quiet
       - name: Unit Tests
         run: |
           make test


### PR DESCRIPTION
…when installing tools, verify that they are the correct version

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Before running unit tests, the CI runs ``make manifests generate`` and verifies the committed files are in agreement.

Also, when doing ``make controller-gen`` or  ``make kustomize`` the version is verified and then replaced if necessary.

**Which issue(s) this PR fixes**:
Fixes #482 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
