### PR TITLE
Expose the new metrics port in the all-pods service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#315](https://github.com/k8ssandra/cass-operator/issues/351) PodTemplateSpec allows setting Affinities, which are merged with the current rules. PodAntiAffinity behavior has changed, if allowMultipleWorkers is set to true the PodTemplateSpec antiAffinity rules are copied as is, otherwise merged with current restrictions. Prevent usage of deprecated rack.Zone (use topology.kubernetes.io/zone label instead), but allow removal of Zone.
 * [BUGFIX] [#410](https://github.com/k8ssandra/cass-operator/issues/410) Fix installation in IPv6 only environment
 * [BUGFIX] [#455](https://github.com/k8ssandra/cass-operator/issues/455) After task had completed, the running state would still say true
+* [BUGFIX] [#488](https://github.com/k8ssandra/cass-operator/issues/488) Expose the new metrics port in services
 
 ## v1.13.1
 

--- a/pkg/reconciliation/construct_service.go
+++ b/pkg/reconciliation/construct_service.go
@@ -6,6 +6,7 @@ package reconciliation
 // This file defines constructors for k8s service-related objects
 import (
 	"net"
+	"strings"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
@@ -32,7 +33,12 @@ func newServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.Servi
 		namedServicePort("tls-native", 9142, 9142),
 		namedServicePort("mgmt-api", 8080, 8080),
 		namedServicePort("prometheus", 9103, 9103),
-		namedServicePort("thrift", 9160, 9160),
+		namedServicePort("metrics", 9000, 9000),
+	}
+
+	if strings.HasPrefix(dc.Spec.ServerVersion, "3.") || dc.Spec.ServerType == "dse" {
+		ports = append(ports,
+			namedServicePort("thrift", 9160, 9160))
 	}
 
 	if dc.Spec.DseWorkloads != nil {
@@ -257,6 +263,9 @@ func newAllPodsServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev
 		},
 		{
 			Name: "prometheus", Port: 9103, TargetPort: intstr.FromInt(9103),
+		},
+		{
+			Name: "metrics", Port: 9000, TargetPort: intstr.FromInt(9000),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Exposes the 9000 port in 2 services: DC and all-pods.

**Which issue(s) this PR fixes**:
Fixes #488 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
