### PR TITLE
Allow disable mcac even when CDC enabled

### DIFF
--- a/pkg/cdc/generate_config.go
+++ b/pkg/cdc/generate_config.go
@@ -91,8 +91,6 @@ func updateAdditionalJVMOpts(optsSlice []string, CDCConfig *cassdcapi.CDCConfigu
 			optsSlice = append(optsSlice, nameTag+"="+fmt.Sprintf("%s", reflectedValue))
 		}
 	}
-	// We need to add these two elements to the slice first, because the management agent must start before the CDC agent.
-	// If MCAC is disabled, we need to avoid adding it to startup.
 	CDCOpt := fmt.Sprintf("-javaagent:%s=%s", "/opt/cdc_agent/cdc-agent.jar", strings.Join(optsSlice, ","))
 	// We want to disable MCAC when the server being deployed is DSE
 	if cassDC.Spec.ServerType == "cassandra" && mcacEnabled {
@@ -100,7 +98,7 @@ func updateAdditionalJVMOpts(optsSlice []string, CDCConfig *cassdcapi.CDCConfigu
 			"-javaagent:/opt/metrics-collector/lib/datastax-mcac-agent.jar",
 		)
 	}
-	out = append(out, // We need to add these two elements to the slice first, because the management agent must start before the CDC agent.
+	out = append(out,
 		"-javaagent:/opt/management-api/datastax-mgmtapi-agent.jar",
 	)
 	return append(out, CDCOpt), nil


### PR DESCRIPTION
**What this PR does**:

Ensures that CDC classpath/agent manipulation logic doesn't erroneously re-enable MCAC when the MCAC environment variable is set to disable it.

**Which issue(s) this PR fixes**:
Fixes #481 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
