### PR TITLE
Do not track the cleanup task status anymore in CassandraDatacenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#501](https://github.com/k8ssandra/cass-operator/issues/501) Replaced server-system-logger with a Vector based implementation. Also, examples are added how the Cassandra system.log can be parsed to a more structured format.
+* [CHANGE] []() ScalingUp is no longer tied to the lifecycle of the cleanup job. The cleanup job is created after the ScaleUp has finished, but to track its progress one should check the status of the CassandraTask and not the CassandraDatacenter's status. Also, added a new annotation to the Datacenter "cassandra.datastax.com/no-cleanup", which if set prevents from the creation of the CassandraTask.
 
 ## v1.14.0
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -60,6 +60,10 @@ const (
 	// If no finalizer is set, the cass-operator ProcessDeletion() is not run
 	Finalizer = "finalizer.cassandra.datastax.com"
 
+	// NoAutomatedCleanUpAnnotation prevents the cass-operator from creating a CassandraTask to do cleanup after the
+	// cluster has gone through scale up operation.
+	NoAutomatedCleanupAnnotation = "cassandra.datastax.com/no-cleanup"
+
 	CassNodeState = "cassandra.datastax.com/node-state"
 
 	ProgressUpdating ProgressState = "Updating"

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2125,59 +2125,14 @@ func (rc *ReconciliationContext) CheckCassandraNodeStatuses() result.ReconcileRe
 }
 
 func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
-	// Verify if the cleanup task has completed before moving on the with ScalingUp finished
-	task, err := rc.findActiveTask(taskapi.CommandCleanup)
-	if err != nil {
-		return result.Error(err)
-	}
-
-	if task != nil {
-		return rc.activeTaskCompleted(task)
-	}
-
-	// Create the cleanup task
-	err = rc.createTask(taskapi.CommandCleanup)
-	if err != nil {
-		return result.Error(err)
-	}
-
-	return result.RequeueSoon(10)
-}
-
-func (rc *ReconciliationContext) activeTaskCompleted(task *taskapi.CassandraTask) result.ReconcileResult {
-	if task.Status.CompletionTime != nil {
-		// Job was completed, remove it from followed task
-		dc := rc.Datacenter
-		dcPatch := client.MergeFrom(dc.DeepCopy())
-
-		rc.Datacenter.Status.RemoveTrackedTask(task.ObjectMeta)
-
-		if err := rc.Client.Status().Patch(rc.Ctx, dc, dcPatch); err != nil {
+	if !metav1.HasAnnotation(rc.Datacenter.ObjectMeta, api.NoAutomatedCleanupAnnotation) {
+		// Create the cleanup task
+		if err := rc.createTask(taskapi.CommandCleanup); err != nil {
 			return result.Error(err)
 		}
-
-		return result.Continue()
 	}
-	return result.RequeueSoon(10)
-}
 
-func (rc *ReconciliationContext) findActiveTask(command taskapi.CassandraCommand) (*taskapi.CassandraTask, error) {
-	if len(rc.Datacenter.Status.TrackedTasks) > 0 {
-		for _, taskMeta := range rc.Datacenter.Status.TrackedTasks {
-			taskKey := types.NamespacedName{Name: taskMeta.Name, Namespace: taskMeta.Namespace}
-			task := &taskapi.CassandraTask{}
-			if err := rc.Client.Get(rc.Ctx, taskKey, task); err != nil {
-				return nil, err
-			}
-
-			for _, job := range task.Spec.Jobs {
-				if job.Command == command {
-					return task, nil
-				}
-			}
-		}
-	}
-	return nil, nil
+	return result.Continue()
 }
 
 func (rc *ReconciliationContext) createTask(command taskapi.CassandraCommand) error {
@@ -2241,7 +2196,7 @@ func (rc *ReconciliationContext) CheckClearActionConditions() result.ReconcileRe
 
 	// Explicitly handle scaling up here because we want to run a cleanup afterwards
 	if dc.GetConditionStatus(api.DatacenterScalingUp) == corev1.ConditionTrue {
-		// Call the first node with cleanup, wait until it has finished and then move on to the next pod..
+		// Spawn a cleanup task before continuing
 		if res := rc.cleanupAfterScaling(); res.Completed() {
 			return res
 		}

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1520,23 +1520,8 @@ func TestCleanupAfterScaling(t *testing.T) {
 	k8sMockClientPatch(mockClient, nil).Once()
 
 	r := rc.cleanupAfterScaling()
-	assert.Equal(result.RequeueSoon(10), r, "expected result of result.RequeueSoon(10)")
-	assert.Equal(1, len(rc.Datacenter.Status.TrackedTasks))
-
-	// 3. GET - return completed task
-	k8sMockClientGet(rc.Client.(*mocks.Client), nil).
-		Run(func(args mock.Arguments) {
-			arg := args.Get(2).(*taskapi.CassandraTask)
-			task.DeepCopyInto(arg)
-			timeNow := metav1.Now()
-			arg.Status.CompletionTime = &timeNow
-		}).Once()
-	// 4. Patch to datacenter status
-	k8sMockClientPatch(mockClient, nil).Once()
-
-	r = rc.cleanupAfterScaling()
 	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
-	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
+	assert.Equal(taskapi.CommandCleanup, task.Spec.Jobs[0].Command)
 }
 
 func TestStripPassword(t *testing.T) {

--- a/tests/scale_up/scale_up_suite_test.go
+++ b/tests/scale_up/scale_up_suite_test.go
@@ -80,7 +80,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterReady(dcName)
 
 			// Ensure we have a single CassandraTask created which is a cleanup (and it succeeded)
-			ns.CheckForCompletedCassandraTasks(dcName, "cleanup", 1)
+			ns.WaitForCompletedCassandraTasks(dcName, "cleanup", 1)
 
 			step = "scale up to 4 nodes"
 			json = "{\"spec\": {\"size\": 4}}"
@@ -93,7 +93,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionFalse))
 
 			// Ensure we have two CassandraTasks created which are cleanup (and they succeeded)
-			ns.CheckForCompletedCassandraTasks(dcName, "cleanup", 2)
+			ns.WaitForCompletedCassandraTasks(dcName, "cleanup", 2)
 
 			step = "scale up to 5 nodes"
 			json = "{\"spec\": {\"size\": 5}}"
@@ -106,7 +106,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionFalse))
 
 			// Ensure we have three CassandraTasks created which are cleanup (and they succeeded)
-			ns.CheckForCompletedCassandraTasks(dcName, "cleanup", 3)
+			ns.WaitForCompletedCassandraTasks(dcName, "cleanup", 3)
 
 			// Also verify that we have exactly 3 tasks, no more
 			ns.CheckForCassandraTasks(dcName, "cleanup", false, 3)

--- a/tests/util/ginkgo/lib.go
+++ b/tests/util/ginkgo/lib.go
@@ -668,7 +668,7 @@ func (ns *NsWrapper) CheckForCassandraTasks(dcName, command string, completed bo
 	ns.WaitForOutputAndLog(step, k, duplicate(command, count), 120)
 }
 
-func (ns *NsWrapper) CheckForCompletedCassandraTasks(dcName, command string, count int) {
+func (ns *NsWrapper) WaitForCompletedCassandraTasks(dcName, command string, count int) {
 	ns.CheckForCassandraTasks(dcName, command, true, count)
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The cleanup task is created after scale up operation, but we no longer wait for its completion in the CassandraDatacenter reconciliation. That's the job of the CassandraTask reconciler.

Also, add a new annotation "cassandra.datastax.com/no-cleanup" which if applied to CassandraDatacenter prevents the creation of the task after the scale up.

**Which issue(s) this PR fixes**:
Fixes #496 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
