### PR TITLE
Modify ServiceAccountName behavior. Add Spec.ServiceAccountName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [ENHANCEMENT] [#523](https://github.com/k8ssandra/cass-operator/issues/516) Spec.ServiceAccountName is introduced as replacements to Spec.ServiceAccount (to account for naming changes in Kubernetes itself), also PodTemplateSpec.Spec.ServiceAccountName is supported. Precendence order is: Spec.ServiceAccountName > Spec.ServiceAccount > PodTemplateSpec.
 * [CHANGE] [#516](https://github.com/k8ssandra/cass-operator/issues/516) Modify sidecar default CPU and memory limits.
 
 ## v1.10.6

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -191,7 +191,8 @@ type CassandraDatacenterSpec struct {
 	// Deprecated DeprecatedServiceAccount Use ServiceAccountName instead, which takes precedence. The k8s service account to use for the server pods
 	DeprecatedServiceAccount string `json:"serviceAccount,omitempty"`
 
-	// ServiceAccountName is the Kubernetes service account to use for the server pods.
+	// ServiceAccountName is the Kubernetes service account to use for the server pods. This takes presedence over DeprecatedServiceAccount and both take precedence over
+	// setting it in the PodTemplateSpec.
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Deprecated. Use CassandraTask for rolling restarts. Whether to do a rolling restart at the next opportunity. The operator will set this back

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -154,8 +154,8 @@ type CassandraDatacenterSpec struct {
 	// StorageConfig describes the persistent storage request of each server node
 	StorageConfig StorageConfig `json:"storageConfig"`
 
-	// DEPRECATED Use CassandraTask replacenode to achieve correct node replacement. A list of pod names that need to be replaced.
-	ReplaceNodes []string `json:"replaceNodes,omitempty"`
+	// Deprecated Use CassandraTask replacenode to achieve correct node replacement. A list of pod names that need to be replaced.
+	DeprecatedReplaceNodes []string `json:"replaceNodes,omitempty"`
 
 	// The name by which CQL clients and instances will know the cluster. If the same
 	// cluster name is shared by multiple Datacenters in the same Kubernetes namespace,
@@ -188,15 +188,15 @@ type CassandraDatacenterSpec struct {
 	// If it is omitted, we will generate a secret instead.
 	SuperuserSecretName string `json:"superuserSecretName,omitempty"`
 
-	// DEPRECATED Use ServiceAccountName instead, which takes precedence. The k8s service account to use for the server pods
-	ServiceAccount string `json:"serviceAccount,omitempty"`
+	// Deprecated DeprecatedServiceAccount Use ServiceAccountName instead, which takes precedence. The k8s service account to use for the server pods
+	DeprecatedServiceAccount string `json:"serviceAccount,omitempty"`
 
-	// ServiceAccountName is the Kubernetes service account to use for the server pods
+	// ServiceAccountName is the Kubernetes service account to use for the server pods.
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// DEPRECATED. Use CassandraTask for rolling restarts. Whether to do a rolling restart at the next opportunity. The operator will set this back
+	// Deprecated. Use CassandraTask for rolling restarts. Whether to do a rolling restart at the next opportunity. The operator will set this back
 	// to false once the restart is in progress.
-	RollingRestartRequested bool `json:"rollingRestartRequested,omitempty"`
+	DeprecatedRollingRestartRequested bool `json:"rollingRestartRequested,omitempty"`
 
 	// A map of label keys and values to restrict Cassandra node scheduling to k8s workers
 	// with matchiing labels.
@@ -343,8 +343,8 @@ type Rack struct {
 	// +kubebuilder:validation:MinLength=2
 	Name string `json:"name"`
 
-	// Deprecated. Use nodeAffinityLabels instead. Zone name to pin the rack, using node affinity
-	Zone string `json:"zone,omitempty"`
+	// Deprecated. Use nodeAffinityLabels instead. DeprecatedZone name to pin the rack, using node affinity
+	DeprecatedZone string `json:"zone,omitempty"`
 
 	// NodeAffinityLabels to pin the rack, using node affinity
 	NodeAffinityLabels map[string]string `json:"nodeAffinityLabels,omitempty"`

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -188,8 +188,11 @@ type CassandraDatacenterSpec struct {
 	// If it is omitted, we will generate a secret instead.
 	SuperuserSecretName string `json:"superuserSecretName,omitempty"`
 
-	// The k8s service account to use for the server pods
+	// DEPRECATED Use ServiceAccountName instead, which takes precedence. The k8s service account to use for the server pods
 	ServiceAccount string `json:"serviceAccount,omitempty"`
+
+	// ServiceAccountName is the Kubernetes service account to use for the server pods
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// DEPRECATED. Use CassandraTask for rolling restarts. Whether to do a rolling restart at the next opportunity. The operator will set this back
 	// to false once the restart is in progress.

--- a/apis/cassandra/v1beta1/cassandradatacenter_webhook.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_webhook.go
@@ -150,7 +150,7 @@ func ValidateDatacenterFieldChanges(oldDc CassandraDatacenter, newDc CassandraDa
 		return attemptedTo("change superuserSecretName")
 	}
 
-	if oldDc.Spec.ServiceAccount != newDc.Spec.ServiceAccount {
+	if oldDc.Spec.DeprecatedServiceAccount != newDc.Spec.DeprecatedServiceAccount {
 		return attemptedTo("change serviceAccount")
 	}
 
@@ -206,11 +206,11 @@ func ValidateDatacenterFieldChanges(oldDc CassandraDatacenter, newDc CassandraDa
 				oldRack.Name,
 				newRack.Name)
 		}
-		if oldRack.Zone != newRack.Zone {
-			if newRack.Zone != "" {
+		if oldRack.DeprecatedZone != newRack.DeprecatedZone {
+			if newRack.DeprecatedZone != "" {
 				return attemptedTo("change rack zone from '%s' to '%s'",
-					oldRack.Zone,
-					newRack.Zone)
+					oldRack.DeprecatedZone,
+					newRack.DeprecatedZone)
 			}
 		}
 	}
@@ -221,7 +221,7 @@ func ValidateDatacenterFieldChanges(oldDc CassandraDatacenter, newDc CassandraDa
 // ValidateDeprecatedFieldUsage prevents adding fields that are deprecated
 func ValidateDeprecatedFieldUsage(dc CassandraDatacenter) error {
 	for _, rack := range dc.GetRacks() {
-		if rack.Zone != "" {
+		if rack.DeprecatedZone != "" {
 			return attemptedTo("use deprecated parameter Zone, use NodeAffinityLabels instead.")
 		}
 	}

--- a/apis/cassandra/v1beta1/webhook_test.go
+++ b/apis/cassandra/v1beta1/webhook_test.go
@@ -306,7 +306,7 @@ func Test_ValidateDatacenterFieldChanges(t *testing.T) {
 					ClusterName:                 "oldname",
 					AllowMultipleNodesPerWorker: false,
 					SuperuserSecretName:         "hush",
-					ServiceAccount:              "admin",
+					DeprecatedServiceAccount:    "admin",
 					StorageConfig: StorageConfig{
 						CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
 							StorageClassName: &storageName,
@@ -333,7 +333,7 @@ func Test_ValidateDatacenterFieldChanges(t *testing.T) {
 					ClusterName:                 "oldname",
 					AllowMultipleNodesPerWorker: false,
 					SuperuserSecretName:         "hush",
-					ServiceAccount:              "admin",
+					DeprecatedServiceAccount:    "admin",
 					StorageConfig: StorageConfig{
 						CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
 							StorageClassName: &storageName,
@@ -441,7 +441,7 @@ func Test_ValidateDatacenterFieldChanges(t *testing.T) {
 					Name: "exampleDC",
 				},
 				Spec: CassandraDatacenterSpec{
-					ServiceAccount: "admin",
+					DeprecatedServiceAccount: "admin",
 				},
 			},
 			newDc: &CassandraDatacenter{
@@ -449,7 +449,7 @@ func Test_ValidateDatacenterFieldChanges(t *testing.T) {
 					Name: "exampleDC",
 				},
 				Spec: CassandraDatacenterSpec{
-					ServiceAccount: "newadmin",
+					DeprecatedServiceAccount: "newadmin",
 				},
 			},
 			errString: "change serviceAccount",

--- a/apis/cassandra/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cassandra/v1beta1/zz_generated.deepcopy.go
@@ -289,8 +289,8 @@ func (in *CassandraDatacenterSpec) DeepCopyInto(out *CassandraDatacenterSpec) {
 		}
 	}
 	in.StorageConfig.DeepCopyInto(&out.StorageConfig)
-	if in.ReplaceNodes != nil {
-		in, out := &in.ReplaceNodes, &out.ReplaceNodes
+	if in.DeprecatedReplaceNodes != nil {
+		in, out := &in.DeprecatedReplaceNodes, &out.DeprecatedReplaceNodes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -8517,7 +8517,8 @@ spec:
                 type: string
               serviceAccountName:
                 description: ServiceAccountName is the Kubernetes service account
-                  to use for the server pods.
+                  to use for the server pods. This takes presedence over DeprecatedServiceAccount
+                  and both take precedence over setting it in the PodTemplateSpec.
                 type: string
               size:
                 description: Desired number of Cassandra server nodes

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -8511,7 +8511,12 @@ spec:
                 pattern: (6\.8\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)
                 type: string
               serviceAccount:
-                description: The k8s service account to use for the server pods
+                description: DEPRECATED Use ServiceAccountName instead, which takes
+                  precedence. The k8s service account to use for the server pods
+                type: string
+              serviceAccountName:
+                description: ServiceAccountName is the Kubernetes service account
+                  to use for the server pods
                 type: string
               size:
                 description: Desired number of Cassandra server nodes

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -8449,7 +8449,7 @@ spec:
                         affinity
                       type: object
                     zone:
-                      description: Deprecated. Use nodeAffinityLabels instead. Zone
+                      description: Deprecated. Use nodeAffinityLabels instead. DeprecatedZone
                         name to pin the rack, using node affinity
                       type: string
                   required:
@@ -8457,7 +8457,7 @@ spec:
                   type: object
                 type: array
               replaceNodes:
-                description: DEPRECATED Use CassandraTask replacenode to achieve correct
+                description: Deprecated Use CassandraTask replacenode to achieve correct
                   node replacement. A list of pod names that need to be replaced.
                 items:
                   type: string
@@ -8489,7 +8489,7 @@ spec:
                     type: object
                 type: object
               rollingRestartRequested:
-                description: DEPRECATED. Use CassandraTask for rolling restarts. Whether
+                description: Deprecated. Use CassandraTask for rolling restarts. Whether
                   to do a rolling restart at the next opportunity. The operator will
                   set this back to false once the restart is in progress.
                 type: boolean
@@ -8511,12 +8511,13 @@ spec:
                 pattern: (6\.8\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)
                 type: string
               serviceAccount:
-                description: DEPRECATED Use ServiceAccountName instead, which takes
-                  precedence. The k8s service account to use for the server pods
+                description: Deprecated DeprecatedServiceAccount Use ServiceAccountName
+                  instead, which takes precedence. The k8s service account to use
+                  for the server pods
                 type: string
               serviceAccountName:
                 description: ServiceAccountName is the Kubernetes service account
-                  to use for the server pods
+                  to use for the server pods.
                 type: string
               size:
                 description: Desired number of Cassandra server nodes

--- a/pkg/reconciliation/check_nodes.go
+++ b/pkg/reconciliation/check_nodes.go
@@ -180,7 +180,7 @@ func (rc *ReconciliationContext) StartNodeReplace(podName string) error {
 	}
 
 	// Add the cassandra node to replace nodes
-	rc.Datacenter.Spec.ReplaceNodes = append(rc.Datacenter.Spec.ReplaceNodes, podName)
+	rc.Datacenter.Spec.DeprecatedReplaceNodes = append(rc.Datacenter.Spec.DeprecatedReplaceNodes, podName)
 
 	// Update CassandraDatacenter
 	if err := rc.Client.Update(rc.Ctx, rc.Datacenter); err != nil {

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -673,11 +673,11 @@ func buildPodTemplateSpec(dc *api.CassandraDatacenter, rack api.Rack, addLegacyI
 
 	// Service Account
 
-	serviceAccount := "default"
-	if dc.Spec.ServiceAccount != "" {
-		serviceAccount = dc.Spec.ServiceAccount
+	if dc.Spec.ServiceAccountName != "" {
+		baseTemplate.Spec.ServiceAccountName = dc.Spec.ServiceAccountName
+	} else if dc.Spec.ServiceAccount != "" {
+		baseTemplate.Spec.ServiceAccountName = dc.Spec.ServiceAccount
 	}
-	baseTemplate.Spec.ServiceAccountName = serviceAccount
 
 	// Host networking
 

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -675,8 +675,8 @@ func buildPodTemplateSpec(dc *api.CassandraDatacenter, rack api.Rack, addLegacyI
 
 	if dc.Spec.ServiceAccountName != "" {
 		baseTemplate.Spec.ServiceAccountName = dc.Spec.ServiceAccountName
-	} else if dc.Spec.ServiceAccount != "" {
-		baseTemplate.Spec.ServiceAccountName = dc.Spec.ServiceAccount
+	} else if dc.Spec.DeprecatedServiceAccount != "" {
+		baseTemplate.Spec.ServiceAccountName = dc.Spec.DeprecatedServiceAccount
 	}
 
 	// Host networking

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -1484,10 +1484,10 @@ func TestServiceAccountPrecedence(t *testing.T) {
 		{
 			dc: &api.CassandraDatacenter{
 				Spec: api.CassandraDatacenterSpec{
-					ClusterName:    "bob",
-					ServerType:     "cassandra",
-					ServerVersion:  "4.0.9",
-					ServiceAccount: "sa",
+					ClusterName:              "bob",
+					ServerType:               "cassandra",
+					ServerVersion:            "4.0.9",
+					DeprecatedServiceAccount: "sa",
 					Racks: []api.Rack{
 						{
 							Name: "r1",
@@ -1520,11 +1520,11 @@ func TestServiceAccountPrecedence(t *testing.T) {
 		{
 			dc: &api.CassandraDatacenter{
 				Spec: api.CassandraDatacenterSpec{
-					ClusterName:        "bob",
-					ServerType:         "cassandra",
-					ServerVersion:      "4.0.9",
-					ServiceAccountName: "san",
-					ServiceAccount:     "sa",
+					ClusterName:              "bob",
+					ServerType:               "cassandra",
+					ServerVersion:            "4.0.9",
+					ServiceAccountName:       "san",
+					DeprecatedServiceAccount: "sa",
 					Racks: []api.Rack{
 						{
 							Name: "r1",
@@ -1537,11 +1537,11 @@ func TestServiceAccountPrecedence(t *testing.T) {
 		{
 			dc: &api.CassandraDatacenter{
 				Spec: api.CassandraDatacenterSpec{
-					ClusterName:        "bob",
-					ServerType:         "cassandra",
-					ServerVersion:      "4.0.9",
-					ServiceAccountName: "san",
-					ServiceAccount:     "sa",
+					ClusterName:              "bob",
+					ServerType:               "cassandra",
+					ServerVersion:            "4.0.9",
+					ServiceAccountName:       "san",
+					DeprecatedServiceAccount: "sa",
 					Racks: []api.Rack{
 						{
 							Name: "r1",
@@ -1559,10 +1559,10 @@ func TestServiceAccountPrecedence(t *testing.T) {
 		{
 			dc: &api.CassandraDatacenter{
 				Spec: api.CassandraDatacenterSpec{
-					ClusterName:    "bob",
-					ServerType:     "cassandra",
-					ServerVersion:  "4.0.9",
-					ServiceAccount: "sa",
+					ClusterName:              "bob",
+					ServerType:               "cassandra",
+					ServerVersion:            "4.0.9",
+					DeprecatedServiceAccount: "sa",
 					Racks: []api.Rack{
 						{
 							Name: "r1",

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -58,14 +58,14 @@ func rackNodeAffinitylabels(dc *api.CassandraDatacenter, rackName string) (map[s
 		if rack.Name == rackName {
 			nodeAffinityLabels = utils.MergeMap(emptyMapIfNil(dc.Spec.NodeAffinityLabels),
 				emptyMapIfNil(rack.NodeAffinityLabels))
-			if rack.Zone != "" {
+			if rack.DeprecatedZone != "" {
 				if _, found := nodeAffinityLabels[zoneLabel]; found {
 					log.Error(nil,
 						"Deprecated parameter Zone is used and also defined in NodeAffinityLabels. "+
 							"You should only define it in NodeAffinityLabels")
 				}
 				nodeAffinityLabels = utils.MergeMap(
-					emptyMapIfNil(nodeAffinityLabels), map[string]string{zoneLabel: rack.Zone},
+					emptyMapIfNil(nodeAffinityLabels), map[string]string{zoneLabel: rack.DeprecatedZone},
 				)
 			}
 			break

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -624,8 +624,8 @@ func Test_newStatefulSetForCassandraDatacenter_dcNameOverride(t *testing.T) {
 			},
 			Racks: []api.Rack{
 				{
-					Name: "rack1",
-					Zone: "z1",
+					Name:           "rack1",
+					DeprecatedZone: "z1",
 				},
 			},
 		},

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1060,10 +1060,10 @@ func (rc *ReconciliationContext) updateCurrentReplacePodsProgress() error {
 func (rc *ReconciliationContext) startReplacePodsIfReplacePodsSpecified() error {
 	dc := rc.Datacenter
 
-	if len(dc.Spec.ReplaceNodes) > 0 {
-		rc.ReqLogger.Info("Requested replacing pods", "pods", dc.Spec.ReplaceNodes)
+	if len(dc.Spec.DeprecatedReplaceNodes) > 0 {
+		rc.ReqLogger.Info("Requested replacing pods", "pods", dc.Spec.DeprecatedReplaceNodes)
 
-		for _, podName := range dc.Spec.ReplaceNodes {
+		for _, podName := range dc.Spec.DeprecatedReplaceNodes {
 			// Each podName has to be in the dcPods
 			for _, dcPod := range rc.dcPods {
 				if podName == dcPod.Name {
@@ -1087,7 +1087,7 @@ func (rc *ReconciliationContext) startReplacePodsIfReplacePodsSpecified() error 
 
 		// Now that we've recorded these nodes in the status, we can blank
 		// out this field on the spec
-		dc.Spec.ReplaceNodes = []string{}
+		dc.Spec.DeprecatedReplaceNodes = []string{}
 	}
 
 	return nil
@@ -2022,7 +2022,7 @@ func (rc *ReconciliationContext) CheckRollingRestart() result.ReconcileResult {
 	dc := rc.Datacenter
 	logger := rc.ReqLogger
 
-	if dc.Spec.RollingRestartRequested {
+	if dc.Spec.DeprecatedRollingRestartRequested {
 		dcPatch := client.MergeFrom(dc.DeepCopy())
 		dc.Status.LastRollingRestart = metav1.Now()
 		_ = rc.setCondition(
@@ -2034,7 +2034,7 @@ func (rc *ReconciliationContext) CheckRollingRestart() result.ReconcileResult {
 		}
 
 		dcPatch = client.MergeFromWithOptions(dc.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		dc.Spec.RollingRestartRequested = false
+		dc.Spec.DeprecatedRollingRestartRequested = false
 		err = rc.Client.Patch(rc.Ctx, dc, dcPatch)
 		if err != nil {
 			logger.Error(err, "error patching datacenter for rolling restart")

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1589,23 +1589,23 @@ func TestNodereplacements(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(0, len(rc.Datacenter.Status.NodeReplacements))
 
-	rc.Datacenter.Spec.ReplaceNodes = []string{""}
+	rc.Datacenter.Spec.DeprecatedReplaceNodes = []string{""}
 	err = rc.startReplacePodsIfReplacePodsSpecified()
 	assert.NoError(err)
 	assert.Equal(0, len(rc.Datacenter.Status.NodeReplacements))
-	assert.Equal(0, len(rc.Datacenter.Spec.ReplaceNodes))
+	assert.Equal(0, len(rc.Datacenter.Spec.DeprecatedReplaceNodes))
 
-	rc.Datacenter.Spec.ReplaceNodes = []string{"dc1-default-sts-3"} // Does not exist
+	rc.Datacenter.Spec.DeprecatedReplaceNodes = []string{"dc1-default-sts-3"} // Does not exist
 	err = rc.startReplacePodsIfReplacePodsSpecified()
 	assert.NoError(err)
 	assert.Equal(0, len(rc.Datacenter.Status.NodeReplacements))
-	assert.Equal(0, len(rc.Datacenter.Spec.ReplaceNodes))
+	assert.Equal(0, len(rc.Datacenter.Spec.DeprecatedReplaceNodes))
 
-	rc.Datacenter.Spec.ReplaceNodes = []string{"dc1-default-sts-0"}
+	rc.Datacenter.Spec.DeprecatedReplaceNodes = []string{"dc1-default-sts-0"}
 	err = rc.startReplacePodsIfReplacePodsSpecified()
 	assert.NoError(err)
 	assert.Equal(1, len(rc.Datacenter.Status.NodeReplacements))
-	assert.Equal(0, len(rc.Datacenter.Spec.ReplaceNodes))
+	assert.Equal(0, len(rc.Datacenter.Spec.DeprecatedReplaceNodes))
 }
 
 // TestFailedStart verifies the pod is deleted if nodeMgmtClient start fails


### PR DESCRIPTION
…which is used before Spec.ServiceAccount and also add the ability to set the ServiceAccountName in the PodTemplateSpec, which is used as the last value.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Introduces new field: ServiceAccountName in the Spec, which behaves like the ServiceAccount. This is to follow the same naming convention changes as what Kubernetes did. Also, PodTemplateSpec.ServiceAccountName is no longer removed if no other value is used (ServiceAccountName > ServiceAccount > PodTemplateSpec is the order).

**Which issue(s) this PR fixes**:
Fixes #523 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
