### PR TITLE
Add KIND_CLUSTER make variable to allow targeting different kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ IMAGE_TAG_BASE ?= $(ORG)/cass-operator
 
 M_INTEG_DIR ?= all
 
+# KIND_CLUSTER is the kind context to target with the make commands to load images
+KIND_CLUSTER ?= kind
+
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
@@ -165,8 +168,8 @@ docker-build: ## Build docker image with the manager.
 
 .PHONY: docker-kind
 docker-kind: docker-build ## Build docker image and load to kind cluster
-	kind load docker-image ${IMG}
-	kind load docker-image ${IMG_LATEST}
+	kind load docker-image --name $(KIND_CLUSTER) ${IMG}
+	kind load docker-image --name $(KIND_CLUSTER) ${IMG_LATEST}
 
 .PHONY: docker-push
 docker-push: ## Build and push docker image with the manager.
@@ -184,8 +187,8 @@ docker-logger-push: ## Push system-logger-image
 
 .PHONY: docker-logger-kind
 docker-logger-kind: docker-logger-build ## Build system-logger image and load to kind cluster
-	kind load docker-image ${LOG_IMG}
-	kind load docker-image ${LOG_IMG_LATEST}
+	kind load docker-image --name $(KIND_CLUSTER) ${LOG_IMG}
+	kind load docker-image --name $(KIND_CLUSTER) ${LOG_IMG_LATEST}
 
 ##@ Deployment
 

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -12,7 +12,7 @@ if [ "${running}" != 'true' ]; then
 fi
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --image kindest/node:v1.25.3 --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.26.4 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:


### PR DESCRIPTION
…ters

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
One can now override KIND_CLUSTER parameter in the make, such as with:

``make KIND_CLUSTER=k8ssandra-0 docker-kind``

That would load (and build) the newest cass-operator to the kind cluster named ``k8ssandra-0``

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
