### PR TITLE
Enable new config builder for 4.1 deployments

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -88,12 +88,12 @@ jobs:
     strategy:
       matrix:
         version:
-          - "6.8.29"
+          - "6.8.37"
         integration_test:
           - cdc_successful
         include:
-          - version: 6.8.29
-            serverImage: datastax/dse-mgmtapi-6_8:6.8.29-jdk8 # DSE 6.8.29
+          - version: 6.8.37
+            serverImage: datastax/dse-mgmtapi-6_8:6.8.37-ubi8 # DSE 6.8.37
             serverType: dse
             integration_test: "cdc_successful"
       fail-fast: true
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "4.0.7"
+          - "4.1.2"
         integration_test:
           # Single worker tests:
           - additional_serviceoptions
@@ -202,15 +202,15 @@ jobs:
     strategy:
       matrix:
         version:
-          - "3.11.14"
-          - "4.0.7"
-          - "6.8.29"
+          - "3.11.15"
+          - "4.0.10"
+          - "4.1.2"
+          - "6.8.37"
         integration_test:
           - test_all_the_things
-          - test_all_the_things
         include:
-          - version: 6.8.29
-            serverImage: datastax/dse-mgmtapi-6_8:6.8.29-jdk8 # DSE 6.8.29
+          - version: 6.8.37
+            serverImage: datastax/dse-mgmtapi-6_8:6.8.37-ubi8 # DSE 6.8.37
             serverType: dse
             integration_test: "test_all_the_things"
       fail-fast: true

--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           name: system-logger
           path: /tmp/k8ssandra-system-logger.tar
-  # This job is only for tests that don't run or don't pass againats 4.0 yet
+  # This job is only for tests that don't run or don't pass against 4.0 yet
   kind_311_tests:
     needs: build_docker_images
     strategy:
@@ -82,7 +82,36 @@ jobs:
         with:
           name: k8s-logs-${{ matrix.integration_test }}
           path: ./build/kubectl_dump
-
+  # This job is only for tests that don't run or don't pass against 4.1 yet
+  kind_40_tests:
+    needs: build_docker_images
+    strategy:
+      matrix:
+        version:
+          - "4.0.10"
+        integration_test:
+          - cdc_successful # OSS only
+          - config_fql
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+      M_INTEG_DIR: ${{ matrix.integration_test }}
+    steps:
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request'
+      - uses: ./.github/actions/run-integ-test
+        with:
+          integration_test: ${{ matrix.integration_test }}
+      - name: Archive k8s logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: k8s-logs-${{ matrix.integration_test }}
+          path: ./build/kubectl_dump
   kind_dse_tests:
     needs: build_docker_images
     strategy:
@@ -142,7 +171,7 @@ jobs:
           # Three worker tests:
           - canary_upgrade
           # - config_change_condition # config_change takes care of testing the same
-          - cdc_successful # OSS only
+          #- cdc_successful # OSS only
           # - delete_node_lost_readiness # DSE specific behavior
           - host_network
           - internode-encryption-generated
@@ -170,7 +199,7 @@ jobs:
           - scale_up
           - scale_up_stop_resume
           - seed_selection
-          - config_fql # OSS only
+          #- config_fql # OSS only
           - decommission_dc
         # - stop_resume_scale_up # Odd insufficient CPU issues in kind+GHA
       # let other tests continue to run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] [#553](https://github.com/k8ssandra/cass-operator/issues/553) dockerImageRunsAsCassandra is no longer used for anything as that's the default for current images. Use SecurityContext to override default SecurityContext (999:999)
 * [ENHANCEMENT] [#554](https://github.com/k8ssandra/cass-operator/issues/554) Add new empty directory as mount to server-system-logger (/var/lib/vector) so it works with multiple securityContexes
+* [ENHANCEMENT] [#512](https://github.com/k8ssandra/cass-operator/issues/512) Configs are now built using the newer k8ssandra-client config build command instead of the older cass-config-builder. This provides support for Cassandra 4.1.x config properties and to newer.
 
 ## v1.16.0
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ endif
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):v$(VERSION)
-IMG_LATEST ?= $(IMAGE_TAG_BASE):latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -73,7 +72,6 @@ ENVTEST_K8S_VERSION = 1.27.x
 # Logger image
 LOG_IMG_BASE ?= $(ORG)/system-logger
 LOG_IMG ?= $(LOG_IMG_BASE):v$(VERSION)
-LOG_IMG_LATEST ?= $(LOG_IMG_BASE):latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -162,31 +160,27 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker buildx build --build-arg VERSION=${VERSION} -t ${IMG} -t ${IMG_LATEST} . --load
+	docker buildx build --build-arg VERSION=${VERSION} -t ${IMG} . --load
 
 .PHONY: docker-kind
 docker-kind: docker-build ## Build docker image and load to kind cluster
 	kind load docker-image ${IMG}
-	kind load docker-image ${IMG_LATEST}
 
 .PHONY: docker-push
 docker-push: ## Build and push docker image with the manager.
 	docker push ${IMG}
-	docker push ${IMG_LATEST}
 
 .PHONY: docker-logger-build
 docker-logger-build: ## Build system-logger image.
-	docker buildx build -t ${LOG_IMG} -t ${LOG_IMG_LATEST} --build-arg VERSION=${VERSION} -f logger.Dockerfile . --load
+	docker buildx build -t ${LOG_IMG} --build-arg VERSION=${VERSION} -f logger.Dockerfile . --load
 
 .PHONY: docker-logger-push
 docker-logger-push: ## Push system-logger-image
 	docker push ${LOG_IMG}
-	docker push ${LOG_IMG_LATEST}
 
 .PHONY: docker-logger-kind
 docker-logger-kind: docker-logger-build ## Build system-logger image and load to kind cluster
 	kind load docker-image ${LOG_IMG}
-	kind load docker-image ${LOG_IMG_LATEST}
 
 ##@ Deployment
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	"github.com/k8ssandra/cass-operator/pkg/serverconfig"
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -952,4 +953,8 @@ func (dc *CassandraDatacenter) DatacenterName() string {
 		return dc.Spec.DatacenterName
 	}
 	return dc.Name
+}
+
+func (dc *CassandraDatacenter) UseClientImage() bool {
+	return dc.Spec.ServerType == "cassandra" && semver.Compare(fmt.Sprintf("v%s", dc.Spec.ServerVersion), "v4.1.0") >= 0
 }

--- a/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types_test.go
@@ -54,3 +54,64 @@ func TestLegacyInternodeDisabled(t *testing.T) {
 
 	assert.False(t, dc.LegacyInternodeEnabled())
 }
+
+func TestUseClientImage(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		serverType string
+		version    string
+		should     bool
+	}{
+		{
+			serverType: "cassandra",
+			version:    "4.1.0",
+			should:     true,
+		},
+		{
+			serverType: "cassandra",
+			version:    "4.1.2",
+			should:     true,
+		},
+		{
+			serverType: "cassandra",
+			version:    "5.0.0",
+			should:     true,
+		},
+		{
+			serverType: "cassandra",
+			version:    "3.11.17",
+			should:     false,
+		},
+		{
+			serverType: "cassandra",
+			version:    "4.0.8",
+			should:     false,
+		},
+		{
+			serverType: "dse",
+			version:    "6.8.39",
+			should:     false,
+		},
+		{
+			serverType: "dse",
+			version:    "4.1.2",
+			should:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		dc := CassandraDatacenter{
+			Spec: CassandraDatacenterSpec{
+				ServerVersion: tt.version,
+				ServerType:    tt.serverType,
+			},
+		}
+
+		if tt.should {
+			assert.True(dc.UseClientImage())
+		} else {
+			assert.False(dc.UseClientImage())
+		}
+	}
+}

--- a/apis/config/v1beta1/imageconfig_types.go
+++ b/apis/config/v1beta1/imageconfig_types.go
@@ -55,6 +55,8 @@ type Images struct {
 	SystemLogger string `json:"system-logger"`
 
 	ConfigBuilder string `json:"config-builder"`
+
+	Client string `json:"k8ssandra-client,omitempty"`
 }
 
 type DefaultImages struct {

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -3,9 +3,9 @@ kind: ImageConfig
 metadata:
   name: image-config
 images:
-  system-logger: "k8ssandra/system-logger:latest"
+  system-logger: "k8ssandra/system-logger:v1.17.0-dev.ada6cb3-20230727"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
-  k8ssandra-client: "k8ssandra/k8ssandra-client:bee01ccf"
+  k8ssandra-client: "michaelburman290/k8ssandra-client:v0.2.0-dev.bee01cc-20230727"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -3,9 +3,9 @@ kind: ImageConfig
 metadata:
   name: image-config
 images:
-  system-logger: "k8ssandra/system-logger:v1.17.0-dev.ada6cb3-20230727"
+  system-logger: "k8ssandra/system-logger:v1.17.0"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
-  k8ssandra-client: "k8ssandra/k8ssandra-client:73bae732"
+  k8ssandra-client: "k8ssandra/k8ssandra-client:e5ae32c3"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -5,7 +5,7 @@ metadata:
 images:
   system-logger: "k8ssandra/system-logger:v1.17.0-dev.ada6cb3-20230727"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
-  k8ssandra-client: "michaelburman290/k8ssandra-client:v0.2.0-dev.bee01cc-20230727"
+  k8ssandra-client: "k8ssandra/k8ssandra-client:73bae732"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -5,6 +5,7 @@ metadata:
 images:
   system-logger: "k8ssandra/system-logger:latest"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
+  k8ssandra-client: "docker.io/k8ssandra/k8ssandra-client:v0.2.0-dev.4eb934d-20230619"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -5,7 +5,7 @@ metadata:
 images:
   system-logger: "k8ssandra/system-logger:latest"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
-  k8ssandra-client: "michaelburman290/k8ssandra-client:v0.2.0-dev.cfda014-20230724"
+  k8ssandra-client: "k8ssandra/k8ssandra-client:bee01ccf"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -5,7 +5,7 @@ metadata:
 images:
   system-logger: "k8ssandra/system-logger:latest"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
-  k8ssandra-client: "michaelburman290/k8ssandra-client:latest"
+  k8ssandra-client: "michaelburman290/k8ssandra-client:v0.2.0-dev.cfda014-20230724"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -5,7 +5,7 @@ metadata:
 images:
   system-logger: "k8ssandra/system-logger:latest"
   config-builder: "datastax/cass-config-builder:1.0-ubi7"
-  k8ssandra-client: "docker.io/k8ssandra/k8ssandra-client:v0.2.0-dev.4eb934d-20230619"
+  k8ssandra-client: "michaelburman290/k8ssandra-client:latest"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
   # dse:

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/onsi/ginkgo/v2 v2.9.4
 	go.uber.org/zap v1.24.0
+	golang.org/x/mod v0.12.0
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -172,6 +172,10 @@ func GetConfigBuilderImage() string {
 	return ApplyRegistry(GetImageConfig().Images.ConfigBuilder)
 }
 
+func GetClientImage() string {
+	return ApplyRegistry(GetImageConfig().Images.Client)
+}
+
 func GetSystemLoggerImage() string {
 	return ApplyRegistry(GetImageConfig().Images.SystemLogger)
 }

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -28,6 +28,7 @@ import (
 const (
 	DefaultTerminationGracePeriodSeconds = 120
 	ServerConfigContainerName            = "server-config-init"
+	ServerBaseConfigContainerName        = "server-config-init-base"
 	CassandraContainerName               = "cassandra"
 	PvcName                              = "server-data"
 	SystemLoggerContainerName            = "server-system-logger"
@@ -297,21 +298,24 @@ func addVolumes(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTemplateSpe
 		},
 	}
 
-	vBaseConfig := corev1.Volume{
-		Name: "server-config-base",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	}
-
 	vServerLogs := corev1.Volume{
 		Name: "server-logs",
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
+	volumeDefaults := []corev1.Volume{vServerConfig, vServerLogs}
 
-	volumeDefaults := []corev1.Volume{vServerConfig, vBaseConfig, vServerLogs}
+	if dc.UseClientImage() {
+		vBaseConfig := corev1.Volume{
+			Name: "server-config-base",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}
+
+		volumeDefaults = append(volumeDefaults, vBaseConfig)
+	}
 
 	if !dc.Spec.DisableSystemLoggerSidecar {
 		vectorLib := corev1.Volume{
@@ -388,21 +392,23 @@ func buildInitContainers(dc *api.CassandraDatacenter, rackName string, baseTempl
 
 	if serverCfg.Image == "" {
 
-		if images.GetClientImage() != "" {
-			serverCfg.Image = images.GetClientImage()
-			serverCfg.Args = []string{
-				"config",
-				"build",
+		if dc.UseClientImage() {
+			if images.GetClientImage() != "" {
+				serverCfg.Image = images.GetClientImage()
+				serverCfg.Args = []string{
+					"config",
+					"build",
+				}
 			}
-		}
-
-		/*
+		} else {
+			// Use older config-builder
 			if dc.GetConfigBuilderImage() != "" {
 				serverCfg.Image = dc.GetConfigBuilderImage()
 			} else {
 				serverCfg.Image = images.GetConfigBuilderImage()
 			}
-		*/
+		}
+
 		if images.GetImageConfig() != nil && images.GetImageConfig().ImagePullPolicy != "" {
 			serverCfg.ImagePullPolicy = images.GetImageConfig().ImagePullPolicy
 		}
@@ -413,12 +419,42 @@ func buildInitContainers(dc *api.CassandraDatacenter, rackName string, baseTempl
 		MountPath: "/config",
 	}
 
-	configBaseMount := corev1.VolumeMount{
-		Name:      "server-config-base",
-		MountPath: "/cassandra-base-config",
+	configMounts := []corev1.VolumeMount{serverCfgMount}
+
+	var configContainer *corev1.Container
+	if dc.UseClientImage() {
+
+		configBaseMount := corev1.VolumeMount{
+			Name:      "server-config-base",
+			MountPath: "/cassandra-base-config",
+		}
+
+		configMounts = append(configMounts, configBaseMount)
+
+		// Similar to k8ssandra 1.x, use config-container if use new config-builder replacement
+		configContainer = &corev1.Container{
+			Name: ServerBaseConfigContainerName,
+		}
+
+		if configContainer.Image == "" {
+			serverImage, err := makeImage(dc)
+			if err != nil {
+				return err
+			}
+
+			configContainer.Image = serverImage
+			if images.GetImageConfig() != nil && images.GetImageConfig().ImagePullPolicy != "" {
+				configContainer.ImagePullPolicy = images.GetImageConfig().ImagePullPolicy
+			}
+
+			configContainer.Command = []string{"/bin/sh"}
+			configContainer.Args = []string{"-c", "cp -rf /etc/cassandra/* /cassandra-base-config/"}
+		}
+
+		configContainer.VolumeMounts = []corev1.VolumeMount{configBaseMount}
 	}
 
-	serverCfg.VolumeMounts = combineVolumeMountSlices([]corev1.VolumeMount{serverCfgMount, configBaseMount}, serverCfg.VolumeMounts)
+	serverCfg.VolumeMounts = combineVolumeMountSlices(configMounts, serverCfg.VolumeMounts)
 
 	serverCfg.Resources = *getResourcesOrDefault(&dc.Spec.ConfigBuilderResources, &DefaultsConfigInitContainer)
 
@@ -450,32 +486,14 @@ func buildInitContainers(dc *api.CassandraDatacenter, rackName string, baseTempl
 
 	serverCfg.Env = combineEnvSlices(envDefaults, serverCfg.Env)
 
-	// Similar to k8ssandra 1.x, use config-container..
-	configContainer := &corev1.Container{
-		Name: "base-config-init",
-	}
-
-	if configContainer.Image == "" {
-		serverImage, err := makeImage(dc)
-		if err != nil {
-			return err
-		}
-
-		configContainer.Image = serverImage
-		if images.GetImageConfig() != nil && images.GetImageConfig().ImagePullPolicy != "" {
-			configContainer.ImagePullPolicy = images.GetImageConfig().ImagePullPolicy
-		}
-
-		configContainer.Command = []string{"/bin/sh"}
-		configContainer.Args = []string{"-c", "cp -rf /etc/cassandra/* /cassandra-base-config/"}
-	}
-
-	configContainer.VolumeMounts = []corev1.VolumeMount{configBaseMount}
-
 	if !foundOverrides {
 		// Note that append makes a copy, so we must do this after
 		// serverCfg has been properly set up.
-		baseTemplate.Spec.InitContainers = append(baseTemplate.Spec.InitContainers, *configContainer, *serverCfg)
+		if dc.UseClientImage() {
+			baseTemplate.Spec.InitContainers = append(baseTemplate.Spec.InitContainers, *configContainer, *serverCfg)
+		} else {
+			baseTemplate.Spec.InitContainers = append(baseTemplate.Spec.InitContainers, *serverCfg)
+		}
 	}
 
 	return nil

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -1180,10 +1180,11 @@ func TestCassandraDatacenter_buildPodTemplateSpec_clientImage(t *testing.T) {
 	assert.Equal(ServerConfigContainerName, initContainers[0].Name)
 
 	volumes := spec40.Spec.Volumes
-	assert.Equal(2, len(volumes))
+	assert.Equal(3, len(volumes))
 	// We use a contains check here because the ordering is not important
 	assert.True(volumesContains(volumes, volumeNameMatcher("server-config")))
 	assert.True(volumesContains(volumes, volumeNameMatcher("server-logs")))
+	assert.True(volumesContains(volumes, volumeNameMatcher("vector-lib")))
 
 	spec41, err := buildPodTemplateSpec(dc41, dc41.Spec.Racks[0], false, false)
 	assert.NoError(err, "should not have gotten error when building podTemplateSpec")
@@ -1206,11 +1207,12 @@ func TestCassandraDatacenter_buildPodTemplateSpec_clientImage(t *testing.T) {
 	assert.True(volumeMountsContains(serverConfigInitContainer.VolumeMounts, volumeMountNameMatcher("server-config-base")))
 
 	volumes = spec41.Spec.Volumes
-	assert.Equal(3, len(volumes))
+	assert.Equal(4, len(volumes))
 	// We use a contains check here because the ordering is not important
 	assert.True(volumesContains(volumes, volumeNameMatcher("server-config")))
 	assert.True(volumesContains(volumes, volumeNameMatcher("server-logs")))
 	assert.True(volumesContains(volumes, volumeNameMatcher("server-config-base")))
+	assert.True(volumesContains(volumes, volumeNameMatcher("vector-lib")))
 }
 
 func TestCassandraDatacenter_buildPodTemplateSpec_openShift(t *testing.T) {

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -211,10 +211,11 @@ func TestStatefulSetWithAdditionalVolumesFromSource(t *testing.T) {
 	assert.Equal(4, len(sts.Spec.Template.Spec.Volumes))
 	assert.Equal("server-config", sts.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal("server-logs", sts.Spec.Template.Spec.Volumes[1].Name)
-	assert.Equal("vector-lib", sts.Spec.Template.Spec.Volumes[2].Name)
-	assert.Equal("metrics-config", sts.Spec.Template.Spec.Volumes[3].Name)
-	assert.NotNil(sts.Spec.Template.Spec.Volumes[3].ConfigMap)
-	assert.Equal("metrics-config-map", sts.Spec.Template.Spec.Volumes[3].ConfigMap.Name)
+	assert.Equal("server-config-base", sts.Spec.Template.Spec.Volumes[2].Name)
+	assert.Equal("vector-lib", sts.Spec.Template.Spec.Volumes[3].Name)
+	assert.Equal("metrics-config", sts.Spec.Template.Spec.Volumes[4].Name)
+	assert.NotNil(sts.Spec.Template.Spec.Volumes[4].ConfigMap)
+	assert.Equal("metrics-config-map", sts.Spec.Template.Spec.Volumes[4].ConfigMap.Name)
 
 	cassandraContainer := findContainer(sts.Spec.Template.Spec.Containers, CassandraContainerName)
 	assert.NotNil(cassandraContainer)
@@ -232,7 +233,7 @@ func TestStatefulSetWithAdditionalVolumesFromSource(t *testing.T) {
 	dc = &api.CassandraDatacenter{
 		Spec: api.CassandraDatacenterSpec{
 			ServerType:    "cassandra",
-			ServerVersion: "4.1.0",
+			ServerVersion: "4.0.8",
 			ClusterName:   "cluster1",
 			StorageConfig: api.StorageConfig{
 				CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -208,7 +208,7 @@ func TestStatefulSetWithAdditionalVolumesFromSource(t *testing.T) {
 	sts, err := newStatefulSetForCassandraDatacenter(nil, "r1", dc, 3, false)
 	assert.NoError(err)
 
-	assert.Equal(4, len(sts.Spec.Template.Spec.Volumes))
+	assert.Equal(5, len(sts.Spec.Template.Spec.Volumes))
 	assert.Equal("server-config", sts.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal("server-logs", sts.Spec.Template.Spec.Volumes[1].Name)
 	assert.Equal("server-config-base", sts.Spec.Template.Spec.Volumes[2].Name)

--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -74,7 +74,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterReady(dcName)
 
 			step = "change the config"
-			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity_in_ms\": 256000, \"materialized_views_enabled\": \"true\"}}}}"
+			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity\": \"256000ms\", \"materialized_views_enabled\": \"true\"}}}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 
@@ -83,11 +83,11 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterOperatorProgress(dcName, "Ready", 1800)
 			ns.WaitForDatacenterCondition(dcName, "Updating", string(corev1.ConditionFalse))
 
-			step = "checking that the init container got the updated config roles_validity_in_ms=256000"
+			step = "checking that the init container got the updated config roles_validity=256000ms"
 			json = "jsonpath={.spec.initContainers[0].env[7].value}"
 			k = kubectl.Get(fmt.Sprintf("pod/%s-%s-r1-sts-0", clusterName, dcName)).
 				FormatOutput(json)
-			ns.WaitForOutputContainsAndLog(step, k, "\"roles_validity_in_ms\":256000", 30)
+			ns.WaitForOutputContainsAndLog(step, k, "\"roles_validity\":\"256000ms\"", 30)
 
 			step = "checking that statefulsets have the right owner reference"
 			json = "jsonpath={.metadata.ownerReferences[0].name}"

--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -84,7 +84,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterCondition(dcName, "Updating", string(corev1.ConditionFalse))
 
 			step = "checking that the init container got the updated config roles_validity=256000ms"
-			json = "jsonpath={.spec.initContainers[0].env[7].value}"
+			json = "jsonpath={.spec.initContainers[1].env[7].value}"
 			k = kubectl.Get(fmt.Sprintf("pod/%s-%s-r1-sts-0", clusterName, dcName)).
 				FormatOutput(json)
 			ns.WaitForOutputContainsAndLog(step, k, "\"roles_validity\":\"256000ms\"", 30)

--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -74,7 +74,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterReady(dcName)
 
 			step = "change the config"
-			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity_in_ms\": 256000}}}}"
+			json = "{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity_in_ms\": 256000, \"materialized_views_enabled\": \"true\"}}}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 

--- a/tests/config_change_condition/config_change_condition_suite_test.go
+++ b/tests/config_change_condition/config_change_condition_suite_test.go
@@ -65,7 +65,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterReady(dcName)
 
 			step = "change the config"
-			json := ginkgo_util.CreateTestJson("{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity_in_ms\": 256000}, \"jvm-server-options\": {\"garbage_collector\": \"CMS\"}}}}")
+			json := ginkgo_util.CreateTestJson("{\"spec\": {\"config\": {\"cassandra-yaml\": {\"roles_validity\": \"256000ms\"}, \"jvm-server-options\": {\"garbage_collector\": \"CMS\"}}}}")
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 

--- a/tests/config_secret/config_secret_suite_test.go
+++ b/tests/config_secret/config_secret_suite_test.go
@@ -83,7 +83,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout_in_ms: 10000", 60)
 
 			step = "stop using config secret"
-			json := ginkgo_util.CreateTestJson(`[{"op": "remove", "path": "/spec/configSecret"}, {"op": "add", "path": "/spec/config", "value": {"cassandra-yaml": {"read_request_timeout_in_ms": 25000}, "jvm-options": {"initial_heap_size": "512M", "max_heap_size": "512M"}}}]`)
+			json := ginkgo_util.CreateTestJson(`[{"op": "remove", "path": "/spec/configSecret"}, {"op": "add", "path": "/spec/config", "value": {"cassandra-yaml": {"read_request_timeout": "25000ms"}, "jvm-server-options": {"initial_heap_size": "512M", "max_heap_size": "512M"}}}]`)
 			k = kubectl.PatchJson(dcResource, json)
 			ns.ExecAndLog(step, k)
 
@@ -92,7 +92,7 @@ var _ = Describe(testName, func() {
 
 			step = "checking cassandra.yaml"
 			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", ginkgo_util.GetCassandraConfigYamlLocation())
-			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout_in_ms: 25000", 120)
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: \"25000ms\"", 120)
 
 			step = "use config secret again"
 			json = `{"spec": {"config": null, "configSecret": "test-config"}}`
@@ -104,7 +104,7 @@ var _ = Describe(testName, func() {
 
 			step = "checking cassandra.yaml"
 			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", ginkgo_util.GetCassandraConfigYamlLocation())
-			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout_in_ms: 10000", 120)
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: \"10000ms\"", 120)
 		})
 	})
 })

--- a/tests/config_secret/config_secret_suite_test.go
+++ b/tests/config_secret/config_secret_suite_test.go
@@ -92,7 +92,7 @@ var _ = Describe(testName, func() {
 
 			step = "checking cassandra.yaml"
 			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", ginkgo_util.GetCassandraConfigYamlLocation())
-			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: \"25000ms\"", 120)
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: 25000ms", 120)
 
 			step = "use config secret again"
 			json = `{"spec": {"config": null, "configSecret": "test-config"}}`
@@ -104,7 +104,7 @@ var _ = Describe(testName, func() {
 
 			step = "checking cassandra.yaml"
 			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", ginkgo_util.GetCassandraConfigYamlLocation())
-			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: \"10000ms\"", 120)
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: 10000ms", 120)
 		})
 	})
 })

--- a/tests/config_secret/config_secret_suite_test.go
+++ b/tests/config_secret/config_secret_suite_test.go
@@ -80,7 +80,7 @@ var _ = Describe(testName, func() {
 
 			step = "checking cassandra.yaml"
 			k = kubectl.ExecOnPod("cluster1-dc1-r1-sts-0", "-c", "cassandra", "--", "cat", ginkgo_util.GetCassandraConfigYamlLocation())
-			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout_in_ms: 10000", 60)
+			ns.WaitForOutputContainsAndLog(step, k, "read_request_timeout: 10000ms", 60)
 
 			step = "stop using config secret"
 			json := ginkgo_util.CreateTestJson(`[{"op": "remove", "path": "/spec/configSecret"}, {"op": "add", "path": "/spec/config", "value": {"cassandra-yaml": {"read_request_timeout": "25000ms"}, "jvm-server-options": {"initial_heap_size": "512M", "max_heap_size": "512M"}}}]`)

--- a/tests/testdata/default-single-rack-2-node-dc-with-auth-enabled.yaml
+++ b/tests/testdata/default-single-rack-2-node-dc-with-auth-enabled.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster2
   serverType: cassandra
-  serverVersion: "3.11.10"
+  serverVersion: "4.1.2"
   managementApiAuth:
     insecure: {}
   size: 2
@@ -20,10 +20,12 @@ spec:
   racks:
     - name: r1
   config:
-    jvm-options:
+    jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"
     cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
+      rpc_address: "0.0.0.0"
       authenticator: PasswordAuthenticator
       authorizer: CassandraAuthorizer
       role_manager: CassandraRoleManager

--- a/tests/testdata/default-single-rack-2-node-dc-with-superuser-secret.yaml
+++ b/tests/testdata/default-single-rack-2-node-dc-with-superuser-secret.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster2
   serverType: cassandra
-  serverVersion: "3.11.10"
+  serverVersion: "4.1.2"
   managementApiAuth:
     insecure: {}
   size: 2
@@ -24,10 +24,12 @@ spec:
   racks:
     - name: r1
   config:
-    jvm-options:
+    jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"
     cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
+      rpc_address: "0.0.0.0"
       authenticator: PasswordAuthenticator
       authorizer: CassandraAuthorizer
       role_manager: CassandraRoleManager

--- a/tests/testdata/default-single-rack-2-node-dc.yaml
+++ b/tests/testdata/default-single-rack-2-node-dc.yaml
@@ -20,6 +20,8 @@ spec:
   racks:
     - name: r1
   config:
+    cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
     jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"

--- a/tests/testdata/default-single-rack-2-node-dc1.yaml
+++ b/tests/testdata/default-single-rack-2-node-dc1.yaml
@@ -20,6 +20,8 @@ spec:
   racks:
     - name: r1
   config:
+    cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
     jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"

--- a/tests/testdata/default-single-rack-single-node-dc.yaml
+++ b/tests/testdata/default-single-rack-single-node-dc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster2
   serverType: cassandra
-  serverVersion: "4.0.1"
+  serverVersion: "4.1.1"
   managementApiAuth:
     insecure: {}
   size: 1

--- a/tests/testdata/default-two-rack-four-node-dc.yaml
+++ b/tests/testdata/default-two-rack-four-node-dc.yaml
@@ -21,6 +21,8 @@ spec:
     - name: r1
     - name: r2
   config:
+    cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
     jvm-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"

--- a/tests/testdata/encrypted-single-rack-2-node-dc.yaml
+++ b/tests/testdata/encrypted-single-rack-2-node-dc.yaml
@@ -24,6 +24,7 @@ spec:
       initial_heap_size: "512m"
       max_heap_size: "512m"
     cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
       server_encryption_options:
         internode_encryption: all
         keystore: /etc/encryption/node-keystore.jks

--- a/tests/testdata/nodeport-service-dc.yaml
+++ b/tests/testdata/nodeport-service-dc.yaml
@@ -25,6 +25,8 @@ spec:
     - name: r1
     - name: r2
   config:
+    cassandra-yaml:
+      allocate_tokens_for_local_replication_factor: 2
     jvm-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"

--- a/tests/testdata/test-config-secret.yaml
+++ b/tests/testdata/test-config-secret.yaml
@@ -7,7 +7,7 @@ stringData:
   config: |-
     {
       "cassandra-yaml": {
-        "read_request_timeout_in_ms": 5000
+        "read_request_timeout": "5000ms"
       },
       "jvm-options": {
         "initial_heap_size": "512M",

--- a/tests/testdata/updated-test-config-secret.yaml
+++ b/tests/testdata/updated-test-config-secret.yaml
@@ -7,7 +7,7 @@ stringData:
   config: |-
     {
       "cassandra-yaml": {
-        "read_request_timeout_in_ms": 10000
+        "read_request_timeout": "10000ms"
       },
       "jvm-options": {
         "initial_heap_size": "512M",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Replaces the usage of cass-config-builder with the new k8ssandra-client config build when a Cassandra 4.1 and newer OSS image is deployed.

The old behavior remains with DSE and older versions of Cassandra.

**Which issue(s) this PR fixes**:
Fixes #512
Fixes #513
Fixes #514

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
