### PR TITLE
Change OLM deployment to add ServiceAccount with nonroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#542](https://github.com/k8ssandra/cass-operator/issues/542) Support 7.x.x version numbers for DSE and 5.x.x for Cassandra
 * [CHANGE] [#531](https://github.com/k8ssandra/cass-operator/issues/531) Update to Kubebuilder gov4-alpha layout structure
 * [ENHANCEMENT] [#523](https://github.com/k8ssandra/cass-operator/issues/516) Spec.ServiceAccountName is introduced as replacements to Spec.ServiceAccount (to account for naming changes in Kubernetes itself), also PodTemplateSpec.Spec.ServiceAccountName is supported. Precendence order is: Spec.ServiceAccountName > Spec.ServiceAccount > PodTemplateSpec.
+* [ENHANCEMENT] [#541](https://github.com/k8ssandra/cass-operator/issues/541) When deployed through OLM, add serviceAccount to Cassandra pods that use nonroot priviledge
 * [CHANGE] [#516](https://github.com/k8ssandra/cass-operator/issues/516) Modify sidecar default CPU and memory limits.
 * [CHANGE] [#495](https://github.com/k8ssandra/cass-operator/issues/495) Remove all the VMware PSP specific code from the codebase. This has been inoperational since 1.8.0
 * [CHANGE] [#494](https://github.com/k8ssandra/cass-operator/issues/494) Remove deprecated generated clientsets. 

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,8 @@ endif
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPSDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | $(OPSDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	scripts/preprocess-bundle.sh
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | $(OPSDK) generate bundle -q --overwrite --extra-service-accounts cass-operator-cassandra-default-sa --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	scripts/postprocess-bundle.sh
 	$(OPSDK) bundle validate ./bundle --select-optional suite=operatorframework
 

--- a/config/rbac/nonroot_role.yaml
+++ b/config/rbac/nonroot_role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cassandra-nonroot
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cassandra-nonroot-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: cassandra-default-sa
+roleRef:
+  kind: Role
+  name: cassandra-nonroot
+  apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,6 +132,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cassandra-default-sa

--- a/config/samples/example-cassdc-three-nodes-single-rack.yaml
+++ b/config/samples/example-cassdc-three-nodes-single-rack.yaml
@@ -17,7 +17,7 @@ spec:
         resources:
           requests:
             storage: 10Gi
-  dockerImageRunsAsCassandra: false
+  dockerImageRunsAsCassandra: true
   resources:
     requests:
       memory: 2Gi

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -56,6 +56,7 @@ import (
 // +kubebuilder:rbac:groups=apps,namespace=cass-operator,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods;endpoints;services;configmaps;secrets;persistentvolumeclaims;events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=serviceaccounts,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes;nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,namespace=cass-operator,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -31,6 +31,7 @@ const (
 	CassandraContainerName               = "cassandra"
 	PvcName                              = "server-data"
 	SystemLoggerContainerName            = "server-system-logger"
+	OLMPodServiceAccount                 = "cass-operator-cassandra-default-sa"
 )
 
 // calculateNodeAffinity provides a way to decide where to schedule pods within a statefulset based on labels
@@ -663,7 +664,7 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 	return nil
 }
 
-func buildPodTemplateSpec(dc *api.CassandraDatacenter, rack api.Rack, addLegacyInternodeMount bool) (*corev1.PodTemplateSpec, error) {
+func buildPodTemplateSpec(dc *api.CassandraDatacenter, rack api.Rack, addLegacyInternodeMount, olmDeployment bool) (*corev1.PodTemplateSpec, error) {
 
 	baseTemplate := dc.Spec.PodTemplateSpec.DeepCopy()
 
@@ -672,6 +673,9 @@ func buildPodTemplateSpec(dc *api.CassandraDatacenter, rack api.Rack, addLegacyI
 	}
 
 	// Service Account
+	if olmDeployment {
+		baseTemplate.Spec.ServiceAccountName = OLMPodServiceAccount
+	}
 
 	if dc.Spec.ServiceAccountName != "" {
 		baseTemplate.Spec.ServiceAccountName = dc.Spec.ServiceAccountName

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -78,7 +78,8 @@ func newStatefulSetForCassandraDatacenter(
 	sts *appsv1.StatefulSet,
 	rackName string,
 	dc *api.CassandraDatacenter,
-	replicaCount int) (*appsv1.StatefulSet, error) {
+	replicaCount int,
+	olmDeployment bool) (*appsv1.StatefulSet, error) {
 
 	replicaCountInt32 := int32(replicaCount)
 
@@ -126,7 +127,7 @@ func newStatefulSetForCassandraDatacenter(
 
 	nsName := newNamespacedNameForStatefulSet(dc, rackName)
 
-	template, err := buildPodTemplateSpec(dc, rack, legacyInternodeMount(dc, sts))
+	template, err := buildPodTemplateSpec(dc, rack, legacyInternodeMount(dc, sts), olmDeployment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -164,6 +164,16 @@ func (rc *ReconciliationContext) CheckRackCreation() result.ReconcileResult {
 	return result.Continue()
 }
 
+func (rc *ReconciliationContext) deployedWithOLM(namespace string) (bool, error) {
+	sa := &corev1.ServiceAccount{}
+	saKey := types.NamespacedName{Namespace: namespace, Name: OLMPodServiceAccount}
+	if err := rc.Client.Get(rc.Ctx, saKey, sa); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	return true, nil
+}
+
 func (rc *ReconciliationContext) CheckRackPodTemplate() result.ReconcileResult {
 	logger := rc.ReqLogger
 	dc := rc.Datacenter
@@ -179,7 +189,12 @@ func (rc *ReconciliationContext) CheckRackPodTemplate() result.ReconcileResult {
 		}
 		statefulSet := rc.statefulSets[idx]
 
-		desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, int(*statefulSet.Spec.Replicas))
+		olmDeployment, err := rc.deployedWithOLM(statefulSet.Namespace)
+		if err != nil {
+			return result.Error(err)
+		}
+
+		desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, int(*statefulSet.Spec.Replicas), olmDeployment)
 
 		if err != nil {
 			logger.Error(err, "error calling newStatefulSetForCassandraDatacenter")
@@ -330,7 +345,7 @@ func (rc *ReconciliationContext) CheckRackForceUpgrade() result.ReconcileResult 
 
 			// have to use zero here, because each statefulset is created with no replicas
 			// in GetStatefulSetForRack()
-			desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, nextRack.NodeCount)
+			desiredSts, err := newStatefulSetForCassandraDatacenter(statefulSet, rackName, dc, nextRack.NodeCount, false)
 			if err != nil {
 				logger.Error(err, "error calling newStatefulSetForCassandraDatacenter")
 				return result.Error(err)
@@ -1378,7 +1393,7 @@ func (rc *ReconciliationContext) GetStatefulSetForRack(
 		currentStatefulSet,
 		nextRack.RackName,
 		rc.Datacenter,
-		nextRack.NodeCount)
+		nextRack.NodeCount, false)
 	if err != nil {
 		return nil, false, err
 	}

--- a/scripts/postprocess-bundle.sh
+++ b/scripts/postprocess-bundle.sh
@@ -5,13 +5,11 @@ cat <<EOF >> bundle.Dockerfile
 # Certified Openshift required labels
 LABEL com.redhat.openshift.versions="v4.9"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.delivery.backport=true
 EOF
 
 # Add them to the bundle metadata also
 yq eval -i '.annotations."com.redhat.openshift.versions" = "v4.9"' bundle/metadata/annotations.yaml
 yq eval -i '.annotations."com.redhat.delivery.operator.bundle" = true' bundle/metadata/annotations.yaml
-yq eval -i '.annotations."com.redhat.delivery.backport" = true' bundle/metadata/annotations.yaml
 yq eval -i '.annotations."com.redhat.openshift.versions" headComment = "Certified Openshift required labels"' bundle/metadata/annotations.yaml
 
 # This file is extra from creation process on config/manifests, should not be in the bundle itself

--- a/scripts/preprocess-bundle.sh
+++ b/scripts/preprocess-bundle.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cat << EOF >> config/rbac/kustomization.yaml
+# Add Openshift nonroot Role
+- nonroot_role.yaml
+EOF

--- a/scripts/release-helm-chart.sh
+++ b/scripts/release-helm-chart.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# This script assumes k8ssandra is checked out at ../k8ssandra and is checked out at main
+if [ "$#" -ne 1 ]; then
+    echo "Usage: scripts/release-helm-chart.sh version"
+    echo "Script assumes you are in the correct branch / tag and that k8ssandra repository"
+    echo "has been checked out to ../k8ssandra/"
+    exit
+fi
+
+VERSION=$1
+CHART_HOME=../k8ssandra/charts/cass-operator
+CRD_TARGET_PATH=$CHART_HOME/crds
+TEMPLATE_HOME=$CHART_HOME/templates
+
+# Checkout tag
+git checkout v$VERSION
+
+# Create CRDs
+kustomize build config/crd  --output $CRD_TARGET_PATH
+
+# Rename generated CRDs to shorter format
+for f in $CRD_TARGET_PATH/*; do
+    TARGET_FILENAME=$(yq '.spec.names.plural' $f).yaml
+    mv $f $CRD_TARGET_PATH/$TARGET_FILENAME
+done
+
+# TODO Update all the necessary fields also (Chart.yaml, values.yaml, configmap.yaml)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
When creating the bundle, a new serviceAccount called `cass-operator-cassandra-default-sa` is created with nonroot access. If cass-operator detects the Datacenter is deployed in a OLM installation, this same ServiceAccount is set for the StatefulSets.

Output in CSV:

```yaml
        - rules:
            - apiGroups:
                - security.openshift.io
              resourceNames:
                - nonroot
              resources:
                - securitycontextconstraints
              verbs:
                - use
          serviceAccountName: cass-operator-cassandra-default-sa
```

@mgoerens

**Which issue(s) this PR fixes**:
Fixes #541

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
