### PR TITLE
Fix registry prefixer in bundle creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # cassandra.datastax.com/cass-oper-bundle:$VERSION and cassandra.datastax.com/cass-oper-catalog:$VERSION.
 
+REGISTRY ?=
 ORG ?= k8ssandra
 IMAGE_TAG_BASE ?= $(ORG)/cass-operator
 
@@ -320,7 +321,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	scripts/preprocess-bundle.sh
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | $(OPSDK) generate bundle -q --overwrite --extra-service-accounts cass-operator-cassandra-default-sa --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	scripts/postprocess-bundle.sh
+	scripts/postprocess-bundle.sh $(REGISTRY)
 	$(OPSDK) bundle validate ./bundle --select-optional suite=operatorframework
 
 .PHONY: bundle-build

--- a/scripts/postprocess-bundle.sh
+++ b/scripts/postprocess-bundle.sh
@@ -18,8 +18,11 @@ rm -f bundle/manifests/field-config_v1_configmap.yaml
 # Use yq to set that date to the createdAt field
 createdAt=$(date +%Y-%m-%d) yq eval '.metadata.annotations.createdAt = env(createdAt)' -i bundle/manifests/cass-operator.clusterserviceversion.yaml 
 
-# Modify image to have repository prefix (docker.io/k8ssandra/cass-operator)
-yq eval '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= "docker.io/" + .' -i bundle/manifests/cass-operator.clusterserviceversion.yaml
+REGISTRY=$1
+if [ -n "${REGISTRY}" ]; then
+    # Modify image to have repository prefix (docker.io/k8ssandra/cass-operator)
+    yq eval '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= "'"$REGISTRY"'" + "/" + .' -i bundle/manifests/cass-operator.clusterserviceversion.yaml
+fi
 
 # Use the correct containerImage from the deployment
 yq eval '.metadata.annotations.containerImage = .spec.install.spec.deployments[0].spec.template.spec.containers[0].image' -i bundle/manifests/cass-operator.clusterserviceversion.yaml

--- a/scripts/release-community-bundles.sh
+++ b/scripts/release-community-bundles.sh
@@ -14,7 +14,7 @@ TARGET_DIRS=(community-operators community-operators-prod)
 git checkout v$VERSION
 
 # Create bundle
-make VERSION=$VERSION bundle
+make VERSION=$VERSION REGISTRY=docker.io bundle
 
 # Modify package name to cass-operator-community
 yq eval -i '.annotations."operators.operatorframework.io.bundle.package.v1" = "cass-operator-community"' bundle/metadata/annotations.yaml

--- a/scripts/release-helm-chart.sh
+++ b/scripts/release-helm-chart.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# This script assumes k8ssandra is checked out at ../k8ssandra and is checked out at main
+if [ "$#" -ne 1 ]; then
+    echo "Usage: scripts/release-helm-chart.sh version"
+    echo "Script assumes you are in the correct branch / tag and that k8ssandra repository"
+    echo "has been checked out to ../k8ssandra/"
+    exit
+fi
+
+VERSION=$1
+CHART_HOME=../k8ssandra/charts/cass-operator
+CRD_TARGET_PATH=$CHART_HOME/crds
+TEMPLATE_HOME=$CHART_HOME/templates
+
+# Checkout tag
+git checkout v$VERSION
+
+# Create CRDs
+kustomize build config/crd  --output $CRD_TARGET_PATH
+
+# Rename generated CRDs to shorter format
+for f in $CRD_TARGET_PATH/*; do
+    TARGET_FILENAME=$(yq '.spec.names.plural' $f).yaml
+    mv $f $CRD_TARGET_PATH/$TARGET_FILENAME
+done
+
+# TODO Update all the necessary fields also (Chart.yaml, values.yaml, configmap.yaml)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
community-bundles require the docker.io prefix (or any other registry, but set to docker.io for now), while certified bundles use the registry.connect.redhat.com registry.

The current master has a bug where it sets the certified to docker.io/registry.connect.redhat.com/ ..

**Which issue(s) this PR fixes**:
Fixes #549 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
