### PR TITLE
Release changes to use prefixed repositories

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -119,12 +119,12 @@ jobs:
     strategy:
       matrix:
         version:
-          - "6.8.37"
+          - "6.8.39"
         integration_test:
           - cdc_successful
         include:
-          - version: 6.8.37
-            serverImage: datastax/dse-mgmtapi-6_8:6.8.37-ubi8 # DSE 6.8.37
+          - version: 6.8.39
+            serverImage: datastax/dse-mgmtapi-6_8:6.8.39-ubi8 # DSE 6.8.39
             serverType: dse
             integration_test: "cdc_successful"
       fail-fast: true
@@ -236,12 +236,12 @@ jobs:
           - "3.11.15"
           - "4.0.10"
           - "4.1.2"
-          - "6.8.37"
+          - "6.8.39"
         integration_test:
           - test_all_the_things
         include:
-          - version: 6.8.37
-            serverImage: datastax/dse-mgmtapi-6_8:6.8.37-ubi8 # DSE 6.8.37
+          - version: 6.8.39
+            serverImage: datastax/dse-mgmtapi-6_8:6.8.39-ubi8 # DSE 6.8.39
             serverType: dse
             integration_test: "test_all_the_things"
       fail-fast: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [CHANGE] [#479](https://github.com/k8ssandra/cass-operator/issues/479) Set the default deployed DSE image to use our newer management-api by changing the repository to datastax/dse-mgmtapi-6_8
 * [CHANGE] [#573](https://github.com/k8ssandra/cass-operator/issues/573) Add the namespace as env variable in the server-system-logger container to label metrics with.
 * [ENHANCEMENT] [#580](https://github.com/k8ssandra/cass-operator/issues/580) Add garbageCollect CassandraTask that removes deleted data
 * [ENHANCEMENT] [#578](https://github.com/k8ssandra/cass-operator/issues/578) Add flush CassandraTask that flushed memtables to the disk

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -18,6 +18,7 @@ defaults:
   # Note, postfix is ignored if repository is not set
   cassandra:
     repository: "k8ssandra/cass-management-api"
+    suffix: "-ubi8"
   dse:
-    repository: "datastax/dse-server"
-    suffix: "-ubi7"
+    repository: "datastax/dse-mgmtapi-6_8"
+    suffix: "-ubi8"

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -81,11 +81,11 @@ func TestDefaultImageConfigParsing(t *testing.T) {
 	assert.True(strings.HasPrefix(GetImageConfig().Images.ConfigBuilder, "datastax/cass-config-builder:"))
 
 	assert.Equal("k8ssandra/cass-management-api", GetImageConfig().DefaultImages.CassandraImageComponent.Repository)
-	assert.Equal("datastax/dse-server", GetImageConfig().DefaultImages.DSEImageComponent.Repository)
+	assert.Equal("datastax/dse-mgmtapi-6_8", GetImageConfig().DefaultImages.DSEImageComponent.Repository)
 
 	path, err := GetCassandraImage("dse", "6.8.17")
 	assert.NoError(err)
-	assert.Equal("datastax/dse-server:6.8.17-ubi7", path)
+	assert.Equal("datastax/dse-mgmtapi-6_8:6.8.17-ubi8", path)
 }
 
 func TestImageConfigParsing(t *testing.T) {

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -1441,7 +1441,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "dse",
 				serverVersion: "6.8.0",
 			},
-			want:      "datastax/dse-server:6.8.0-ubi7",
+			want:      "datastax/dse-mgmtapi-6_8:6.8.0-ubi8",
 			errString: "",
 		},
 		{
@@ -1451,7 +1451,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "cassandra",
 				serverVersion: "3.11.10",
 			},
-			want:      "k8ssandra/cass-management-api:3.11.10",
+			want:      "k8ssandra/cass-management-api:3.11.10-ubi8",
 			errString: "",
 		},
 		{
@@ -1491,7 +1491,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "dse",
 				serverVersion: "6.8.1234",
 			},
-			want:      "datastax/dse-server:6.8.1234-ubi7",
+			want:      "datastax/dse-mgmtapi-6_8:6.8.1234-ubi8",
 			errString: "",
 		},
 		{
@@ -1501,7 +1501,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "dse",
 				serverVersion: "6.8.26",
 			},
-			want:      "datastax/dse-server:6.8.26-ubi7",
+			want:      "datastax/dse-mgmtapi-6_8:6.8.26-ubi8",
 			errString: "",
 		},
 	}

--- a/scripts/pre-release-process.sh
+++ b/scripts/pre-release-process.sh
@@ -29,6 +29,7 @@ LOG_IMG=k8ssandra/system-logger:${TAG} yq eval -i '.images.system-logger = env(L
 
 # Add cr.k8ssandra.io prefixes
 yq eval -i '.images.system-logger |= "cr.k8ssandra.io/" + .' config/manager/image_config.yaml
+yq eval -i '.images.k8ssandra-client |= "cr.k8ssandra.io/" + .' config/manager/image_config.yaml
 yq eval -i '.defaults.cassandra.repository |= "cr.k8ssandra.io/" + .' config/manager/image_config.yaml
 
 # Add cr.dstx.io prefixes

--- a/scripts/pre-release-process.sh
+++ b/scripts/pre-release-process.sh
@@ -8,7 +8,7 @@ fi
 TAG=$1
 #PREVTAG=$2
 PREVTAG=$(git describe --abbrev=0 --tags)
-IMG=k8ssandra/cass-operator:${TAG}
+IMG=cr.k8ssandra.io/k8ssandra/cass-operator:${TAG}
 
 # Ensure kustomize is installed
 make kustomize
@@ -26,6 +26,16 @@ cd config/manager && $KUSTOMIZE edit set image controller=$IMG && cd -
 
 # Modify config/manager/image_config.yaml to have proper version for server-system-logger
 LOG_IMG=k8ssandra/system-logger:${TAG} yq eval -i '.images.system-logger = env(LOG_IMG)' config/manager/image_config.yaml
+
+# Add cr.k8ssandra.io prefixes
+yq eval -i '.images.system-logger |= "cr.k8ssandra.io/" + .' config/manager/image_config.yaml
+yq eval -i '.defaults.cassandra.repository |= "cr.k8ssandra.io/" + .' config/manager/image_config.yaml
+
+# Add cr.dstx.io prefixes
+yq eval -i '.images.config-builder |= "cr.dtsx.io/" + .' config/manager/image_config.yaml
+yq eval -i '.defaults.dse.repository |= "cr.dtsx.io/" + .' config/manager/image_config.yaml
+
+# Modify the controller
 
 # Now add everything and create a commit + tag
 git add CHANGELOG.md

--- a/scripts/release-community-bundles.sh
+++ b/scripts/release-community-bundles.sh
@@ -14,7 +14,7 @@ TARGET_DIRS=(community-operators community-operators-prod)
 git checkout v$VERSION
 
 # Create bundle
-make VERSION=$VERSION REGISTRY=docker.io bundle
+make VERSION=$VERSION REGISTRY=cr.dtsx.io bundle
 
 # Modify package name to cass-operator-community
 yq eval -i '.annotations."operators.operatorframework.io.bundle.package.v1" = "cass-operator-community"' bundle/metadata/annotations.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
cr.k8ssandra.io prefix for all deployed images from k8ssandra/* and cr.dstx.io for all deployed images from datastax/*

Resulting image_config.yaml:

```yaml
apiVersion: config.k8ssandra.io/v1beta1
kind: ImageConfig
metadata:
  name: image-config
images:
  system-logger: "cr.k8ssandra.io/k8ssandra/system-logger:latest"
  config-builder: "cr.dtsx.io/datastax/cass-config-builder:1.0-ubi7"
  # cassandra:
  #   "4.0.0": "k8ssandra/cassandra-ubi:latest"
  # dse:
  #   "6.8.999": "datastax/dse-server-prototype:latest"
# imageRegistry: "localhost:5000"
# imagePullPolicy: Always
# imagePullSecret:
#   name: my-secret-pull-registry
defaults:
  # Note, postfix is ignored if repository is not set
  cassandra:
    repository: "cr.k8ssandra.io/k8ssandra/cass-management-api"
    suffix: "-ubi8"
  dse:
    repository: "cr.dtsx.io/datastax/dse-mgmtapi-6_8"
    suffix: "-ubi8"
```

**Which issue(s) this PR fixes**:
Fixes #479 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
