### PR TITLE
Add new Prometheus metrics, cass_operator_datacenter_pods_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#553](https://github.com/k8ssandra/cass-operator/issues/553) dockerImageRunsAsCassandra is no longer used for anything as that's the default for current images. Use SecurityContext to override default SecurityContext (999:999)
 * [ENHANCEMENT] [#554](https://github.com/k8ssandra/cass-operator/issues/554) Add new empty directory as mount to server-system-logger (/var/lib/vector) so it works with multiple securityContexes
 * [ENHANCEMENT] [#512](https://github.com/k8ssandra/cass-operator/issues/512) Configs are now built using the newer k8ssandra-client config build command instead of the older cass-config-builder. This provides support for Cassandra 4.1.x config properties and to newer.
+* [ENHANCEMENT] [#184](https://github.com/k8ssandra/cass-operator/issues/184) Implement metrics to indicate the status of the Datacenter pods. Experimental, these metric names and values could be changed in the future versions.
 
 ## v1.16.0
 

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -1,0 +1,89 @@
+package monitoring
+
+import (
+	"strings"
+
+	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type PodStatus string
+
+const (
+	PodStatusInitializing    PodStatus = "Initializing"
+	PodStatusReady           PodStatus = "Ready"
+	PodStatusPending         PodStatus = "Pending"
+	PodStatusError           PodStatus = "Error"
+	PodStatusDecommissioning PodStatus = "Decommissioning"
+)
+
+var podStatuses []PodStatus = []PodStatus{PodStatusInitializing, PodStatusReady, PodStatusPending, PodStatusError, PodStatusDecommissioning}
+
+func getPodStatus(pod *corev1.Pod) PodStatus {
+	status := PodStatusReady
+
+	if pod.Labels[api.CassNodeState] == "Decommissioning" {
+		return PodStatusDecommissioning
+	}
+
+	switch pod.Status.Phase {
+	case corev1.PodPending:
+		return PodStatusPending
+	case corev1.PodFailed:
+		return PodStatusError
+	case corev1.PodRunning:
+	default:
+	}
+
+	allContainersReady := true
+
+	for _, s := range pod.Status.ContainerStatuses {
+		if !s.Ready {
+			allContainersReady = false
+			break
+		}
+	}
+
+	if !allContainersReady {
+		return PodStatusInitializing
+	}
+
+	return status
+}
+
+var (
+	PodStatusVec *prometheus.GaugeVec
+)
+
+func init() {
+	podVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "cass_operator",
+		Subsystem: "datacenter_pods",
+		Name:      "status",
+		Help:      "Cassandra pod statuses",
+	}, []string{"cluster", "datacenter", "rack", "pod", "status"})
+
+	metrics.Registry.Register(podVec)
+	PodStatusVec = podVec
+}
+
+func UpdatePodStatusMetric(pod *corev1.Pod) {
+	currentState := getPodStatus(pod)
+
+	// Delete all status metrics for this pod
+	RemovePodStatusMetric(pod)
+
+	// Add just the current one
+	PodStatusVec.WithLabelValues(pod.Labels[api.ClusterLabel], pod.Labels[api.DatacenterLabel], pod.Labels[api.RackLabel], pod.Name, strings.ToLower(string(currentState))).Set(1)
+}
+
+func RemovePodStatusMetric(pod *corev1.Pod) {
+	PodStatusVec.DeletePartialMatch(prometheus.Labels{"cluster": pod.Labels[api.ClusterLabel], "datacenter": pod.Labels[api.DatacenterLabel], "rack": pod.Labels[api.RackLabel], "pod": pod.Name})
+}
+
+func RemoveDatacenterPods(cluster, datacenter string) {
+	PodStatusVec.DeletePartialMatch(prometheus.Labels{"cluster": cluster, "datacenter": datacenter})
+}

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -20,8 +20,6 @@ const (
 	PodStatusDecommissioning PodStatus = "Decommissioning"
 )
 
-var podStatuses []PodStatus = []PodStatus{PodStatusInitializing, PodStatusReady, PodStatusPending, PodStatusError, PodStatusDecommissioning}
-
 func getPodStatus(pod *corev1.Pod) PodStatus {
 	status := PodStatusReady
 
@@ -66,7 +64,7 @@ func init() {
 		Help:      "Cassandra pod statuses",
 	}, []string{"cluster", "datacenter", "rack", "pod", "status"})
 
-	metrics.Registry.Register(podVec)
+	metrics.Registry.MustRegister(podVec)
 	PodStatusVec = podVec
 }
 

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -62,7 +62,7 @@ func init() {
 		Subsystem: "datacenter_pods",
 		Name:      "status",
 		Help:      "Cassandra pod statuses",
-	}, []string{"cluster", "datacenter", "rack", "pod", "status"})
+	}, []string{"namespace", "cluster", "datacenter", "rack", "pod", "status"})
 
 	metrics.Registry.MustRegister(podVec)
 	PodStatusVec = podVec
@@ -75,13 +75,13 @@ func UpdatePodStatusMetric(pod *corev1.Pod) {
 	RemovePodStatusMetric(pod)
 
 	// Add just the current one
-	PodStatusVec.WithLabelValues(pod.Labels[api.ClusterLabel], pod.Labels[api.DatacenterLabel], pod.Labels[api.RackLabel], pod.Name, strings.ToLower(string(currentState))).Set(1)
+	PodStatusVec.WithLabelValues(pod.Namespace, pod.Labels[api.ClusterLabel], pod.Labels[api.DatacenterLabel], pod.Labels[api.RackLabel], pod.Name, strings.ToLower(string(currentState))).Set(1)
 }
 
 func RemovePodStatusMetric(pod *corev1.Pod) {
-	PodStatusVec.DeletePartialMatch(prometheus.Labels{"cluster": pod.Labels[api.ClusterLabel], "datacenter": pod.Labels[api.DatacenterLabel], "rack": pod.Labels[api.RackLabel], "pod": pod.Name})
+	PodStatusVec.DeletePartialMatch(prometheus.Labels{"namespace": pod.Namespace, "cluster": pod.Labels[api.ClusterLabel], "datacenter": pod.Labels[api.DatacenterLabel], "rack": pod.Labels[api.RackLabel], "pod": pod.Name})
 }
 
-func RemoveDatacenterPods(cluster, datacenter string) {
-	PodStatusVec.DeletePartialMatch(prometheus.Labels{"cluster": cluster, "datacenter": datacenter})
+func RemoveDatacenterPods(namespace, cluster, datacenter string) {
+	PodStatusVec.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "cluster": cluster, "datacenter": datacenter})
 }

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -1,0 +1,108 @@
+package monitoring
+
+import (
+	"fmt"
+	"testing"
+
+	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestMetricAdder(t *testing.T) {
+	pods := make([]*corev1.Pod, 6)
+	for i := 0; i < len(pods); i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("pod%d", i),
+				Labels: map[string]string{
+					api.ClusterLabel:    "cluster1",
+					api.DatacenterLabel: "datacenter1",
+					api.RackLabel:       "rack1",
+					api.CassNodeState:   "Started",
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Ready: true,
+					},
+				},
+			},
+		}
+		pods[i] = pod
+		UpdatePodStatusMetric(pod)
+	}
+
+	require := require.New(t)
+
+	status, err := getCurrentPodStatus("pod0")
+	require.NoError(err)
+	require.Equal("ready", status)
+
+	pods[2].Status.ContainerStatuses[0].Ready = false
+	UpdatePodStatusMetric(pods[2])
+
+	status, err = getCurrentPodStatus("pod2")
+	require.NoError(err)
+	require.Equal("initializing", status)
+
+	pods[3].Status.Phase = corev1.PodFailed
+	UpdatePodStatusMetric(pods[3])
+
+	status, err = getCurrentPodStatus("pod3")
+	require.NoError(err)
+	require.Equal("error", status)
+
+	RemovePodStatusMetric(pods[4])
+	_, err = getCurrentPodStatus("pod4")
+	require.Error(err)
+
+	metav1.SetMetaDataLabel(&pods[5].ObjectMeta, api.CassNodeState, "Decommissioning")
+	UpdatePodStatusMetric(pods[5])
+	status, err = getCurrentPodStatus("pod5")
+	require.NoError(err)
+	require.Equal("decommissioning", status)
+
+	// Verify pod4 can be added back
+	UpdatePodStatusMetric(pods[4])
+	status, err = getCurrentPodStatus("pod4")
+	require.NoError(err)
+	require.Equal("ready", status)
+
+	RemoveDatacenterPods("cluster1", "datacenter1")
+	_, err = getCurrentPodStatus("pod4")
+	require.Error(err)
+}
+
+func getCurrentPodStatus(podName string) (string, error) {
+	families, err := metrics.Registry.Gather()
+	if err != nil {
+		return "", err
+	}
+
+	for _, fam := range families {
+		if *fam.Name == "cass_operator_datacenter_pods_status" {
+		Metric:
+			for _, m := range fam.Metric {
+				status := ""
+				for _, label := range m.Label {
+					if *label.Name == "pod" {
+						if *label.Value != podName {
+							continue Metric
+						}
+					}
+					if *label.Name == "status" {
+						status = *label.Value
+					}
+				}
+				if *m.Gauge.Value > 0 {
+					return status, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("No pod status found")
+}

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1129,7 +1129,7 @@ func (rc *ReconciliationContext) UpdateStatus() result.ReconcileResult {
 	}
 
 	// Update current state of the pods
-	monitoring.RemoveDatacenterPods(dc.Spec.ClusterName, dc.DatacenterName())
+	monitoring.RemoveDatacenterPods(dc.Namespace, dc.Spec.ClusterName, dc.DatacenterName())
 	for _, pod := range rc.dcPods {
 		monitoring.UpdatePodStatusMetric(pod)
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a new Prometheus metric cass_operator_datacenter_pods_status which has status label as the current status of the pod, with value of 1 indicating the current active status.

While this fixes #184, we might want to add more metrics indicating the reconciliation status also in the future.

**Which issue(s) this PR fixes**:
Fixes #184

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
