### PR TITLE
Ensure server-config-init and server-config-init-base are in initContainers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [ENHANCEMENT] [#571](https://github.com/k8ssandra/cass-operator/issues/571) Ensure both "server-config-init" as well as "server-config-init-base" are always created in the initContainers if 4.1.x is used.  
+
 ## v1.17.1
 
 * [CHANGE] [#541](https://github.com/k8ssandra/cass-operator/issues/541) Revert when deployed through OLM, add serviceAccount to Cassandra pods that use nonroot priviledge. This is no longer necessary with 1.17.0 and up.

--- a/tests/testdata/default-single-rack-single-node-addtional-volumes-dc.yaml
+++ b/tests/testdata/default-single-rack-single-node-addtional-volumes-dc.yaml
@@ -28,6 +28,9 @@ spec:
     - name: r1
   podTemplateSpec:
     spec:
+      initContainers:
+        - name: server-config-init
+          resources: {}
       containers:
         - args: ["/bin/sh", "-c", "tail -n+1 -F /var/log/cassandra/system.log"]
           image: busybox


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes the override function of initContainers. Previously, setting "server-config-init" would allow overriding all the initContainers, but that also meant removing "server-config-init-base" even if that was actually necessary and user did not set it.

**Which issue(s) this PR fixes**:
Fixes #571

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
