### PR TITLE
Adding debug target on Makefile, fixing leaderElection and imageConfi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run ./cmd/main.go --config=./config/manager/controller_manager_config.yaml
 
 .PHONY: debug
 debug: manifests build

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,11 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
 
+.PHONY: debug
+debug: manifests build
+	dlv --listen=:2345 --headless=true --api-version=2 exec ./bin/manager  -- \
+		--config=./config/manager/controller_manager_config.yaml
+
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
 	docker buildx build --build-arg VERSION=${VERSION} -t ${IMG} . --load

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -9,7 +9,7 @@ metrics:
 webhook:
   port: 9443
 leaderElection:
-  leaderElect: true
+  leaderElect: false
   resourceName: b569adb7.cassandra.datastax.com
 disableWebhooks: true
-imageConfigFile: /configs/image_config.yaml
+imageConfigFile: ./config/manager/image_config.yaml


### PR DESCRIPTION
…gFile reference

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds the `make debug` directive, which allows developers to attach the debugger to delve locally in port 2345.
It also fixes the config files for the manager and container images, to correctly load the default operator config, and allow for properly downloading the cassandra container images.


**Which issue(s) this PR fixes**:
Fixes #610 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
