### PR TITLE
Allow replacenode task to replace nodes that have Cassandra crashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#618](https://github.com/k8ssandra/cass-operator/issues/618) Update dependencies to support controller-runtime 0.17.2, modify required parts.
+* [ENHANCEMENT] [#628](https://github.com/k8ssandra/cass-operator/issues/628) Replace pod task can replace any node, including those that have crashed
 * [ENHANCEMENT] [#532](https://github.com/k8ssandra/cass-operator/issues/532) Instead of rejecting updates/creates with deprecated fields, return kubectl warnings.
 
 ## v1.19.1

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -296,8 +296,6 @@ JobDefinition:
 			completed = taskConfig.Completed
 			break JobDefinition
 		case api.CommandReplaceNode:
-			// Should we do it here? This is going to target just a single node in any case
-			// Validate the pod is a known one and get it
 			r.replace(taskConfig)
 		case api.CommandUpgradeSSTables:
 			upgradesstables(taskConfig)
@@ -342,7 +340,7 @@ JobDefinition:
 		}
 
 		if job.Command == api.CommandReplaceNode {
-			// Special handling for replace process
+			// Special handling for replace process since it targets a single pod
 			if err := r.replacePreProcess(taskConfig); err != nil {
 				return ctrl.Result{}, err
 			}

--- a/internal/controllers/control/cassandratask_controller_test.go
+++ b/internal/controllers/control/cassandratask_controller_test.go
@@ -515,7 +515,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 					Expect(completedTask.Status.Failed).To(BeNumerically(">=", 1))
 					Expect(completedTask.Status.Conditions[2].Type).To(Equal(string(api.JobFailed)))
-					Expect(completedTask.Status.Conditions[2].Message).To(Equal("valid pod_name to replace is required"))
+					Expect(completedTask.Status.Conditions[2].Message).To(Equal("terminal error: valid pod_name to replace is required"))
 				})
 			})
 		})

--- a/pkg/httphelper/client_test.go
+++ b/pkg/httphelper/client_test.go
@@ -210,6 +210,11 @@ func Test_featureSet(t *testing.T) {
 	assert.False(featureSet.Supports(AsyncSSTableTasks))
 }
 
+func TestEmptyFeatureSupports(t *testing.T) {
+	features := &FeatureSet{}
+	assert.False(t, features.Supports(AsyncSSTableTasks))
+}
+
 func TestNodeMgmtClient_GetKeyspaceReplication(t *testing.T) {
 	successBody := map[string]string{"class": "org.apache.cassandra.locator.NetworkTopologyStrategy", "dc1": "3", "dc2": "1"}
 	tests := []struct {

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -211,6 +211,8 @@ var _ = Describe(testName, func() {
 			verifyAllPodsAreCorrect()
 		})
 		Specify("cassandratask can be used to replace a node", func() {
+			// TODO Crash the Cassandra instance (emulate fsync failure or similar)
+
 			// Create CassandraTask that should replace a node
 			step := "creating a cassandra task to replace a node"
 			k := kubectl.ApplyFiles(taskYaml)

--- a/tests/util/ginkgo/lib.go
+++ b/tests/util/ginkgo/lib.go
@@ -500,6 +500,15 @@ func (ns *NsWrapper) EnableGossip(podName string) {
 	ns.ExecVPanic(k)
 }
 
+func (ns *NsWrapper) KillCassandra(podName string) {
+	execArgs := []string{"-c", "cassandra",
+		"--", "bash", "-c",
+		"pkill -f -9 CassandraDaemon",
+	}
+	k := kubectl.ExecOnPod(podName, execArgs...)
+	ns.ExecVPanic(k)
+}
+
 func (ns *NsWrapper) GetDatacenterPodNames(dcName string) []string {
 	json := "jsonpath={.items[*].metadata.name}"
 	k := kubectl.Get("pods").


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Modifies the replace pod process to be able to replace a node that has no longer a running Cassandra pod. Also, add a test to verify the PVs that the pod uses are different from previous ones in the replace node e2e test.

**Which issue(s) this PR fixes**:
Fixes #628

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
