### PR TITLE
make minReadySecond configurable for cassandra statefulSet

### DIFF
--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -220,6 +220,9 @@ type CassandraDatacenterSpec struct {
 
 	DseWorkloads *DseWorkloads `json:"dseWorkloads,omitempty"`
 
+	// set the minReadySeconds value for cassandra StatefulSet
+	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
+
 	// PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the cassandra pods
 	PodTemplateSpec *corev1.PodTemplateSpec `json:"podTemplateSpec,omitempty"`
 

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -348,6 +348,11 @@ spec:
                     - serverSecretName
                     type: object
                 type: object
+              minReadySeconds:
+                description: This is an alpha field from kubernetes 1.22 until 1.24
+                  which requires enabling the StatefulSetMinReadySeconds feature gate.
+                format: int32
+                type: integer
               networking:
                 properties:
                   hostNetwork:

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -145,6 +145,7 @@ func newStatefulSetForCassandraDatacenter(
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			Template:             *template,
 			VolumeClaimTemplates: volumeClaimTemplates,
+			MinReadySeconds:      dc.Spec.MinReadySeconds,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
