### PR TITLE
Update nodeStatuses info when a pod is recreated (fixes #652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#652](https://github.com/k8ssandra/cass-operator/issues/652) Update nodeStatuses info when a pod is recreated
+
 ## v1.20.0
 
 * [CHANGE] [#566](https://github.com/k8ssandra/cass-operator/issues/566) BREAKING: StatefulSets will no longer be automatically updated if CassandraDatacenter is not modified, unless an annotation "cassandra.datastax.com/autoupdate-spec" is set to the CassandraDatacenter with value "always" or "once". This means users of config secret should set this variable to "always" to keep their existing behavior. For other users, this means that for example the upgrades of operator will no longer automatically apply updated settings or system-logger image. The benefit is that updating the operator no longer causes the cluster to have a rolling restart. A new condition to indicate such change could be necessary is called "RequiresUpdate" and it will be set to True until the next refresh of reconcile has happened. 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -989,21 +989,21 @@ func (rc *ReconciliationContext) UpdateCassandraNodeStatus(force bool) error {
 		}
 
 		if pod.Status.PodIP != "" && isMgmtApiRunning(pod) {
+			ip := getRpcAddress(dc, pod)
+			nodeStatus.IP = ip
+			nodeStatus.Rack = pod.Labels[api.RackLabel]
+
 			// Getting the HostID requires a call to the node management API which is
 			// moderately expensive, so if we already have a HostID, don't bother. This
 			// would only change if something has gone horribly horribly wrong.
-
 			if force || nodeStatus.HostID == "" {
 				endpointsResponse, err := rc.NodeMgmtClient.CallMetadataEndpointsEndpoint(pod)
 				if err == nil {
-					ip := getRpcAddress(dc, pod)
 					nodeStatus.HostID = findHostIdForIpFromEndpointsData(
 						endpointsResponse.Entity, ip)
 					if nodeStatus.HostID == "" {
 						logger.Info("Failed to find host ID", "pod", pod.Name)
 					}
-					nodeStatus.IP = ip
-					nodeStatus.Rack = pod.Labels[api.RackLabel]
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does**:
Update nodeStatuses info when a pod is recreated

**Which issue(s) this PR fixes**:
Fixes #652

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
