### PR TITLE
Upgrade canary test to fully update the cluster after the canary upgrade

### DIFF
--- a/.github/actions/run-integ-test/action.yml
+++ b/.github/actions/run-integ-test/action.yml
@@ -23,7 +23,7 @@ runs:
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /opt/ghc
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
         cache: true

--- a/.github/workflows/operatorBuildAndDeploy.yml
+++ b/.github/workflows/operatorBuildAndDeploy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request'
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -53,7 +53,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [BUGFIX] [#652](https://github.com/k8ssandra/cass-operator/issues/652) Update nodeStatuses info when a pod is recreated
+* [BUGFIX] [#656](https://github.com/k8ssandra/cass-operator/issues/656) After canary upgrade, it was not possible to continue upgrading rest of the nodes if the only change was removing the canary upgrade
+* [BUGFIX] [#657](https://github.com/k8ssandra/cass-operator/issues/657) If a change did not result in StatefulSet changes, a Ready -> Ready state would lose an ObservedGeneration update in the status
+* [BUGFIX] [#382](https://github.com/k8ssandra/cass-operator/issues/382) If StatefulSet has not caught up yet, do not allow any changes to it. Instead, requeue and wait (does not change behavior of forceRacksUpgrade)
 
 ## v1.20.0
 

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -152,6 +152,23 @@ func newStatefulSetForCassandraDatacenter(
 		result.Spec.ServiceName = sts.Spec.ServiceName
 	}
 
+	if dc.Spec.CanaryUpgrade {
+		var partition int32
+		if dc.Spec.CanaryUpgradeCount == 0 || dc.Spec.CanaryUpgradeCount > replicaCountInt32 {
+			partition = replicaCountInt32
+		} else {
+			partition = replicaCountInt32 - dc.Spec.CanaryUpgradeCount
+		}
+
+		strategy := appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+				Partition: &partition,
+			},
+		}
+		result.Spec.UpdateStrategy = strategy
+	}
+
 	// add a hash here to facilitate checking if updates are needed
 	utils.AddHashAnnotation(result)
 

--- a/pkg/reconciliation/handler.go
+++ b/pkg/reconciliation/handler.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"sync"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
@@ -65,9 +67,28 @@ func (rc *ReconciliationContext) CalculateReconciliationActions() (reconcile.Res
 		return result.Error(err).Output()
 	}
 
-	result, err := rc.ReconcileAllRacks()
+	res, err := rc.ReconcileAllRacks()
+	if err != nil {
+		return result.Error(err).Output()
+	}
 
-	return result, err
+	if err := rc.updateStatus(); err != nil {
+		return result.Error(err).Output()
+	}
+
+	return res, nil
+}
+
+func (rc *ReconciliationContext) updateStatus() error {
+	patch := client.MergeFrom(rc.Datacenter.DeepCopy())
+	rc.Datacenter.Status.ObservedGeneration = rc.Datacenter.Generation
+	rc.setCondition(api.NewDatacenterCondition(api.DatacenterRequiresUpdate, corev1.ConditionFalse))
+	if err := rc.Client.Status().Patch(rc.Ctx, rc.Datacenter, patch); err != nil {
+		rc.ReqLogger.Error(err, "error updating the Cassandra Operator Progress state")
+		return err
+	}
+
+	return nil
 }
 
 // This file contains various definitions and plumbing setup used for reconciliation.

--- a/tests/canary_upgrade/canary_upgrade_test.go
+++ b/tests/canary_upgrade/canary_upgrade_test.go
@@ -100,6 +100,22 @@ var _ = Describe(testName, func() {
 			ns.WaitForCassandraImages(dcName, images, 300)
 			ns.WaitForDatacenterReadyPodCount(dcName, 3)
 
+			// TODO Verify that after the canary upgrade we can issue upgrades to the rest of the nodes
+			step = "remove canary upgrade"
+			json = "{\"spec\": {\"canaryUpgrade\": false}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
+			ns.WaitForDatacenterReadyPodCount(dcName, 3)
+
+			images = []string{
+				updated,
+				updated,
+				updated,
+			}
+			ns.WaitForCassandraImages(dcName, images, 300)
+
 			step = "deleting the dc"
 			k = kubectl.DeleteFromFiles(dcYaml)
 			ns.ExecAndLog(step, k)

--- a/tests/canary_upgrade/canary_upgrade_test.go
+++ b/tests/canary_upgrade/canary_upgrade_test.go
@@ -102,7 +102,7 @@ var _ = Describe(testName, func() {
 
 			// TODO Verify that after the canary upgrade we can issue upgrades to the rest of the nodes
 			step = "remove canary upgrade"
-			json = "{\"spec\": {\"canaryUpgrade\": false}"
+			json = "{\"spec\": {\"canaryUpgrade\": false}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Tests that after the canary upgrade, we can fully upgrade the cluster to the state we wanted. This means, first running a canary upgrade to test that the new version works and then update the rest.

**Which issue(s) this PR fixes**:
Fixes #656
Fixes #657 
Fixes #382 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
