### PR TITLE
Do not update ObservedGeneration and RequiresUpdate mid process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#665](https://github.com/k8ssandra/cass-operator/issues/665) The RequiresUpdate and ObservedGenerations were updated too often, even when the reconcile was not finished.
+
 ## v1.21.0
 
 * [FEATURE] [#659](https://github.com/k8ssandra/cass-operator/issues/659) Add support for HCD serverType with versions 1.x.x. It will be deployed like Cassandra >= 4.1 for now.

--- a/pkg/reconciliation/handler.go
+++ b/pkg/reconciliation/handler.go
@@ -7,11 +7,9 @@ import (
 	"fmt"
 	"sync"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
@@ -67,28 +65,7 @@ func (rc *ReconciliationContext) CalculateReconciliationActions() (reconcile.Res
 		return result.Error(err).Output()
 	}
 
-	res, err := rc.ReconcileAllRacks()
-	if err != nil {
-		return result.Error(err).Output()
-	}
-
-	if err := rc.updateStatus(); err != nil {
-		return result.Error(err).Output()
-	}
-
-	return res, nil
-}
-
-func (rc *ReconciliationContext) updateStatus() error {
-	patch := client.MergeFrom(rc.Datacenter.DeepCopy())
-	rc.Datacenter.Status.ObservedGeneration = rc.Datacenter.Generation
-	rc.setCondition(api.NewDatacenterCondition(api.DatacenterRequiresUpdate, corev1.ConditionFalse))
-	if err := rc.Client.Status().Patch(rc.Ctx, rc.Datacenter, patch); err != nil {
-		rc.ReqLogger.Error(err, "error updating the Cassandra Operator Progress state")
-		return err
-	}
-
-	return nil
+	return rc.ReconcileAllRacks()
 }
 
 // This file contains various definitions and plumbing setup used for reconciliation.

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2422,6 +2422,10 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return result.Error(err).Output()
 	}
 
+	if err := setDatacenterStatus(rc); err != nil {
+		return result.Error(err).Output()
+	}
+
 	if err := rc.enableQuietPeriod(5); err != nil {
 		logger.Error(
 			err,

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -370,6 +370,13 @@ func TestCheckRackPodTemplate_GenerationCheck(t *testing.T) {
 	assert.True(found)
 	assert.Equal(corev1.ConditionTrue, cond.Status)
 
+	// Verify full reconcile does not remove our updated condition
+	_, err := rc.ReconcileAllRacks()
+	require.NoError(t, err)
+	cond, found = rc.Datacenter.GetCondition(api.DatacenterRequiresUpdate)
+	assert.True(found)
+	assert.Equal(corev1.ConditionTrue, cond.Status)
+
 	// Add annotation
 	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.UpdateAllowedAnnotation, string(api.AllowUpdateAlways))
 	rc.Datacenter.Spec.ServerVersion = "6.8.44" // This needs to be reapplied, since we call Patch in the CheckRackPodTemplate()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The bugfix of canary upgrade inadvertently caused the status upgrades to be pushed too often, resulting in removal of RequiresUpdate status and ObservedGeneration change while the previous process wasn't yet complete.

**Which issue(s) this PR fixes**:
Fixes #665

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
