### PR TITLE
Change default labels to use Kubernetes resource name

### DIFF
--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -261,8 +261,7 @@ type CassandraDatacenterSpec struct {
 	// CDC allows configuration of the change data capture agent which can run within the Management API container. Use it to send data to Pulsar.
 	CDC *CDCConfiguration `json:"cdc,omitempty"`
 
-	// DatacenterName allows to override the name of the Cassandra datacenter. Kubernetes objects will be named after a sanitized version of it if set, and if not metadata.name. In Cassandra the DC name will be overridden by this value.
-	// It may generate some confusion as objects created for the DC will have a different name than the CasandraDatacenter object itself.
+	// DatacenterName allows to override the name of the Cassandra datacenter. In Cassandra the DC name will be overridden by this value.
 	// This setting can create conflicts if multiple DCs coexist in the same namespace if metadata.name for a DC with no override is set to the same value as the override name of another DC.
 	// Use cautiously.
 	// +optional

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -300,8 +300,7 @@ spec:
                 type: string
               datacenterName:
                 description: |-
-                  DatacenterName allows to override the name of the Cassandra datacenter. Kubernetes objects will be named after a sanitized version of it if set, and if not metadata.name. In Cassandra the DC name will be overridden by this value.
-                  It may generate some confusion as objects created for the DC will have a different name than the CasandraDatacenter object itself.
+                  DatacenterName allows to override the name of the Cassandra datacenter. In Cassandra the DC name will be overridden by this value.
                   This setting can create conflicts if multiple DCs coexist in the same namespace if metadata.name for a DC with no override is set to the same value as the override name of another DC.
                   Use cautiously.
                 type: string

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -11221,6 +11221,9 @@ spec:
                   with the management API
                 format: date-time
                 type: string
+              metadataVersion:
+                format: int64
+                type: integer
               nodeReplacements:
                 items:
                   type: string

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -18,7 +18,7 @@ defaults:
   # Note, postfix is ignored if repository is not set
   cassandra:
     repository: "k8ssandra/cass-management-api"
-    suffix: "-ubi8"
+    suffix: "-ubi"
   dse:
     repository: "datastax/dse-mgmtapi-6_8"
     suffix: "-ubi8"

--- a/internal/controllers/cassandra/cassandradatacenter_controller_test.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller_test.go
@@ -155,8 +155,9 @@ var _ = Describe("CassandraDatacenter tests", func() {
 				refreshDatacenter(ctx, &dc)
 
 				By("Updating the size to 3")
+				patch := client.MergeFrom(dc.DeepCopy())
 				dc.Spec.Size = 3
-				Expect(k8sClient.Update(ctx, &dc)).To(Succeed())
+				Expect(k8sClient.Patch(ctx, &dc, patch)).To(Succeed())
 
 				waitForDatacenterCondition(ctx, dcName, cassdcapi.DatacenterScalingUp, corev1.ConditionTrue).Should(Succeed())
 				waitForDatacenterProgress(ctx, dcName, cassdcapi.ProgressUpdating).Should(Succeed())

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -202,7 +202,7 @@ func (r *CassandraTaskReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, errors.Wrapf(err, "unable to fetch target CassandraDatacenter: %s", cassTask.Spec.Datacenter)
 	}
 
-	logger = log.FromContext(ctx, "datacenterName", dc.SanitizedName(), "clusterName", dc.Spec.ClusterName)
+	logger = log.FromContext(ctx, "datacenterName", dc.LabelResourceName(), "clusterName", dc.Spec.ClusterName)
 	log.IntoContext(ctx, logger)
 
 	// If we're active, we can proceed - otherwise verify if we're allowed to run

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -94,7 +94,7 @@ func TestDefaultImageConfigParsing(t *testing.T) {
 
 	path, err = GetCassandraImage("cassandra", "4.1.4")
 	assert.NoError(err)
-	assert.Equal("k8ssandra/cass-management-api:4.1.4-ubi8", path)
+	assert.Equal("k8ssandra/cass-management-api:4.1.4-ubi", path)
 }
 
 func TestImageConfigParsing(t *testing.T) {

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -379,7 +379,7 @@ func addVolumes(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTemplateSpe
 			Name: "encryption-cred-storage",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: fmt.Sprintf("%s-keystore", dc.SanitizedName()),
+					SecretName: fmt.Sprintf("%s-keystore", dc.LabelResourceName()),
 				},
 			},
 		}
@@ -614,7 +614,7 @@ func getConfigDataEnVars(dc *api.CassandraDatacenter) ([]corev1.EnvVar, error) {
 			return envVars, nil
 		}
 
-		return nil, fmt.Errorf("datacenter %s is missing %s annotation", dc.SanitizedName(), api.ConfigHashAnnotation)
+		return nil, fmt.Errorf("datacenter %s is missing %s annotation", dc.LabelResourceName(), api.ConfigHashAnnotation)
 	}
 
 	configData, err := dc.GetConfigAsJSON(dc.Spec.Config)

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -1548,7 +1548,7 @@ func Test_makeImage(t *testing.T) {
 				serverType:    "cassandra",
 				serverVersion: "3.11.10",
 			},
-			want:      "localhost:5000/k8ssandra/cass-management-api:3.11.10-ubi8",
+			want:      "localhost:5000/k8ssandra/cass-management-api:3.11.10-ubi",
 			errString: "",
 		},
 		{

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -26,7 +26,7 @@ func newNamespacedNameForStatefulSet(
 	dc *api.CassandraDatacenter,
 	rackName string) types.NamespacedName {
 
-	name := api.CleanupForKubernetes(dc.Spec.ClusterName) + "-" + dc.SanitizedName() + "-" + api.CleanupSubdomain(rackName) + "-sts"
+	name := api.CleanupForKubernetes(dc.Spec.ClusterName) + "-" + dc.LabelResourceName() + "-" + api.CleanupSubdomain(rackName) + "-sts"
 	ns := dc.Namespace
 
 	return types.NamespacedName{

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -641,7 +641,7 @@ func Test_newStatefulSetForCassandraDatacenter_dcNameOverride(t *testing.T) {
 		oplabels.NameLabel:      oplabels.NameLabelValue,
 		oplabels.CreatedByLabel: oplabels.CreatedByLabelValue,
 		oplabels.VersionLabel:   "4.0.1",
-		api.DatacenterLabel:     "MySuperDC",
+		api.DatacenterLabel:     "dc1",
 		api.ClusterLabel:        "piclem",
 		api.RackLabel:           dc.Spec.Racks[0].Name,
 	}
@@ -652,7 +652,7 @@ func Test_newStatefulSetForCassandraDatacenter_dcNameOverride(t *testing.T) {
 		oplabels.NameLabel:      oplabels.NameLabelValue,
 		oplabels.CreatedByLabel: oplabels.CreatedByLabelValue,
 		oplabels.VersionLabel:   "4.0.1",
-		api.DatacenterLabel:     "MySuperDC",
+		api.DatacenterLabel:     "dc1",
 		api.ClusterLabel:        "piclem",
 		api.RackLabel:           dc.Spec.Racks[0].Name,
 		api.CassNodeState:       stateReadyToStart,

--- a/pkg/reconciliation/constructor.go
+++ b/pkg/reconciliation/constructor.go
@@ -31,7 +31,7 @@ func newPodDisruptionBudgetForDatacenter(dc *api.CassandraDatacenter) *policyv1.
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        dc.SanitizedName() + "-pdb",
+			Name:        dc.LabelResourceName() + "-pdb",
 			Namespace:   dc.Namespace,
 			Labels:      labels,
 			Annotations: anns,
@@ -62,8 +62,11 @@ func setOperatorProgressStatus(rc *ReconciliationContext, newState api.ProgressS
 	rc.Datacenter.Status.CassandraOperatorProgress = newState
 
 	if newState == api.ProgressReady {
+		if rc.Datacenter.Status.MetadataVersion < 1 {
+			rc.Datacenter.Status.MetadataVersion = 1
+		}
 		if rc.Datacenter.Status.DatacenterName == nil {
-			rc.Datacenter.Status.DatacenterName = &rc.Datacenter.Spec.DatacenterName
+			rc.Datacenter.Status.DatacenterName = &rc.Datacenter.Name
 		}
 	}
 	if err := rc.Client.Status().Patch(rc.Ctx, rc.Datacenter, patch); err != nil {

--- a/pkg/reconciliation/context.go
+++ b/pkg/reconciliation/context.go
@@ -92,7 +92,7 @@ func CreateReconciliationContext(
 	}
 
 	rc.ReqLogger = rc.ReqLogger.
-		WithValues("datacenterName", dc.SanitizedName()).
+		WithValues("datacenterName", dc.LabelResourceName()).
 		WithValues("clusterName", dc.Spec.ClusterName)
 
 	log.IntoContext(ctx, rc.ReqLogger)
@@ -146,8 +146,8 @@ func (rc *ReconciliationContext) validateDatacenterNameConflicts() []error {
 		errs = append(errs, fmt.Errorf("failed to list CassandraDatacenters in namespace %s: %w", dc.Namespace, err))
 	} else {
 		for _, existingDc := range cassandraDatacenters.Items {
-			if existingDc.SanitizedName() == dc.SanitizedName() && existingDc.Name != dc.Name {
-				errs = append(errs, fmt.Errorf("datacenter name/override %s/%s is already in use by CassandraDatacenter %s/%s", dc.Name, dc.SanitizedName(), existingDc.Name, existingDc.SanitizedName()))
+			if existingDc.LabelResourceName() == dc.LabelResourceName() && existingDc.Name != dc.Name {
+				errs = append(errs, fmt.Errorf("datacenter name/override %s/%s is already in use by CassandraDatacenter %s/%s", dc.Name, dc.LabelResourceName(), existingDc.Name, existingDc.LabelResourceName()))
 			}
 		}
 	}
@@ -164,7 +164,7 @@ func (rc *ReconciliationContext) validateDatacenterNameOverride() []error {
 		return errs
 	} else {
 		if *dc.Status.DatacenterName != dc.Spec.DatacenterName {
-			errs = append(errs, fmt.Errorf("datacenter %s name override '%s' cannot be changed after creation to '%s'.", dc.Name, dc.Spec.DatacenterName, *dc.Status.DatacenterName))
+			errs = append(errs, fmt.Errorf("datacenter %s name override '%s' cannot be changed after creation to '%s'", dc.Name, dc.Spec.DatacenterName, *dc.Status.DatacenterName))
 		}
 	}
 

--- a/pkg/reconciliation/handler_reconcile_test.go
+++ b/pkg/reconciliation/handler_reconcile_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -26,7 +27,7 @@ import (
 
 func TestReconcile(t *testing.T) {
 	var (
-		name            = "cluster-example-cluster"
+		name            = "dc1-example"
 		namespace       = "default"
 		size      int32 = 2
 	)
@@ -74,6 +75,7 @@ func TestReconcile(t *testing.T) {
 		Client:   fakeClient,
 		Scheme:   s,
 		Recorder: record.NewFakeRecorder(100),
+		Log:      ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
 	}
 
 	request := reconcile.Request{
@@ -88,8 +90,8 @@ func TestReconcile(t *testing.T) {
 		t.Fatalf("Reconciliation Failure: (%v)", err)
 	}
 
-	if result != (reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Second}) {
-		t.Error("Reconcile did not return a correct result.")
+	if result != (reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}) {
+		t.Errorf("Reconcile did not return a correct result. (%v)", result)
 	}
 }
 

--- a/pkg/reconciliation/handler_test.go
+++ b/pkg/reconciliation/handler_test.go
@@ -220,7 +220,11 @@ func TestConflictingDcNameOverride(t *testing.T) {
 				Spec: api.CassandraDatacenterSpec{
 					ClusterName:    "cluster1",
 					DatacenterName: "CassandraDatacenter_example",
-				}}}
+				},
+				Status: api.CassandraDatacenterStatus{
+					DatacenterName: ptr.To[string]("CassandraDatacenter_example"),
+				},
+			}}
 		})
 
 	errs := rc.validateDatacenterNameConflicts()

--- a/pkg/reconciliation/reconcile_configsecret.go
+++ b/pkg/reconciliation/reconcile_configsecret.go
@@ -131,7 +131,7 @@ func getConfigFromConfigSecret(dc *api.CassandraDatacenter, secret *corev1.Secre
 
 // getDatacenterConfigSecretName The format is clusterName-dcName-config
 func getDatacenterConfigSecretName(dc *api.CassandraDatacenter) string {
-	return api.CleanupForKubernetes(dc.Spec.ClusterName) + "-" + dc.SanitizedName() + "-config"
+	return api.CleanupForKubernetes(dc.Spec.ClusterName) + "-" + dc.LabelResourceName() + "-config"
 }
 
 // getDatacenterConfigSecret Fetches the secret from the api server or creates a new secret

--- a/pkg/reconciliation/reconcile_datacenter.go
+++ b/pkg/reconciliation/reconcile_datacenter.go
@@ -50,13 +50,12 @@ func (rc *ReconciliationContext) ProcessDeletion() result.ReconcileResult {
 	}
 
 	if _, found := rc.Datacenter.Annotations[api.DecommissionOnDeleteAnnotation]; found {
-		podList, err := rc.listPods(rc.Datacenter.GetDatacenterLabels())
+		dcPods, err := rc.listPods(rc.Datacenter.GetDatacenterLabels())
 		if err != nil {
 			rc.ReqLogger.Error(err, "Failed to list pods, unable to proceed with deletion")
 			return result.Error(err)
 		}
-		dcPods := PodPtrsFromPodList(podList)
-		if len(podList.Items) > 0 {
+		if len(dcPods) > 0 {
 			rc.ReqLogger.V(1).Info("Deletion is being processed by the decommission check")
 			dcs, err := rc.getClusterDatacenters(dcPods)
 			if err != nil {

--- a/pkg/reconciliation/reconcile_fql.go
+++ b/pkg/reconciliation/reconcile_fql.go
@@ -25,7 +25,7 @@ func (rc *ReconciliationContext) CheckFullQueryLogging() result.ReconcileResult 
 		rc.ReqLogger.Error(err, "error listing all pods in the cluster to progress full query logging reconciliation")
 		return result.RequeueSoon(2)
 	}
-	for _, podPtr := range PodPtrsFromPodList(podList) {
+	for _, podPtr := range podList {
 		features, err := rc.NodeMgmtClient.FeatureSet(podPtr)
 		if err != nil {
 			rc.ReqLogger.Error(err, "failed to verify featureset for FQL support")

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2437,9 +2437,9 @@ func (rc *ReconciliationContext) datacenterPods() []*corev1.Pod {
 	dcPods := FilterPodListByLabels(rc.clusterPods, dcSelector)
 
 	if rc.Datacenter.Status.MetadataVersion < 1 && rc.Datacenter.Status.DatacenterName != nil && *rc.Datacenter.Status.DatacenterName == rc.Datacenter.Spec.DatacenterName {
-		rc.ReqLogger.Info("Fetching with the old metadata version also")
+		rc.ReqLogger.Info("Fetching datacenter pods with the old metadata version labels")
 		dcSelector[api.DatacenterLabel] = api.CleanLabelValue(rc.Datacenter.Spec.DatacenterName)
-		rc.dcPods = append(rc.dcPods, FilterPodListByLabels(rc.clusterPods, dcSelector)...)
+		dcPods = append(dcPods, FilterPodListByLabels(rc.clusterPods, dcSelector)...)
 	}
 
 	return dcPods

--- a/scripts/release-helm-chart.sh
+++ b/scripts/release-helm-chart.sh
@@ -6,7 +6,7 @@ if [[ ! $0 == scripts/* ]]; then
 fi
 
 # This script assumes k8ssandra is checked out at ../k8ssandra and is checked out at main
-if [ "$#" -le 1 ]; then
+if [ "$#" -lt 1 ]; then
     echo "Usage: scripts/release-helm-chart.sh version legacy"
     echo "Script assumes you are in the correct branch / tag and that k8ssandra repository"
     echo "has been checked out to ../k8ssandra/. If legacy is set, the script will generate"

--- a/tests/decommission_dc/decommission_dc_suite_test.go
+++ b/tests/decommission_dc/decommission_dc_suite_test.go
@@ -12,22 +12,19 @@ import (
 	"github.com/k8ssandra/cass-operator/tests/kustomize"
 	ginkgo_util "github.com/k8ssandra/cass-operator/tests/util/ginkgo"
 	"github.com/k8ssandra/cass-operator/tests/util/kubectl"
-
-	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 )
 
 var (
-	testName        = "Delete DC and verify it is correctly decommissioned in multi-dc cluster"
-	namespace       = "test-decommission-dc"
-	dc1Name         = "dc1"
-	dc1OverrideName = "My_Super_Dc"
-	dc2Name         = "dc2"
-	dc1Yaml         = "../testdata/default-two-rack-two-node-dc.yaml"
-	dc2Yaml         = "../testdata/default-two-rack-two-node-dc2.yaml"
-	dc1Label        = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dc1OverrideName))
-	dc2Label        = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc2Name)
-	seedLabel       = "cassandra.datastax.com/seed-node=true"
-	taskYaml        = "../testdata/tasks/rebuild_task.yaml"
+	testName  = "Delete DC and verify it is correctly decommissioned in multi-dc cluster"
+	namespace = "test-decommission-dc"
+	dc1Name   = "dc1"
+	dc2Name   = "dc2"
+	dc1Yaml   = "../testdata/default-two-rack-two-node-dc.yaml"
+	dc2Yaml   = "../testdata/default-two-rack-two-node-dc2.yaml"
+	dc1Label  = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc1Name)
+	dc2Label  = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dc2Name)
+	seedLabel = "cassandra.datastax.com/seed-node=true"
+	taskYaml  = "../testdata/tasks/rebuild_task.yaml"
 	// dcLabel   = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)
 	ns = ginkgo_util.NewWrapper(testName, namespace)
 )
@@ -137,7 +134,7 @@ var _ = Describe(testName, func() {
 			// Wait for the task to be completed
 			ns.WaitForCompleteTask("rebuild-dc")
 
-			podNames := ns.GetDatacenterReadyPodNames(dc1OverrideName)
+			podNames := ns.GetDatacenterReadyPodNames(dc1Name)
 			Expect(len(podNames)).To(Equal(2))
 			dcs := findDatacenters(podNames[0])
 
@@ -160,7 +157,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForOutputAndLog(step, k, "[]", 300)
 
 			// Verify nodetool status has only a single Datacenter
-			podNames = ns.GetDatacenterReadyPodNames(dc1OverrideName)
+			podNames = ns.GetDatacenterReadyPodNames(dc1Name)
 
 			if len(podNames) != 2 {
 				// This is to catch why the test sometimes fails on the check (string parsing? or real issue?)

--- a/tests/rolling_restart_with_override/rolling_restart_suite_with_override_test.go
+++ b/tests/rolling_restart_with_override/rolling_restart_suite_with_override_test.go
@@ -20,14 +20,13 @@ import (
 )
 
 var (
-	testName       = "DC override Rolling Restart"
-	namespace      = "test-override-with-rolling-restart"
-	dcName         = "dc1"
-	dcNameOverride = "My_Super_Dc"
-	dcYaml         = "../testdata/default-two-rack-two-node-dc.yaml"
-	taskYaml       = "../testdata/tasks/rolling_restart_override.yaml"
-	dcResource     = fmt.Sprintf("CassandraDatacenter/%s", dcName)
-	ns             = ginkgo_util.NewWrapper(testName, namespace)
+	testName   = "DC override Rolling Restart"
+	namespace  = "test-override-with-rolling-restart"
+	dcName     = "dc1"
+	dcYaml     = "../testdata/default-two-rack-two-node-dc.yaml"
+	taskYaml   = "../testdata/tasks/rolling_restart_override.yaml"
+	dcResource = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	ns         = ginkgo_util.NewWrapper(testName, namespace)
 )
 
 func TestLifecycle(t *testing.T) {
@@ -86,7 +85,7 @@ var _ = Describe(testName, func() {
 			step = "get ready pods"
 			json = "jsonpath={.items[*].status.containerStatuses[0].ready}"
 			k = kubectl.Get("pods").
-				WithLabel(fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dcNameOverride))).
+				WithLabel(fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dcName))).
 				WithFlag("field-selector", "status.phase=Running").
 				FormatOutput(json)
 
@@ -105,7 +104,7 @@ var _ = Describe(testName, func() {
 			// Verify each pod does have the annotation..
 			json := `jsonpath={.items[0].metadata.annotations.control\.k8ssandra\.io/restartedAt}`
 			k = kubectl.Get("pods").
-				WithLabel(fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dcNameOverride))).
+				WithLabel(fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dcName))).
 				WithFlag("field-selector", "status.phase=Running").
 				FormatOutput(json)
 			ns.WaitForOutputPatternAndLog(step, k, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`, 360)

--- a/tests/test_all_the_things/test_all_the_things_suite_test.go
+++ b/tests/test_all_the_things/test_all_the_things_suite_test.go
@@ -22,14 +22,13 @@ import (
 )
 
 var (
-	testName       = "Test all the things"
-	namespace      = "test-test-all-the-things"
-	dcName         = "dc1"
-	dcNameOverride = "My_Super_Dc"
-	dcYaml         = "../testdata/default-two-rack-two-node-dc.yaml"
-	dcResource     = fmt.Sprintf("CassandraDatacenter/%s", dcName)
-	dcLabel        = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dcNameOverride))
-	ns             = ginkgo_util.NewWrapper(testName, namespace)
+	testName   = "Test all the things"
+	namespace  = "test-test-all-the-things"
+	dcName     = "dc1"
+	dcYaml     = "../testdata/default-two-rack-two-node-dc.yaml"
+	dcResource = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	dcLabel    = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", api.CleanLabelValue(dcName))
+	ns         = ginkgo_util.NewWrapper(testName, namespace)
 )
 
 func TestLifecycle(t *testing.T) {
@@ -89,12 +88,12 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
 			ns.WaitForDatacenterConditionWithTimeout(dcName, "ScalingUp", string(corev1.ConditionFalse), 1200)
 			// Ensure that when 'ScaleUp' becomes 'false' that our pods are in fact up and running
-			Expect(len(ns.GetDatacenterReadyPodNames(api.CleanLabelValue(dcNameOverride)))).To(Equal(4))
+			Expect(len(ns.GetDatacenterReadyPodNames(api.CleanLabelValue(dcName)))).To(Equal(4))
 
 			ns.ExpectDoneReconciling(dcName)
 			ns.WaitForDatacenterReady(dcName)
 
-			ns.ExpectDatacenterNameStatusUpdated(dcName, dcNameOverride)
+			ns.ExpectDatacenterNameStatusUpdated(dcName, dcName)
 
 			// Ensure we have a single CassandraTask created which is a cleanup (and it succeeded)
 			ns.WaitForCompletedCassandraTasks(dcName, "cleanup", 1)
@@ -114,7 +113,7 @@ var _ = Describe(testName, func() {
 				FormatOutput(json)
 			ns.WaitForOutputAndLog(step, k, "4", 20)
 
-			ns.WaitForDatacenterToHaveNoPods(api.CleanLabelValue(dcNameOverride))
+			ns.WaitForDatacenterToHaveNoPods(api.CleanLabelValue(dcName))
 
 			step = "resume the dc"
 			json = "{\"spec\": {\"stopped\": false}}"
@@ -133,7 +132,7 @@ var _ = Describe(testName, func() {
 			wg.Add(1)
 			go func() {
 				k = kubectl.Logs("-f").
-					WithLabel(fmt.Sprintf("statefulset.kubernetes.io/pod-name=cluster1-%s-r1-sts-0", api.CleanupForKubernetes(dcNameOverride))).
+					WithLabel(fmt.Sprintf("statefulset.kubernetes.io/pod-name=cluster1-%s-r1-sts-0", dcName)).
 					WithFlag("container", "cassandra")
 				output, err := ns.Output(k)
 				Expect(err).ToNot(HaveOccurred())
@@ -148,7 +147,7 @@ var _ = Describe(testName, func() {
 
 			found, err := regexp.MatchString("node/drain status=200 OK", logOutput)
 			if err == nil && !found {
-				ns.Log(fmt.Sprintf("logOutput, pod: statefulset.kubernetes.io/pod-name=cluster1-%s-r1-sts-0 => %s", api.CleanLabelValue(dcNameOverride), logOutput))
+				ns.Log(fmt.Sprintf("logOutput, pod: statefulset.kubernetes.io/pod-name=cluster1-%s-r1-sts-0 => %s", dcName, logOutput))
 			}
 			if err != nil {
 				ns.Log(fmt.Sprintf("Regexp parsing failed: %v", err))

--- a/tests/testdata/default-three-rack-three-node-dc-4x.yaml
+++ b/tests/testdata/default-three-rack-three-node-dc-4x.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   clusterName: cluster1
   serverType: cassandra
-  serverVersion: 4.1.4
+  datacenterName: My_Super_Dc
+  serverVersion: 4.1.6
   managementApiAuth:
     insecure: {}
   size: 3

--- a/tests/testdata/image_config_parsing.yaml
+++ b/tests/testdata/image_config_parsing.yaml
@@ -18,7 +18,7 @@ defaults:
   # Note, postfix is ignored if repository is not set
   cassandra:
     repository: "k8ssandra/cass-management-api"
-    suffix: "-ubi8"
+    suffix: "-ubi"
   dse:
     repository: "datastax/dse-mgmtapi-6_8"
     suffix: "-ubi8"

--- a/tests/upgrade_operator/upgrade_operator_suite_test.go
+++ b/tests/upgrade_operator/upgrade_operator_suite_test.go
@@ -20,6 +20,7 @@ var (
 	testName   = "Upgrade Operator"
 	namespace  = "test-upgrade-operator"
 	dcName     = "dc1"
+	podId      = "pod/cluster1-my-super-dc-r1-sts-0"
 	dcYaml     = "../testdata/default-three-rack-three-node-dc-4x.yaml"
 	dcResource = fmt.Sprintf("CassandraDatacenter/%s", dcName)
 	dcLabel    = fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)
@@ -83,7 +84,7 @@ var _ = Describe(testName, func() {
 
 			// Get UID of the cluster pod
 			step = "get Cassandra pods UID"
-			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput("jsonpath={.metadata.uid}")
+			k = kubectl.Get(podId).FormatOutput("jsonpath={.metadata.uid}")
 			createdPodUID := ns.OutputAndLog(step, k)
 
 			step = "get name of 1.19.1 operator pod"
@@ -106,7 +107,7 @@ var _ = Describe(testName, func() {
 
 			// Verify Pod hasn't restarted
 			step = "get Cassandra pods UID"
-			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput("jsonpath={.metadata.uid}")
+			k = kubectl.Get(podId).FormatOutput("jsonpath={.metadata.uid}")
 			postUpgradeCassPodUID := ns.OutputAndLog(step, k)
 
 			Expect(createdPodUID).To(Equal(postUpgradeCassPodUID))
@@ -120,7 +121,7 @@ var _ = Describe(testName, func() {
 			// Get current system-logger image
 			// Verify the Pod now has updated system-logger container image
 			step = "get Cassandra pod system-logger"
-			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput("jsonpath={.spec.containers[?(@.name == 'server-system-logger')].image}")
+			k = kubectl.Get(podId).FormatOutput("jsonpath={.spec.containers[?(@.name == 'server-system-logger')].image}")
 			loggerImage := ns.OutputAndLog(step, k)
 			Expect(loggerImage).To(Equal("cr.k8ssandra.io/k8ssandra/system-logger:v1.19.1"))
 
@@ -137,14 +138,14 @@ var _ = Describe(testName, func() {
 
 			// Verify pod has been restarted
 			step = "get Cassandra pods UID"
-			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput("jsonpath={.metadata.uid}")
+			k = kubectl.Get(podId).FormatOutput("jsonpath={.metadata.uid}")
 			postAllowUpgradeUID := ns.OutputAndLog(step, k)
 
 			Expect(postUpgradeCassPodUID).ToNot(Equal(postAllowUpgradeUID))
 
 			// Verify the Pod now has updated system-logger container image
 			step = "get Cassandra pod system-logger"
-			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput("jsonpath={.spec.containers[?(@.name == 'server-system-logger')].image}")
+			k = kubectl.Get(podId).FormatOutput("jsonpath={.spec.containers[?(@.name == 'server-system-logger')].image}")
 			loggerImageNew := ns.OutputAndLog(step, k)
 			Expect(loggerImage).To(Not(Equal(loggerImageNew)))
 

--- a/tests/upgrade_operator/upgrade_operator_suite_test.go
+++ b/tests/upgrade_operator/upgrade_operator_suite_test.go
@@ -80,7 +80,7 @@ var _ = Describe(testName, func() {
 			k := kubectl.ApplyFiles(dcYaml)
 			ns.ExecAndLog(step, k)
 
-			ns.WaitForDatacenterReady(dcName)
+			ns.WaitForDatacenterOperatorProgress(dcName, "Ready", 1800)
 
 			// Get UID of the cluster pod
 			step = "get Cassandra pods UID"

--- a/tests/util/ginkgo/lib.go
+++ b/tests/util/ginkgo/lib.go
@@ -6,7 +6,6 @@ package ginkgo_util
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -424,16 +425,6 @@ func (ns *NsWrapper) Log(step string) {
 	ginkgo.By(step)
 }
 
-func (ns *NsWrapper) getDcNameWithOverride(dcName string) string {
-	json := "jsonpath={.spec.datacenterName}"
-	k := kubectl.Get("CassandraDatacenter", dcName).FormatOutput(json)
-	dcNameOverride := ns.OutputPanic(k)
-	if dcNameOverride == "" {
-		return dcName
-	}
-	return dcNameOverride
-}
-
 func (ns *NsWrapper) WaitForDatacenterReadyWithTimeouts(dcName string, podCountTimeout int, dcReadyTimeout int) {
 	json := "jsonpath={.spec.size}"
 	k := kubectl.Get("CassandraDatacenter", dcName).FormatOutput(json)
@@ -441,7 +432,7 @@ func (ns *NsWrapper) WaitForDatacenterReadyWithTimeouts(dcName string, podCountT
 	size, err := strconv.Atoi(sizeString)
 	Expect(err).ToNot(HaveOccurred())
 
-	ns.WaitForDatacenterReadyPodCountWithTimeout(ns.getDcNameWithOverride(dcName), size, podCountTimeout)
+	ns.WaitForDatacenterReadyPodCountWithTimeout(dcName, size, podCountTimeout)
 	ns.WaitForDatacenterOperatorProgress(dcName, "Ready", dcReadyTimeout)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes datacenter label value to be Kubernetes resource name for Datacenter again. Provides backwards compatibility with older versions using the wrong one.

All the label names are updated after a successful reconcile (this is an existing feature). Tested with Helm installation of 1.22.1 and then updating the cass-operator image only.

**Which issue(s) this PR fixes**:
Fixes #691
Fixes #699 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
