### PR TITLE
Use metav1.SetMetadataAnnotation instead of secret.Annotations[] in ConfigSecret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [FEATURE] [#651](https://github.com/k8ssandra/cass-operator/issues/651) Add tsreload task for DSE deployments and ability to check if sync operation is available on the mgmt-api side
+* [BUGFIX] [#705](https://github.com/k8ssandra/cass-operator/issues/705) Ensure ConfigSecret has annotations map before trying to set a value
 
 ## v1.22.2
 

--- a/pkg/reconciliation/reconcile_configsecret.go
+++ b/pkg/reconciliation/reconcile_configsecret.go
@@ -90,7 +90,7 @@ func (rc *ReconciliationContext) checkDatacenterNameAnnotation(secret *corev1.Se
 	}
 
 	patch := client.MergeFrom(secret.DeepCopy())
-	secret.Annotations[api.DatacenterAnnotation] = rc.Datacenter.Name
+	metav1.SetMetaDataAnnotation(&secret.ObjectMeta, api.DatacenterAnnotation, rc.Datacenter.Name)
 	return rc.Client.Patch(rc.Ctx, secret, patch)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix ConfigSecret to use metav1.SetMetadataAnnotation which is safe against nil references in annotations

**Which issue(s) this PR fixes**:
Fixes #705 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
