### PR TITLE
Preserve existing SecurityContext when ReadOnlyRootFilesystem is set (fixes #708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [FEATURE] [#651](https://github.com/k8ssandra/cass-operator/issues/651) Add tsreload task for DSE deployments and ability to check if sync operation is available on the mgmt-api side
 * [FEATURE] [#701](https://github.com/k8ssandra/cass-operator/issues/701) Allow ReadOnlyRootFilesystem for DSE also with extra mounts to provide support for cass-config-builder setups
+* [BUGFIX] [#708](https://github.com/k8ssandra/cass-operator/issues/708) Preserve existing SecurityContext when ReadOnlyRootFilesystem is set
 
 ## v1.22.2
 

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -706,9 +706,10 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 	}
 
 	if dc.ReadOnlyFs() {
-		cassContainer.SecurityContext = &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To[bool](true),
+		if cassContainer.SecurityContext == nil {
+			cassContainer.SecurityContext = &corev1.SecurityContext{}
 		}
+		cassContainer.SecurityContext.ReadOnlyRootFilesystem = ptr.To[bool](true)
 	}
 
 	// Combine env vars


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #708

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
