### PR TITLE
Drop most 3.11.x tests, run 5.0.1 as default version. 

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -121,7 +121,7 @@ jobs:
         integration_test:
           - cdc_successful
         include:
-          - version: 6.8.49
+          - version: 6.8.51
             serverImage: datastax/dse-mgmtapi-6_8:6.8.51-ubi8 # DSE 6.8.51
             serverType: dse
             integration_test: "cdc_successful"

--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "4.0.13"
+          - "4.0.14"
         integration_test:
           - cdc_successful # OSS only
           - config_fql
@@ -117,12 +117,12 @@ jobs:
     strategy:
       matrix:
         version:
-          - "6.8.49"
+          - "6.8.51"
         integration_test:
           - cdc_successful
         include:
           - version: 6.8.49
-            serverImage: datastax/dse-mgmtapi-6_8:6.8.49-ubi8 # DSE 6.8.49
+            serverImage: datastax/dse-mgmtapi-6_8:6.8.51-ubi8 # DSE 6.8.51
             serverType: dse
             integration_test: "cdc_successful"
       fail-fast: true
@@ -155,7 +155,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "4.1.6"
+          - "5.0.1"
         integration_test:
           # Single worker tests:
           - additional_serviceoptions
@@ -231,18 +231,18 @@ jobs:
     strategy:
       matrix:
         version:
-          - "3.11.17"
-          - "4.0.13"
-          - "4.1.6"
-          - "6.8.50"
+          - "4.0.14"
+          - "4.1.7"
+          - "5.0.1"
+          - "6.8.51"
           - "6.9.2"
           - "1.0.0"
         integration_test:
           - test_all_the_things
           - smoke_test_read_only_fs
         include:
-          - version: 6.8.50
-            serverImage: datastax/dse-mgmtapi-6_8:6.8.50-ubi8 # DSE 6.8.50
+          - version: 6.8.51
+            serverImage: datastax/dse-mgmtapi-6_8:6.8.51-ubi8 # DSE 6.8.51
             serverType: dse
           - version: 6.9.2
             serverImage: datastax/dse-mgmtapi-6_8:6.9.2-ubi # DSE 6.9.2
@@ -251,8 +251,6 @@ jobs:
             serverImage: datastax/hcd:1.0.0-ubi # HCD 1.0.0
             serverType: hcd
         exclude:
-          - version: 3.11.17
-            integration_test: "smoke_test_read_only_fs"
           - version: 4.0.13
             integration_test: "smoke_test_read_only_fs"
       fail-fast: true
@@ -285,7 +283,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "4.1.6"
+          - "5.0.1"
         integration_test:
           - pvc_expansion
       fail-fast: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR is only intended to see what we might need to fix for 5.0.1 support (if anything urgent). Drops 3.11 smoke tests also.

Drop most 3.11 tests (there remains one which doesn't run with 4.1, need to investigate its future)
Update to 4.0.14 and 4.1.7, DSE 6.8 to 6.8.51

**Which issue(s) this PR fixes**:
Fixes #713

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
