### PR TITLE
cassandradatacenter_types: allow 1length rack name

### DIFF
--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -370,7 +370,7 @@ type ServiceConfigAdditions struct {
 // Rack ...
 type Rack struct {
 	// The rack name
-	// +kubebuilder:validation:MinLength=2
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
 	// Deprecated. Use nodeAffinityLabels instead. DeprecatedZone name to pin the rack, using node affinity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: allow more flexibility in the naming of **rack** by allowing names with only 1char.

**Rationale**: on cloud-environments (ex: when using `GoogleCloudSnitch` for my use-case) & using the simple mapping: datacenter=cloudProvider-region & rack=cloudProvider-zone, we want to define just `a`, `b`, `c` as rack name, which is not possible today.
AFAIK, this is mainly impacting when we have some existing clusters (created outside of the operator, with 1long rack names) and we want to migrate to the operator (using the same rack-name for a safe migration)

NB: the reason for this "min 2" is unclear to me, I only found the [commit](https://github.com/k8ssandra/cass-operator/commit/8fb87afb05803c72b4d85cf98e754db367708757#diff-ab3281adb698bb67b0b19d899334944f71dd218c1ecaa027537817b1b2aa803c) that introduced it but no explanation

**Which issue(s) this PR fixes**: no issue created

**Checklist**
- [ ] Changes manually tested => nothing tested 😆 
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
