### PR TITLE
Add feature to allow waiting for cleanup to finish after ScaleUp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [FEATURE] [#651](https://github.com/k8ssandra/cass-operator/issues/651) Add tsreload task for DSE deployments and ability to check if sync operation is available on the mgmt-api side
+* [ENHANCEMENT] [#722](https://github.com/k8ssandra/cass-operator/issues/722) Add back the ability to track cleanup task before marking scale up as done. This is controlled by an annotation cassandra.datastax.com/track-cleanup-tasks
 * [BUGFIX] [#705](https://github.com/k8ssandra/cass-operator/issues/705) Ensure ConfigSecret has annotations map before trying to set a value
 
 ## v1.22.4

--- a/tests/testdata/default-two-rack-two-node-dc.yaml
+++ b/tests/testdata/default-two-rack-two-node-dc.yaml
@@ -6,7 +6,7 @@ spec:
   clusterName: cluster1
   datacenterName: My_Super_Dc
   serverType: cassandra
-  serverVersion: "4.0.10"
+  serverVersion: "4.1.7"
   managementApiAuth:
     insecure: {}
   size: 2


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add new annotation cassandra.datastax.com/track-cleanup-tasks that en…ables tracking cleanup after scale up. This will wait for the cleanup to finish before scale up is marked as completed. Also, add a unit test for the CheckRackLabels()

This code is lifted from 1.14.0, but encapsulated with additional annotation checks.

**Which issue(s) this PR fixes**:
Fixes #722 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
