### PR TITLE
Support override of the http.Transport in the http.Client - CASS-78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] [#718](https://github.com/k8ssandra/cass-operator/issues/718) Update Kubernetes dependencies to 0.31.0 and controller-runtime to 0.19.x, remove controller-config and instead return command line options as the only way to modify controller-runtime options. cass-operator specific configuration will still remain in the OperatorConfig CRD. Removes kube-auth from the /metrics endpoint from our generated configs and instead adds network-policy generation as one optional module for Kustomize.
 * [CHANGE] [#527](https://github.com/k8ssandra/cass-operator/issues/527) Migrate the Kustomize configuration to Kustomize 5 only. Support for using Kustomize 4.x to generate config is no longer supported.
+* [ENHANCEMENT] [#729](https://github.com/k8ssandra/cass-operator/issues/729) Modify NewMgmtClient to support additional transport option for the http.Client
 
 ## v1.23.0
 

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -355,7 +355,7 @@ JobDefinition:
 			if err := r.replacePreProcess(taskConfig); err != nil {
 				return ctrl.Result{}, err
 			}
-			nodeMgmtClient, err := httphelper.NewMgmtClient(ctx, r.Client, dc)
+			nodeMgmtClient, err := httphelper.NewMgmtClient(ctx, r.Client, dc, nil)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -634,7 +634,7 @@ func (r *CassandraTaskReconciler) reconcileEveryPodTask(ctx context.Context, dc 
 		return dcPods[i].Name < dcPods[j].Name
 	})
 
-	nodeMgmtClient, err := httphelper.NewMgmtClient(ctx, r.Client, dc)
+	nodeMgmtClient, err := httphelper.NewMgmtClient(ctx, r.Client, dc, nil)
 	if err != nil {
 		return ctrl.Result{}, 0, 0, "", err
 	}

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -166,10 +166,10 @@ func (f *FeatureSet) Supports(feature Feature) bool {
 	return found
 }
 
-func NewMgmtClient(ctx context.Context, client client.Client, dc *cassdcapi.CassandraDatacenter) (NodeMgmtClient, error) {
+func NewMgmtClient(ctx context.Context, client client.Client, dc *cassdcapi.CassandraDatacenter, customTransport *http.Transport) (NodeMgmtClient, error) {
 	logger := log.FromContext(ctx)
 
-	httpClient, err := BuildManagementApiHttpClient(dc, client, ctx)
+	httpClient, err := BuildManagementApiHttpClient(ctx, client, dc, customTransport)
 	if err != nil {
 		logger.Error(err, "error in BuildManagementApiHttpClient")
 		return NodeMgmtClient{}, err

--- a/pkg/httphelper/security.go
+++ b/pkg/httphelper/security.go
@@ -723,7 +723,7 @@ func (provider *ManualManagementApiSecurityProvider) ValidateConfig(ctx context.
 
 func (provider *ManualManagementApiSecurityProvider) BuildHttpClient(ctx context.Context, client client.Client, transport *http.Transport) (HttpClient, error) {
 	httpClient := &http.Client{Transport: transport}
-	if transport.TLSClientConfig != nil {
+	if transport != nil && transport.TLSClientConfig != nil {
 		return httpClient, nil
 	}
 

--- a/pkg/httphelper/security_test.go
+++ b/pkg/httphelper/security_test.go
@@ -4,13 +4,22 @@
 package httphelper
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
+	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func helperLoadBytes(t *testing.T, name string) []byte {
@@ -97,4 +106,54 @@ func Test_validatePrivateKey(t *testing.T) {
 	assert.Equal(
 		t, 1, len(errs),
 		"Should consider an empty key as an invalid key")
+}
+
+// Create Datacenter with managementAuth set to manual and TLS enabled, test that the client is created with the correct TLS configuration using
+// BuildManagementApiHttpClient method
+func TestBuildMTLSClient(t *testing.T) {
+	require := require.New(t)
+	api.AddToScheme(scheme.Scheme)
+	decode := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer().Decode
+
+	loadYaml := func(path string) (runtime.Object, error) {
+		bytes, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		obj, _, err := decode(bytes, nil, nil)
+		return obj, err
+	}
+
+	clientSecret, err := loadYaml(filepath.Join("..", "..", "tests", "testdata", "mtls-certs-client.yaml"))
+	require.NoError(err)
+
+	serverSecret, err := loadYaml(filepath.Join("..", "..", "tests", "testdata", "mtls-certs-server.yaml"))
+	require.NoError(err)
+
+	dc := &api.CassandraDatacenter{
+		Spec: api.CassandraDatacenterSpec{
+			ClusterName: "test-cluster",
+			ManagementApiAuth: api.ManagementApiAuthConfig{
+				Manual: &api.ManagementApiAuthManualConfig{
+					ClientSecretName: "mgmt-api-client-credentials",
+					ServerSecretName: "mgmt-api-server-credentials",
+				},
+			},
+		},
+	}
+
+	trackObjects := []runtime.Object{
+		clientSecret,
+		serverSecret,
+		dc,
+	}
+
+	client := fake.NewClientBuilder().WithRuntimeObjects(trackObjects...).Build()
+	ctx := context.TODO()
+
+	httpClient, err := BuildManagementApiHttpClient(ctx, client, dc, nil)
+	require.NoError(err)
+
+	tlsConfig := httpClient.(*http.Client).Transport.(*http.Transport).TLSClientConfig
+	require.NotNil(tlsConfig)
 }

--- a/pkg/httphelper/security_test.go
+++ b/pkg/httphelper/security_test.go
@@ -112,7 +112,7 @@ func Test_validatePrivateKey(t *testing.T) {
 // BuildManagementApiHttpClient method
 func TestBuildMTLSClient(t *testing.T) {
 	require := require.New(t)
-	api.AddToScheme(scheme.Scheme)
+	require.NoError(api.AddToScheme(scheme.Scheme))
 	decode := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer().Decode
 
 	loadYaml := func(path string) (runtime.Object, error) {

--- a/pkg/reconciliation/context.go
+++ b/pkg/reconciliation/context.go
@@ -98,7 +98,7 @@ func CreateReconciliationContext(
 	log.IntoContext(ctx, rc.ReqLogger)
 
 	var err error
-	rc.NodeMgmtClient, err = httphelper.NewMgmtClient(rc.Ctx, cli, dc)
+	rc.NodeMgmtClient, err = httphelper.NewMgmtClient(rc.Ctx, cli, dc, nil)
 	if err != nil {
 		rc.ReqLogger.Error(err, "failed to build NodeMgmtClient")
 		return nil, err


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Support override of the http.Transport in the http.Client we use for management client. 

Reorder certain function parameters in the client.go to match best practices in Go and what we use elsewhere in the codebase

**Which issue(s) this PR fixes**:
Fixes #729 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
