### PR TITLE
Always use dc.ObjectMeta.Name-pdb for the PodDisruptionBudget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [CHANGE] [#720](https://github.com/k8ssandra/cass-operator/issues/720) Always use ObjectMeta.Name for the PodDisruptionBudget resource name, not the DatacenterName
 * [FEATURE] [#651](https://github.com/k8ssandra/cass-operator/issues/651) Add tsreload task for DSE deployments and ability to check if sync operation is available on the mgmt-api side
 * [BUGFIX] [#705](https://github.com/k8ssandra/cass-operator/issues/705) Ensure ConfigSecret has annotations map before trying to set a value
 

--- a/pkg/reconciliation/constructor.go
+++ b/pkg/reconciliation/constructor.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Create a PodDisruptionBudget object for the Datacenter
+// newPodDisruptionBudgetForDatacenter creates a PodDisruptionBudget object for the Datacenter
 func newPodDisruptionBudgetForDatacenter(dc *api.CassandraDatacenter) *policyv1.PodDisruptionBudget {
 	minAvailable := intstr.FromInt(int(dc.Spec.Size - 1))
 	labels := dc.GetDatacenterLabels()
@@ -31,7 +31,7 @@ func newPodDisruptionBudgetForDatacenter(dc *api.CassandraDatacenter) *policyv1.
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        dc.LabelResourceName() + "-pdb",
+			Name:        dc.Name + "-pdb",
 			Namespace:   dc.Namespace,
 			Labels:      labels,
 			Annotations: anns,

--- a/pkg/reconciliation/constructor_test.go
+++ b/pkg/reconciliation/constructor_test.go
@@ -1,0 +1,31 @@
+package reconciliation
+
+import (
+	"testing"
+
+	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodDisruptionBudget(t *testing.T) {
+	assert := assert.New(t)
+
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "test",
+		},
+		Spec: api.CassandraDatacenterSpec{
+			DatacenterName: "dc1-override",
+			Size:           3,
+		},
+	}
+
+	// create a PodDisruptionBudget object
+	pdb := newPodDisruptionBudgetForDatacenter(dc)
+	assert.Equal("dc1-pdb", pdb.Name)
+	assert.Equal("test", pdb.Namespace)
+	assert.Equal("dc1", pdb.Spec.Selector.MatchLabels["cassandra.datastax.com/datacenter"])
+	assert.Equal(pdb.Spec.MinAvailable.IntVal, int32(dc.Spec.Size-1))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Uses the ObjectMeta.Name of the CassandraDatacenter for the pdb name prefix instead of the Spec.DatacenterName

**Which issue(s) this PR fixes**:
Fixes #720 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
