### PR TITLE
If PodDeletionTimestamp != nil, return Pod state as being Terminating

### DIFF
--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -19,6 +19,7 @@ const (
 	PodStatusPending         PodStatus = "Pending"
 	PodStatusError           PodStatus = "Error"
 	PodStatusDecommissioning PodStatus = "Decommissioning"
+	PodStatusTerminating     PodStatus = "Terminating"
 )
 
 func getPodStatus(pod *corev1.Pod) PodStatus {
@@ -35,6 +36,9 @@ func getPodStatus(pod *corev1.Pod) PodStatus {
 		return PodStatusError
 	case corev1.PodRunning:
 	default:
+		if pod.GetDeletionTimestamp() != nil {
+			return PodStatusTerminating
+		}
 	}
 
 	allContainersReady := true

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -73,6 +73,20 @@ func TestMetricAdder(t *testing.T) {
 	require.NoError(err)
 	require.Equal("ready", status)
 
+	now := metav1.Now()
+	pods[1].SetDeletionTimestamp(&now)
+	UpdatePodStatusMetric(pods[1])
+	status, err = getCurrentPodStatus("pod1")
+	require.NoError(err)
+	require.Equal("terminating", status)
+
+	// Decommissioning should be prefered to Terminating if we are decommissioning the pod
+	pods[5].SetDeletionTimestamp(&now)
+	UpdatePodStatusMetric(pods[1])
+	status, err = getCurrentPodStatus("pod5")
+	require.NoError(err)
+	require.Equal("decommissioning", status)
+
 	RemoveDatacenterPods("ns", "cluster1", "datacenter1")
 	_, err = getCurrentPodStatus("pod4")
 	require.Error(err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Modify the metrics state of the pods to return Terminating if DeletionTimestamp is not nil and we are not decommissioning it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
