### PR TITLE
CASS-89 If status.datacenterName is set, but empty, do not use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#718](https://github.com/k8ssandra/cass-operator/issues/718) Update Kubernetes dependencies to 0.31.0 and controller-runtime to 0.19.x, remove controller-config and instead return command line options as the only way to modify controller-runtime options. cass-operator specific configuration will still remain in the OperatorConfig CRD. Removes kube-auth from the /metrics endpoint from our generated configs and instead adds network-policy generation as one optional module for Kustomize.
 * [CHANGE] [#527](https://github.com/k8ssandra/cass-operator/issues/527) Migrate the Kustomize configuration to Kustomize 5 only. Support for using Kustomize 4.x to generate config is no longer supported.
 * [ENHANCEMENT] [#729](https://github.com/k8ssandra/cass-operator/issues/729) Modify NewMgmtClient to support additional transport option for the http.Client
+* [BUGFIX] [#751](https://github.com/k8ssandra/cass-operator/issues/751) If datacenterName == "", do not use it as accepted value, threat it the same way as nil value
 
 ## v1.23.0
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -891,7 +891,7 @@ func SplitRacks(nodeCount, rackCount int) []int {
 }
 
 func (dc *CassandraDatacenter) DatacenterNameStatus() bool {
-	return dc.Status.DatacenterName != nil
+	return dc.Status.DatacenterName != nil && *dc.Status.DatacenterName != ""
 }
 
 // LabelResourceName returns a sanitized version of the name returned by DatacenterName()

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -612,6 +612,24 @@ func TestValidSubdomainNames(t *testing.T) {
 	}
 }
 
+func TestEmptyDatacenterStatusName(t *testing.T) {
+	assert := assert.New(t)
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dc1",
+		},
+		Spec: api.CassandraDatacenterSpec{
+			ClusterName: "cluster1",
+		},
+		Status: api.CassandraDatacenterStatus{
+			DatacenterName: ptr.To[string](""),
+		},
+	}
+
+	typedName := NewNamespacedNameForStatefulSet(dc, "r1")
+	assert.Equal("cluster1-dc1-r1-sts", typedName.Name)
+}
+
 func Test_newStatefulSetForCassandraDatacenter_dcNameOverride(t *testing.T) {
 	dc := &api.CassandraDatacenter{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
…eNames

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes datacenterName processing to not accept "" as valid value for resource names.

**Which issue(s) this PR fixes**:
Fixes #751 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
