### PR TITLE
Do not /start pods which are not supposed to be part of the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#527](https://github.com/k8ssandra/cass-operator/issues/527) Migrate the Kustomize configuration to Kustomize 5 only. Support for using Kustomize 4.x to generate config is no longer supported.
 * [ENHANCEMENT] [#729](https://github.com/k8ssandra/cass-operator/issues/729) Modify NewMgmtClient to support additional transport option for the http.Client
 * [ENHANCEMENT] [#737](https://github.com/k8ssandra/cass-operator/issues/737) Before issuing PVC deletion when deleting a datacenter, verify the PVCs that match the labels are not actually used by any pods.
+* [BUGFIX] [#744](https://github.com/k8ssandra/cass-operator/issues/744) If StatefulSet was manually modified outside CassandraDatacenter, do not start such pods as they would need to be decommissioned instantly and could have IP conflict issues when doing so.
 
 ## v1.23.0
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1998,15 +1998,21 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 func (rc *ReconciliationContext) startAllNodes(endpointData httphelper.CassMetadataEndpoints) (bool, error) {
 	rc.ReqLogger.Info("reconcile_racks::startAllNodes")
 
-	for podRankWithinRack := int32(0); ; podRankWithinRack++ {
+	for podRankWithinRack := 0; ; podRankWithinRack++ {
 
 		done := true
-		for _, statefulSet := range rc.statefulSets {
 
-			maxPodRankInThisRack := *statefulSet.Spec.Replicas - 1
+		for idx := range rc.desiredRackInformation {
+			rackInfo := rc.desiredRackInformation[idx]
+			statefulSet := rc.statefulSets[idx]
+			// for _, statefulSet := range rc.statefulSets {
+
+			maxPodRankInThisRack := rackInfo.NodeCount - 1
+
+			// maxPodRankInThisRack := *statefulSet.Spec.Replicas - 1
 			if podRankWithinRack <= maxPodRankInThisRack {
 
-				podName := getStatefulSetPodNameForIdx(statefulSet, podRankWithinRack)
+				podName := getStatefulSetPodNameForIdx(statefulSet, int32(podRankWithinRack))
 				pod := rc.getDCPodByName(podName)
 				notReady, err := rc.startNode(pod, false, endpointData)
 				if notReady || err != nil {

--- a/tests/scale_down_unbalanced_racks/scale_down_unbalanced_racks_suite_test.go
+++ b/tests/scale_down_unbalanced_racks/scale_down_unbalanced_racks_suite_test.go
@@ -73,8 +73,8 @@ var _ = Describe(testName, func() {
 
 			extraPod := "cluster1-dc1-r2-sts-2"
 
-			step = "check that the extra pod is ready"
-			json = "jsonpath={.items[*].status.containerStatuses[0].ready}"
+			step = "check that the extra pod is created"
+			json = "jsonpath={.items[*].status.initContainerStatuses[0].ready}"
 			k = kubectl.Get("pod").
 				WithFlag("field-selector", fmt.Sprintf("metadata.name=%s", extraPod)).
 				FormatOutput(json)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
startAllNodes should only take into account nodes that are part of the desiredRackInformation. That way we don't start phantom nodes that were created by the StatefulSet controller are not supposed to be part of the Cassandra cluster itself.

This is what causes flakes with scale_down_unbalanced test.

**Which issue(s) this PR fixes**:
Fixes #744

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
