### PR TITLE
Skip pods in the startOneNode that can not be started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#729](https://github.com/k8ssandra/cass-operator/issues/729) Modify NewMgmtClient to support additional transport option for the http.Client
 * [ENHANCEMENT] [#737](https://github.com/k8ssandra/cass-operator/issues/737) Before issuing PVC deletion when deleting a datacenter, verify the PVCs that match the labels are not actually used by any pods.
 * [BUGFIX] [#744](https://github.com/k8ssandra/cass-operator/issues/744) If StatefulSet was manually modified outside CassandraDatacenter, do not start such pods as they would need to be decommissioned instantly and could have IP conflict issues when doing so.
+* [BUGFIX] [#696](https://github.com/k8ssandra/cass-operator/issues/696) If the first pod in the rack was not available to be started (such as in Pending state), the startOneNode would keep waiting for it indefinitely.
 
 ## v1.23.2
 

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.16.4
 OPERATOR_SDK_VERSION ?= 1.38.0
 HELM_VERSION ?= 3.17.0
 OPM_VERSION ?= 1.48.0
-GOLINT_VERSION ?= 1.62.2
+GOLINT_VERSION ?= 1.64.8
 
 .PHONY: cert-manager
 cert-manager: ## Install cert-manager to the cluster

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2049,6 +2049,9 @@ RackLoop:
 		for podRankWithinRack := maxPodRankInThisRack; podRankWithinRack >= 0; podRankWithinRack-- {
 			podName := getStatefulSetPodNameForIdx(statefulSet, int32(maxPodRankInThisRack))
 			pod := rc.getDCPodByName(podName)
+			if pod == nil {
+				return false, fmt.Errorf("pod %s not found, most likely statefulset controller has not caught up yet", podName)
+			}
 			if !isServerReady(pod) {
 				if isServerReadyToStart(pod) && isMgmtApiRunning(pod) {
 					notReady, err := rc.startNode(pod, labelSeedBeforeStart, endpointData)
@@ -2057,7 +2060,6 @@ RackLoop:
 					}
 					continue RackLoop // This rack had a node running, so we can skip the rest of the rack's pods
 				}
-				fmt.Printf("Pod %s is not ready to start yet\n", pod.Name)
 			} else {
 				// This rack had a node running, so we can skip the rest of the rack's pods
 				continue RackLoop

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2036,6 +2036,7 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 
 	labelSeedBeforeStart := readySeeds == 0 && !rc.hasAdditionalSeeds()
 
+RackLoop:
 	for idx := range rc.desiredRackInformation {
 		rackInfo := rc.desiredRackInformation[idx]
 		statefulSet := rc.statefulSets[idx]
@@ -2045,11 +2046,24 @@ func (rc *ReconciliationContext) startOneNodePerRack(endpointData httphelper.Cas
 			continue
 		}
 
-		podName := getStatefulSetPodNameForIdx(statefulSet, int32(maxPodRankInThisRack))
-		pod := rc.getDCPodByName(podName)
-		notReady, err := rc.startNode(pod, labelSeedBeforeStart, endpointData)
-		if notReady || err != nil {
-			return notReady, err
+		for podRankWithinRack := maxPodRankInThisRack; podRankWithinRack >= 0; podRankWithinRack-- {
+			podName := getStatefulSetPodNameForIdx(statefulSet, int32(maxPodRankInThisRack))
+			pod := rc.getDCPodByName(podName)
+			if !isServerReady(pod) {
+				if isServerReadyToStart(pod) && isMgmtApiRunning(pod) {
+					notReady, err := rc.startNode(pod, labelSeedBeforeStart, endpointData)
+					if notReady || err != nil {
+						return notReady, err
+					}
+					continue RackLoop // This rack had a node running, so we can skip the rest of the rack's pods
+				}
+				fmt.Printf("Pod %s is not ready to start yet\n", pod.Name)
+			} else {
+				// This rack had a node running, so we can skip the rest of the rack's pods
+				continue RackLoop
+			}
+			// Note, it's possible that the rack didn't have any pods that could be started (they could be in Pending state), but
+			// we don't want to interrupt other racks from starting even if this rack is down (such as zone failure)
 		}
 	}
 	return false, nil

--- a/pkg/reconciliation/testing.go
+++ b/pkg/reconciliation/testing.go
@@ -146,23 +146,6 @@ func CreateMockReconciliationContext(
 	return rc
 }
 
-// Create a fake client that is tracking a service
-func fakeClientWithService(cassandraDatacenter *api.CassandraDatacenter) (*client.WithWatch, *corev1.Service) {
-
-	service := newServiceForCassandraDatacenter(cassandraDatacenter)
-
-	// Objects to keep track of
-
-	trackObjects := []runtime.Object{
-		cassandraDatacenter,
-		service,
-	}
-
-	fakeClient := fake.NewClientBuilder().WithStatusSubresource(cassandraDatacenter, service).WithRuntimeObjects(trackObjects...).Build()
-
-	return &fakeClient, service
-}
-
 func setupTest() (*ReconciliationContext, *corev1.Service, func()) {
 	// Set up verbose logging
 	logger := zap.New()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If the first pod to be started was for some reason in a state that it can't be started (Pending or mgmt-api can't start etc), we would keep trying that one instead of starting any other pods in the rack.

This modifies the behavior to skip pods that can't be started and try instead another one, hopefully a started one. 

**Which issue(s) this PR fixes**:
Fixes #696 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
