### PR TITLE
Allow to skip PVC deletion when deleting the CassandraDatacenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] [#747](https://github.com/k8ssandra/cass-operator/issues/747) Add ScheduledTask to provide a cronjob like functionality to automatically create a CassandraTask on certain intervals.
 * [ENHANCEMENT] [#729](https://github.com/k8ssandra/cass-operator/issues/729) Modify NewMgmtClient to support additional transport option for the http.Client
 * [ENHANCEMENT] [#737](https://github.com/k8ssandra/cass-operator/issues/737) Before issuing PVC deletion when deleting a datacenter, verify the PVCs that match the labels are not actually used by any pods.
+* [ENHANCEMENT] [#664](https://github.com/k8ssandra/cass-operator/issues/664) Allow skipping deletion of PVCs when the CassandraDatacenter is deleted. Set annotation cassandra.datastax.com/delete-pvc: "false" to prevent deletion, default is still to delete.
 * [BUGFIX] [#744](https://github.com/k8ssandra/cass-operator/issues/744) If StatefulSet was manually modified outside CassandraDatacenter, do not start such pods as they would need to be decommissioned instantly and could have IP conflict issues when doing so.
 
 ## v1.23.2

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -78,6 +78,9 @@ const (
 	// task has completed.
 	TrackCleanupTasksAnnotation = "cassandra.datastax.com/track-cleanup-tasks"
 
+	// DeletePVCAnnotation determines if the operator should delete the PVCs when the CassandraDatacenter is deleted. Default is true, set to false to skip deletion.
+	DeletePVCAnnotation = "cassandra.datastax.com/delete-pvc"
+
 	AllowUpdateAlways AllowUpdateType = "always"
 	AllowUpdateOnce   AllowUpdateType = "once"
 

--- a/pkg/reconciliation/reconcile_datacenter.go
+++ b/pkg/reconciliation/reconcile_datacenter.go
@@ -142,6 +142,11 @@ func (rc *ReconciliationContext) deletePVCs() error {
 		"cassandraDatacenterName", rc.Datacenter.Name,
 	)
 
+	if metav1.HasAnnotation(rc.Datacenter.ObjectMeta, api.DeletePVCAnnotation) && rc.Datacenter.Annotations[api.DeletePVCAnnotation] == "false" {
+		logger.Info("Skipping PVC deletion since annotation is set to false")
+		return nil
+	}
+
 	persistentVolumeClaimList, err := rc.listPVCs(rc.Datacenter.GetDatacenterLabels())
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new annotation to the CassandraDatacenter that allows to skip PVC deletion.

**Which issue(s) this PR fixes**:
Fixes #664 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
