### PR TITLE
If all the pods are still in Pending state, return error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [ENHANCEMENT] [#664](https://github.com/k8ssandra/cass-operator/issues/664) Allow skipping deletion of PVCs when the CassandraDatacenter is deleted. Set annotation cassandra.datastax.com/delete-pvc: "false" to prevent deletion, default is still to delete.
+* [BUGFIX] [#798](https://github.com/k8ssandra/cass-operator/issues/798) If all the pods are in the Pending state, we would skip the startOneNodeRack and might start a pod in the startAllRacks phase which would lead to 0 seeds in a new cluster.
 
 ## v1.24.1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If all the nodes are in Pending state, return error from startOneNodePerRack so we don't skip to startAllNodes. 

**Which issue(s) this PR fixes**:
Fixes #798 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
