### PR TITLE
If IsLocal is set, use that information for the HostID setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#807](https://github.com/k8ssandra/cass-operator/issues/807) EndpointSlices are now separated by type (IPv4, IPv6, FQDN). FQDN addresses (DNS) are no longer resolved by the cass-operator, but left to the Kubernetes' own implementation. Use of FQDN is not recommended.
 * [CHANGE] [#803](https://github.com/k8ssandra/cass-operator/issues/803) Modify additional seeds to use discoveryv1.EndpointSlice instead of deprecated corev1.Endpoints and corev1.EndpointSubsets
 * [ENHANCEMENT] [#778](https://github.com/k8ssandra/cass-operator/issues/778) Migrate to golangici-lint 2.x series and use stricter rules.
+* [ENHANCEMENT] [#814](https://github.com/k8ssandra/cass-operator/issues/814) If IS_LOCAL is supported by the mgmt-api, use that information for the HostID Status updates instead of trying to find the IPs.
+* [BUGFIX] [#808](https://github.com/k8ssandra/cass-operator/issues/808) Decommission of the Datacenter might hang on last pod being decommissioned due to a check in startOneNodePerRack for eligible pods to be started
 
 ## v1.25.0
 

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -61,6 +61,7 @@ type EndpointState struct {
 	SSTableVersion         string `json:"SSTABLE_VERSIONS,omitempty"`
 	HostID                 string `json:"HOST_ID,omitempty"`
 	IsAlive                string `json:"IS_ALIVE,omitempty"`
+	IsLocal                string `json:"IS_LOCAL,omitempty"`
 	EndpointIP             string `json:"ENDPOINT_IP,omitempty"`
 	NativeAddressAndPort   string `json:"NATIVE_ADDRESS_AND_PORT,omitempty"`
 	NativeTransportAddress string `json:"NATIVE_TRANSPORT_ADDRESS,omitempty"`

--- a/pkg/reconciliation/reconcile_racks_helpers_test.go
+++ b/pkg/reconciliation/reconcile_racks_helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/k8ssandra/cass-operator/pkg/httphelper"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -63,4 +64,160 @@ func TestPodPrtsFromPodList(t *testing.T) {
 		actualNames = append(actualNames, p.Name)
 	}
 	assert.ElementsMatch(t, expectedNames, actualNames)
+}
+
+func TestFindHostIdFromEndpointsData(t *testing.T) {
+	// Create test data based on the provided example
+	testCases := []struct {
+		name           string
+		endpointsData  []httphelper.EndpointState
+		expectedHostId string
+	}{
+		{
+			name: "Local node is present and NORMAL",
+			endpointsData: []httphelper.EndpointState{
+				{
+					HostID:  "f6878295-4e81-4a42-a5e2-98710987543b",
+					IsLocal: "true",
+					Status:  "NORMAL,4241053645453754050",
+				},
+				{
+					HostID:  "0e620ae9-1ab3-406e-a3cb-d1d25972c90c",
+					IsLocal: "false",
+					Status:  "NORMAL,-3369421087898920741",
+				},
+				{
+					HostID:  "eaf1d782-2fe3-4cae-b648-8235635fd8d2",
+					IsLocal: "false",
+					Status:  "NORMAL,-6989932144271474238",
+				},
+			},
+			expectedHostId: "f6878295-4e81-4a42-a5e2-98710987543b",
+		},
+		{
+			name: "No local node present",
+			endpointsData: []httphelper.EndpointState{
+				{
+					HostID:  "0e620ae9-1ab3-406e-a3cb-d1d25972c90c",
+					IsLocal: "false",
+					Status:  "NORMAL,-3369421087898920741",
+				},
+				{
+					HostID:  "eaf1d782-2fe3-4cae-b648-8235635fd8d2",
+					IsLocal: "false",
+					Status:  "NORMAL,-6989932144271474238",
+				},
+			},
+			expectedHostId: "",
+		},
+		{
+			name: "Local node present but not NORMAL",
+			endpointsData: []httphelper.EndpointState{
+				{
+					HostID:  "f6878295-4e81-4a42-a5e2-98710987543b",
+					IsLocal: "true",
+					Status:  "JOINING,4241053645453754050",
+				},
+				{
+					HostID:  "0e620ae9-1ab3-406e-a3cb-d1d25972c90c",
+					IsLocal: "false",
+					Status:  "NORMAL,-3369421087898920741",
+				},
+			},
+			expectedHostId: "",
+		},
+		{
+			name:           "Empty endpoints data",
+			endpointsData:  []httphelper.EndpointState{},
+			expectedHostId: "",
+		},
+		{
+			name: "Multiple local nodes (abnormal scenario)",
+			endpointsData: []httphelper.EndpointState{
+				{
+					HostID:  "f6878295-4e81-4a42-a5e2-98710987543b",
+					IsLocal: "true",
+					Status:  "NORMAL,4241053645453754050",
+				},
+				{
+					HostID:  "0e620ae9-1ab3-406e-a3cb-d1d25972c90c",
+					IsLocal: "true",
+					Status:  "NORMAL,-3369421087898920741",
+				},
+			},
+			expectedHostId: "f6878295-4e81-4a42-a5e2-98710987543b", // Should return the first one found
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hostId := findHostIdFromEndpointsData(tc.endpointsData)
+			assert.Equal(t, tc.expectedHostId, hostId, "Expected host ID doesn't match")
+		})
+	}
+}
+
+// Test for the findHostIdForIpFromEndpointsData function based on the same example data
+func TestFindHostIdForIpFromEndpointsDataLegacy(t *testing.T) {
+	// Create test data with real IP addresses from the example
+	endpointsData := []httphelper.EndpointState{
+		{
+			HostID:     "f6878295-4e81-4a42-a5e2-98710987543b",
+			IsLocal:    "true",
+			Status:     "NORMAL,4241053645453754050",
+			RpcAddress: "10.116.3.176",
+		},
+		{
+			HostID:     "0e620ae9-1ab3-406e-a3cb-d1d25972c90c",
+			IsLocal:    "false",
+			Status:     "NORMAL,-3369421087898920741",
+			RpcAddress: "10.116.1.226",
+		},
+		{
+			HostID:     "eaf1d782-2fe3-4cae-b648-8235635fd8d2",
+			IsLocal:    "false",
+			Status:     "JOINING,-6989932144271474238", // Changed to JOINING to test non-NORMAL status
+			RpcAddress: "10.116.7.155",
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		ipToSearch     string
+		expectedReady  bool
+		expectedHostId string
+	}{
+		{
+			name:           "Find NORMAL node by IP",
+			ipToSearch:     "10.116.3.176",
+			expectedReady:  true,
+			expectedHostId: "f6878295-4e81-4a42-a5e2-98710987543b",
+		},
+		{
+			name:           "Find non-NORMAL node by IP",
+			ipToSearch:     "10.116.7.155",
+			expectedReady:  false,
+			expectedHostId: "eaf1d782-2fe3-4cae-b648-8235635fd8d2",
+		},
+		{
+			name:           "IP not found",
+			ipToSearch:     "10.116.9.999",
+			expectedReady:  false,
+			expectedHostId: "",
+		},
+		{
+			name:           "IPv6 address (not in sample data)",
+			ipToSearch:     "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			expectedReady:  false,
+			expectedHostId: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ready, hostId := findHostIdForIpFromEndpointsData(endpointsData, tc.ipToSearch)
+			assert.Equal(t, tc.expectedReady, ready, "Expected ready status doesn't match")
+			assert.Equal(t, tc.expectedHostId, hostId, "Expected host ID doesn't match")
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
mgmt-api v0.1.69 and newer support checking EndpointStates with IS_LOCAL. We could use that information for the HostID instead of the IP matching that's required with older versions.

This change is required for certain multi-CNI or otherwise modified broadcast_addresses.

**Which issue(s) this PR fixes**:
Fixes #814 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
