### PR TITLE
Upgrade the cass-config-builder image to the new ubi10 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] [#807](https://github.com/k8ssandra/cass-operator/issues/807) EndpointSlices are now separated by type (IPv4, IPv6, FQDN). FQDN addresses (DNS) are no longer resolved by the cass-operator, but left to the Kubernetes' own implementation. Use of FQDN is not recommended.
 * [CHANGE] [#803](https://github.com/k8ssandra/cass-operator/issues/803) Modify additional seeds to use discoveryv1.EndpointSlice instead of deprecated corev1.Endpoints and corev1.EndpointSubsets
+* [CHANGE] [#811](https://github.com/k8ssandra/cass-operator/issues/811) Upgrade the cass-config-builder image to the new ubi10 version
 * [ENHANCEMENT] [#778](https://github.com/k8ssandra/cass-operator/issues/778) Migrate to golangici-lint 2.x series and use stricter rules.
 * [ENHANCEMENT] [#814](https://github.com/k8ssandra/cass-operator/issues/814) If IS_LOCAL is supported by the mgmt-api, use that information for the HostID Status updates instead of trying to find the IPs.
 * [BUGFIX] [#808](https://github.com/k8ssandra/cass-operator/issues/808) Decommission of the Datacenter might hang on last pod being decommissioned due to a check in startOneNodePerRack for eligible pods to be started

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:v1.25.0"
-  config-builder: "datastax/cass-config-builder:1.0-ubi7"
+  config-builder: "datastax/cass-config-builder:1.0-ubi"
   imageRegistry: "localhost:5000"
 defaults:
   cassandra:

--- a/config/manager/image_config.yaml
+++ b/config/manager/image_config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0-ubi8"
+  config-builder: "datastax/cass-config-builder:1.0-ubi"
   k8ssandra-client: "k8ssandra/k8ssandra-client:v0.7.0"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -413,7 +413,7 @@ func Test_newStatefulSetForCassandraDatacenterWithAdditionalVolumes(t *testing.T
 		assert.Equal(t, "/var/log/cassandra", got.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].MountPath)
 
 		assert.Equal(t, "server-config-init", got.Spec.Template.Spec.InitContainers[1].Name)
-		assert.Equal(t, "localhost:5000/datastax/cass-config-builder:1.0-ubi8", got.Spec.Template.Spec.InitContainers[1].Image)
+		assert.Equal(t, "localhost:5000/datastax/cass-config-builder:1.0-ubi", got.Spec.Template.Spec.InitContainers[1].Image)
 		assert.Equal(t, 1, len(got.Spec.Template.Spec.InitContainers[1].VolumeMounts))
 		assert.Equal(t, "server-config", got.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].Name)
 		assert.Equal(t, "/config", got.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].MountPath)

--- a/tests/testdata/image_config_parsing.yaml
+++ b/tests/testdata/image_config_parsing.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0-ubi8"
+  config-builder: "datastax/cass-config-builder:1.0-ubi"
   k8ssandra-client: "k8ssandra/k8ssandra-client:v0.2.2"
   cassandra:
     "4.0.0": "k8ssandra/cassandra-ubi:latest"

--- a/tests/testdata/image_config_parsing_more_options.yaml
+++ b/tests/testdata/image_config_parsing_more_options.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-config
 images:
   system-logger: "k8ssandra/system-logger:latest"
-  config-builder: "datastax/cass-config-builder:1.0-ubi8"
+  config-builder: "datastax/cass-config-builder:1.0-ubi"
   k8ssandra-client: "k8ssandra/k8ssandra-client:v0.2.2"
   cassandra:
       "4.0.0": "k8ssandra/cassandra-ubi:latest"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This pull request includes changes to update the `cass-config-builder` image across multiple files to switch to the new ubi10 based image, which is now using the generic `-ubi` prefix.
This will reduce the number of detected CVEs.

**Which issue(s) this PR fixes**:
Fixes #811 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
