### PR TITLE
Modify terminated behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [ENHANCEMENT] [#778](https://github.com/k8ssandra/cass-operator/issues/778) Migrate to golangici-lint 2.x series and use stricter rules.
 * [ENHANCEMENT] [#814](https://github.com/k8ssandra/cass-operator/issues/814) If IS_LOCAL is supported by the mgmt-api, use that information for the HostID Status updates instead of trying to find the IPs.
 * [BUGFIX] [#808](https://github.com/k8ssandra/cass-operator/issues/808) Decommission of the Datacenter might hang on last pod being decommissioned due to a check in startOneNodePerRack for eligible pods to be started
+* [BUGFIX] [#806](https://github.com/k8ssandra/cass-operator/issues/806) If cassandra container crashes during Starting phase we could get stuck in findStartingNodes for a long period of time. Modify the behavior to kill these pods instantly.
+* [BUGFIX] [#816](https://github.com/k8ssandra/cass-operator/issues/816) If pod terminated, we would not usually be allowed to override rack settings because the deleteStuckNodes would clean up the error code before conditions to do forced upgrade were met.
 
 ## v1.25.0
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -208,7 +208,7 @@ func (rc *ReconciliationContext) failureModeDetection() (bool, string) {
 						return true, rackName
 					}
 				}
-				if containerStatus.RestartCount > 2 {
+				if containerStatus.RestartCount > 0 {
 					if containerStatus.State.Terminated != nil {
 						if containerStatus.State.Terminated.ExitCode != 0 {
 							rc.ReqLogger.Info("Failing container state for pod", "pod", pod.Name, "exitCode", containerStatus.State.Terminated.ExitCode)
@@ -229,7 +229,7 @@ func (rc *ReconciliationContext) failureModeDetection() (bool, string) {
 						return true, rackName
 					}
 				}
-				if containerStatus.RestartCount > 2 {
+				if containerStatus.RestartCount > 0 {
 					if containerStatus.State.Terminated != nil {
 						if containerStatus.State.Terminated.ExitCode != 0 {
 							rc.ReqLogger.Info("Failing initcontainer state for pod", "pod", pod.Name, "exitCode", containerStatus.State.Terminated.ExitCode)
@@ -1333,11 +1333,11 @@ func hasBeenXMinutesSinceReady(x int, pod *corev1.Pod) bool {
 	return false
 }
 
-func hasBeenXMinutesSinceTerminated(x int, pod *corev1.Pod) bool {
+func hasCassandraContainerTerminated(pod *corev1.Pod) bool {
 	if status := getCassContainerStatus(pod); status != nil {
 		lastState := status.LastTerminationState
 		if lastState.Terminated != nil {
-			return hasBeenXMinutes(x, lastState.Terminated.FinishedAt.Time)
+			return true
 		}
 	}
 	return false
@@ -1358,7 +1358,7 @@ func isNodeStuckAfterTerminating(pod *corev1.Pod) bool {
 		return false
 	}
 
-	return hasBeenXMinutesSinceTerminated(10, pod)
+	return hasCassandraContainerTerminated(pod)
 }
 
 func isNodeStuckAfterLosingReadiness(pod *corev1.Pod) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes our handling of container State.Terminated. If we notice it in cassandra container, clean up the Pod instantly because there's no automatic recover. Also, allow forceUpgrade of racks happen if there are terminated containers.

**Which issue(s) this PR fixes**:
Fixes #816
Fixes #806 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
