### PR TITLE
Remove certain RBAC requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [CHANGE] [#822](https://github.com/k8ssandra/cass-operator/issues/822) Remove certain RBAC rights from our Role/ClusterRole that are no longer necessary for the operations in cass-operator
 * [FEATURE] [#830](https://github.com/k8ssandra/cass-operator/issues/830) Implement new ImageConfig structure where all the parts of the configured images are split to individual components to allow simpler configuration. This allows to override a single value only (such as registry for single image) in the Helm charts. The configuration is moved to a separate ConfigMap with `k8ssandra.io/config: image` label and this same ImageConfig is then used in the k8ssandra-operator to ensure all the components are configured from a single place.
 * [ENHANCEMENT] [#827](https://github.com/k8ssandra/cass-operator/issues/827) Add a new watch handler for caches in the startup of controller-runtime. If the caches have failures, we should exit the operator and let it restart. This would alert the user that the operator has issues instead of simply logging these errors.
 

--- a/config/imageconfig/image_config.yaml
+++ b/config/imageconfig/image_config.yaml
@@ -24,7 +24,7 @@ defaults:
   pullPolicy: IfNotPresent
   # -- pullSecrets allow configuring the secret to use for pulling images from private registries.
   # pullSecrets:
-  #   - name: my-secret-pull-registry
+  #   - my-secret-pull-registry
 # -- overrides will apply to all images discarding the settings in defaults or what individual images might have.
 # overrides:
   # -- registry to pull from

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -55,9 +55,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - daemonsets
-  - deployments
-  - replicasets
   - statefulsets
   verbs:
   - create
@@ -67,12 +64,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
 - apiGroups:
   - cassandra.datastax.com
   resources:

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -57,9 +57,9 @@ var (
 //+kubebuilder:rbac:groups=cassandra.datastax.com,namespace=cass-operator,resources=cassandradatacenters/finalizers,verbs=update;delete
 
 // Kubernetes core
-// +kubebuilder:rbac:groups=apps,namespace=cass-operator,resources=statefulsets;replicasets;deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,namespace=cass-operator,resources=deployments/finalizers,verbs=update
-// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods;endpoints;endpoints/restricted;services;configmaps;secrets;persistentvolumeclaims;events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,namespace=cass-operator,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods;endpoints;endpoints/restricted;services;configmaps;secrets;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=events,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
@@ -240,13 +240,6 @@ func (r *CassandraDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error
 		}
 		return requests
 	}
-
-	/*
-		// Watch ReplicaSets and enqueue ReplicaSet object key
-		if err := c.Watch(source.Kind(mgr.GetCache(), &appsv1.ReplicaSet{}), &handler.EnqueueRequestForObject{}); err != nil {
-			entryLog.Error(err, "unable to watch ReplicaSets")
-			os.Exit(1)
-		}	*/
 
 	c = c.Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toRequests))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates the RBAC rules to remove certain rights that are no longer necessary for cass-operator.

What's missing however is proper envtests using RBAC restrictions so we could easily test if all operations are really working. We will rely on e2e tests for now.

**Which issue(s) this PR fixes**:
Fixes #822 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
