### PR TITLE
Add new error handler for cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#827](https://github.com/k8ssandra/cass-operator/issues/827) Add a new watch handler for caches in the startup of controller-runtime. If the caches have failures, we should exit the operator and let it restart. This would alert the user that the operator has issues instead of simply logging these errors.
+
 ## v1.26.0
 
 * [CHANGE] [#807](https://github.com/k8ssandra/cass-operator/issues/807) EndpointSlices are now separated by type (IPv4, IPv6, FQDN). FQDN addresses (DNS) are no longer resolved by the cass-operator, but left to the Kubernetes' own implementation. Use of FQDN is not recommended.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Introduces a watch handler for errors that could happen in the startup of Caches. This is to potentially catch issues with incorrect RBAC rights which could cause incorrect handling in reconciliation if we can only access a subset of resources.

No unit tests sadly as we don't have the ability to test main.go in other ways than e2e tests. Envtests have their own initialization code.

**Which issue(s) this PR fixes**:
Fixes #827

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
