### PR TITLE
Add additionalVolumes to the initContainers and a POD_NAME envVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] [#830](https://github.com/k8ssandra/cass-operator/issues/830) Implement new ImageConfig structure where all the parts of the configured images are split to individual components to allow simpler configuration. This allows to override a single value only (such as registry for single image) in the Helm charts. The configuration is moved to a separate ConfigMap with `k8ssandra.io/config: image` label and this same ImageConfig is then used in the k8ssandra-operator to ensure all the components are configured from a single place.
 * [ENHANCEMENT] [#827](https://github.com/k8ssandra/cass-operator/issues/827) Add a new watch handler for caches in the startup of controller-runtime. If the caches have failures, we should exit the operator and let it restart. This would alert the user that the operator has issues instead of simply logging these errors.
 * [ENHANCEMENT] [#831](https://github.com/k8ssandra/cass-operator/issues/831) Add support for Jobs argument in the gargabecollect command for CassandraTask
+* [ENHANCEMENT] [#833](https://github.com/k8ssandra/cass-operator/issues/833) AdditionalVolumes are now mounted to the initContainers also.
 
 ## v1.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] [#830](https://github.com/k8ssandra/cass-operator/issues/830) Implement new ImageConfig structure where all the parts of the configured images are split to individual components to allow simpler configuration. This allows to override a single value only (such as registry for single image) in the Helm charts. The configuration is moved to a separate ConfigMap with `k8ssandra.io/config: image` label and this same ImageConfig is then used in the k8ssandra-operator to ensure all the components are configured from a single place.
 * [ENHANCEMENT] [#827](https://github.com/k8ssandra/cass-operator/issues/827) Add a new watch handler for caches in the startup of controller-runtime. If the caches have failures, we should exit the operator and let it restart. This would alert the user that the operator has issues instead of simply logging these errors.
 * [ENHANCEMENT] [#831](https://github.com/k8ssandra/cass-operator/issues/831) Add support for Jobs argument in the gargabecollect command for CassandraTask
-* [ENHANCEMENT] [#833](https://github.com/k8ssandra/cass-operator/issues/833) AdditionalVolumes are now mounted to the initContainers also.
+* [ENHANCEMENT] [#833](https://github.com/k8ssandra/cass-operator/issues/833) AdditionalVolumes with VolumeSource (Secret, ConfigMap) are now mounted to the server-config-init initContainer also.
 
 ## v1.26.0
 

--- a/apis/config/v1beta2/imageconfig_types.go
+++ b/apis/config/v1beta2/imageconfig_types.go
@@ -32,7 +32,6 @@ type Image struct {
 	Name string `json:"name,omitempty"`
 
 	// The image tag to use. Defaults to "latest".
-	// +kubebuilder:default="latest"
 	// +optional
 	Tag string `json:"tag,omitempty"`
 

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -477,6 +477,15 @@ func buildInitContainers(dc *api.CassandraDatacenter, rackName string, baseTempl
 
 	configMounts := []corev1.VolumeMount{serverCfgMount}
 
+	for _, vol := range dc.Spec.StorageConfig.AdditionalVolumes {
+		if vol.VolumeSource != nil {
+			configMounts = append(configMounts, corev1.VolumeMount{
+				Name:      vol.Name,
+				MountPath: vol.MountPath,
+			})
+		}
+	}
+
 	if dc.UseClientImage() {
 		configBaseMount := corev1.VolumeMount{
 			Name:      "server-config-base",
@@ -560,6 +569,7 @@ func buildInitContainers(dc *api.CassandraDatacenter, rackName string, baseTempl
 		{Name: "RACK_NAME", Value: rackName},
 		{Name: "PRODUCT_VERSION", Value: serverVersion},
 		{Name: "PRODUCT_NAME", Value: dc.Spec.ServerType},
+		{Name: "POD_NAME", ValueFrom: selectorFromFieldPath("metadata.name")},
 	}
 
 	envDefaults = append(envDefaults, configEnvVar...)

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -335,6 +335,7 @@ func TestCassandraDatacenter_buildContainers_use_cassandra_settings(t *testing.T
 func TestServerConfigInitContainerEnvVars(t *testing.T) {
 	rack := "rack1"
 	podIPEnvVar := corev1.EnvVar{Name: "POD_IP", ValueFrom: selectorFromFieldPath("status.podIP")}
+	podNameEnvVar := corev1.EnvVar{Name: "POD_NAME", ValueFrom: selectorFromFieldPath("metadata.name")}
 	hostIPEnvVar := corev1.EnvVar{Name: "HOST_IP", ValueFrom: selectorFromFieldPath("status.hostIP")}
 
 	tests := []struct {
@@ -366,6 +367,7 @@ func TestServerConfigInitContainerEnvVars(t *testing.T) {
 					Name:  "PRODUCT_NAME",
 					Value: "cassandra",
 				},
+				podNameEnvVar,
 			},
 		},
 		{
@@ -393,6 +395,7 @@ func TestServerConfigInitContainerEnvVars(t *testing.T) {
 					Name:  "PRODUCT_NAME",
 					Value: "cassandra",
 				},
+				podNameEnvVar,
 			},
 		},
 	}

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -310,6 +310,14 @@ func TestStatefulSetWithAdditionalVolumesFromSource(t *testing.T) {
 	assert.Equal("tmp", cassandraVolumeMounts[3].Name)
 	assert.Equal("server-data", cassandraVolumeMounts[4].Name)
 	assert.Equal("server-config", cassandraVolumeMounts[5].Name)
+
+	serverConfigInitContainer := findContainer(sts.Spec.Template.Spec.InitContainers, ServerConfigContainerName)
+	assert.NotNil(serverConfigInitContainer)
+
+	serverConfigInitVolumeMounts := serverConfigInitContainer.VolumeMounts
+	assert.Equal(2, len(serverConfigInitVolumeMounts))
+	assert.Equal("server-config", serverConfigInitVolumeMounts[0].Name)
+	assert.Equal("metrics-config", serverConfigInitVolumeMounts[1].Name)
 }
 
 func Test_newStatefulSetForCassandraDatacenterWithAdditionalVolumes(t *testing.T) {

--- a/tests/config_change/config_change_suite_test.go
+++ b/tests/config_change/config_change_suite_test.go
@@ -84,7 +84,7 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterCondition(dcName, "Updating", string(corev1.ConditionFalse))
 
 			step = "checking that the init container got the updated config roles_validity=256000ms"
-			json = "jsonpath={.spec.initContainers[1].env[6].value}"
+			json = "jsonpath={.spec.initContainers[1].env[7].value}"
 			k = kubectl.Get(fmt.Sprintf("pod/%s-%s-r1-sts-0", clusterName, dcName)).
 				FormatOutput(json)
 			ns.WaitForOutputContainsAndLog(step, k, "\"roles_validity\":\"256000ms\"", 30)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Modifies the server-config-init initContainer to include any additionalVolumes with VolumeSource (so not PVCs) and a POD_NAME envVar.

**Which issue(s) this PR fixes**:
Fixes #833 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
