### PR TITLE
Add ability to allow disabling PodDisruptionBudget creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [CHANGE] [#822](https://github.com/k8ssandra/cass-operator/issues/822) Remove certain RBAC rights from our Role/ClusterRole that are no longer necessary for the operations in cass-operator
 * [FEATURE] [#830](https://github.com/k8ssandra/cass-operator/issues/830) Implement new ImageConfig structure where all the parts of the configured images are split to individual components to allow simpler configuration. This allows to override a single value only (such as registry for single image) in the Helm charts. The configuration is moved to a separate ConfigMap with `k8ssandra.io/config: image` label and this same ImageConfig is then used in the k8ssandra-operator to ensure all the components are configured from a single place.
+* [FEATURE] [#824](https://github.com/k8ssandra/cass-operator/issues/824) Setting `cassandra.datastax.com/disable-pdb-creation: true` to the CassandraDatacenter will now disable creation of PodDisruptionBudget for the datacenter
 * [ENHANCEMENT] [#827](https://github.com/k8ssandra/cass-operator/issues/827) Add a new watch handler for caches in the startup of controller-runtime. If the caches have failures, we should exit the operator and let it restart. This would alert the user that the operator has issues instead of simply logging these errors.
 
 ## v1.26.0

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -81,6 +81,9 @@ const (
 	// DeletePVCAnnotation determines if the operator should delete the PVCs when the CassandraDatacenter is deleted. Default is true, set to false to skip deletion.
 	DeletePVCAnnotation = "cassandra.datastax.com/delete-pvc"
 
+	// Allow disabling the creation of PodDisruptionBudget for the datacenter
+	DisablePodDisruptionBudgetAnnotation = "cassandra.datastax.com/disable-pdb-creation"
+
 	AllowUpdateAlways AllowUpdateType = "always"
 	AllowUpdateOnce   AllowUpdateType = "once"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new annotation that prevents creation of default PDB

**Which issue(s) this PR fixes**:
Fixes #824 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
