### PR TITLE
Restart entire rack at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container
+* [ENHANCEMENT] [#841](https://github.com/k8ssandra/cass-operator/issues/841) Add the ability for the rolling restart to restart an entire rack at once. This speeds up the rolling restart process in a cluster that has large amount of nodes in a single rack.
 
 ## v1.28.1
 
@@ -23,7 +24,6 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] [#838](https://github.com/k8ssandra/cass-operator/issues/838) If cass-operator is not deployed in clusterScoped mode, disable features that require such rights and continue functioning correctly otherwise. 
 * [ENHANCEMENT] [#848](https://github.com/k8ssandra/cass-operator/issues/848) Detect more error cases in the PVC resizing operation and notify the user with an event and a change in the Datacenter status.
 * [ENHANCEMENT] [#846](https://github.com/k8ssandra/cass-operator/issues/846) Detect the usage of a digest in the ImageConfig tag field and correctly deploy it without requiring a separate tag to be set. In previous versions, setting tag to for example: `v1.0@sha256:hash` would be required to deploy with digest only.
-* [ENHANCEMENT] [#841](https://github.com/k8ssandra/cass-operator/issues/841) Add the ability for the rolling restart to restart an entire rack at once. This speeds up the rolling restart process in a cluster that has large amount of nodes in a single rack.
 
 ## v1.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [FEATURE] [#838](https://github.com/k8ssandra/cass-operator/issues/838) If cass-operator is not deployed in clusterScoped mode, disable features that require such rights and continue functioning correctly otherwise. 
 * [ENHANCEMENT] [#848](https://github.com/k8ssandra/cass-operator/issues/848) Detect more error cases in the PVC resizing operation and notify the user with an event and a change in the Datacenter status.
 * [ENHANCEMENT] [#846](https://github.com/k8ssandra/cass-operator/issues/846) Detect the usage of a digest in the ImageConfig tag field and correctly deploy it without requiring a separate tag to be set. In previous versions, setting tag to for example: `v1.0@sha256:hash` would be required to deploy with digest only.
+* [ENHANCEMENT] [#841](https://github.com/k8ssandra/cass-operator/issues/841) Add the ability for the rolling restart to restart an entire rack at once. This speeds up the rolling restart process in a cluster that has large amount of nodes in a single rack.
 
 ## v1.27.1
 

--- a/apis/control/v1alpha1/cassandratask_types.go
+++ b/apis/control/v1alpha1/cassandratask_types.go
@@ -118,6 +118,9 @@ type JobArguments struct {
 	// Fast modifies the behavior of rolling restart to restart multiple nodes (or entire rack) at the same time.
 	// If the cluster is degraded in availability, the fast path isn't used
 	Fast bool `json:"fast,omitempty"`
+
+	// Force is used to force the execution of a command even if the operator thinks it is unsafe
+	Force bool `json:"force,omitempty"`
 }
 
 // CassandraTaskStatus defines the observed state of CassandraJob

--- a/apis/control/v1alpha1/cassandratask_types.go
+++ b/apis/control/v1alpha1/cassandratask_types.go
@@ -114,6 +114,10 @@ type JobArguments struct {
 	// command, ignored otherwise. Pods referenced in this map must exist; any existing pod not
 	// referenced in this map will not be moved.
 	NewTokens map[string]string `json:"new_tokens,omitempty"`
+
+	// Fast modifies the behavior of rolling restart to restart multiple nodes (or entire rack) at the same time.
+	// If the cluster is degraded in availability, the fast path isn't used
+	Fast bool `json:"fast,omitempty"`
 }
 
 // CassandraTaskStatus defines the observed state of CassandraJob

--- a/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
@@ -122,6 +122,11 @@ spec:
                       properties:
                         end_token:
                           type: string
+                        fast:
+                          description: |-
+                            Fast modifies the behavior of rolling restart to restart multiple nodes (or entire rack) at the same time.
+                            If the cluster is degraded in availability, the fast path isn't used
+                          type: boolean
                         jobs:
                           type: integer
                         keyspace_name:

--- a/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
@@ -127,6 +127,10 @@ spec:
                             Fast modifies the behavior of rolling restart to restart multiple nodes (or entire rack) at the same time.
                             If the cluster is degraded in availability, the fast path isn't used
                           type: boolean
+                        force:
+                          description: Force is used to force the execution of a command
+                            even if the operator thinks it is unsafe
+                          type: boolean
                         jobs:
                           type: integer
                         keyspace_name:

--- a/config/crd/bases/control.k8ssandra.io_scheduledtasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_scheduledtasks.yaml
@@ -111,6 +111,10 @@ spec:
                                 Fast modifies the behavior of rolling restart to restart multiple nodes (or entire rack) at the same time.
                                 If the cluster is degraded in availability, the fast path isn't used
                               type: boolean
+                            force:
+                              description: Force is used to force the execution of
+                                a command even if the operator thinks it is unsafe
+                              type: boolean
                             jobs:
                               type: integer
                             keyspace_name:

--- a/config/crd/bases/control.k8ssandra.io_scheduledtasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_scheduledtasks.yaml
@@ -106,6 +106,11 @@ spec:
                           properties:
                             end_token:
                               type: string
+                            fast:
+                              description: |-
+                                Fast modifies the behavior of rolling restart to restart multiple nodes (or entire rack) at the same time.
+                                If the cluster is degraded in availability, the fast path isn't used
+                              type: boolean
                             jobs:
                               type: integer
                             keyspace_name:

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -33,6 +33,7 @@ nodes:
 - role: worker
 - role: worker
 - role: worker
+- role: worker
 EOF
 
 # 3. Add the registry config to the nodes

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -470,6 +470,14 @@ func (r *CassandraTaskReconciler) getDatacenterStatefulSets(ctx context.Context,
 	return sts.Items, nil
 }
 
+func (r *CassandraTaskReconciler) getStatefulSetPods(ctx context.Context, dc *cassapi.CassandraDatacenter, st *appsv1.StatefulSet) ([]corev1.Pod, error) {
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, client.InNamespace(dc.Namespace), client.MatchingLabels(st.Spec.Selector.MatchLabels)); err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
 // cleanupJobAnnotations removes the job annotations from the pod once it has finished
 func (r *CassandraTaskReconciler) cleanupJobAnnotations(ctx context.Context, dc *cassapi.CassandraDatacenter, taskId string) error {
 	logger := log.FromContext(ctx)

--- a/internal/controllers/control/cassandratask_controller_test.go
+++ b/internal/controllers/control/cassandratask_controller_test.go
@@ -809,8 +809,8 @@ var _ = Describe("CassandraTask controller tests", func() {
 				taskKey, task := buildTask(api.CommandRestart, testNamespaceName)
 				Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
-				Eventually(func() bool {
-					Expect(k8sClient.List(context.TODO(), &stsAll, client.MatchingLabels(map[string]string{cassdcapi.DatacenterLabel: testDc.Name}), client.InNamespace(testNamespaceName))).To(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.List(context.TODO(), &stsAll, client.MatchingLabels(map[string]string{cassdcapi.DatacenterLabel: testDc.Name}), client.InNamespace(testNamespaceName))).To(Succeed())
 
 					inflight := 0
 
@@ -822,27 +822,24 @@ var _ = Describe("CassandraTask controller tests", func() {
 						}
 					}
 
-					Expect(inflight).To(BeNumerically("<=", 1))
+					g.Expect(inflight).To(BeNumerically("<=", 1))
 
 					for _, sts := range stsAll.Items {
-						if _, found := sts.Spec.Template.ObjectMeta.Annotations[api.RestartedAtAnnotation]; found {
-							// Imitate statefulset_controller
-							if sts.Status.UpdateRevision != "1" {
-								sts.Status.UpdatedReplicas = sts.Status.Replicas
-								sts.Status.ReadyReplicas = sts.Status.Replicas
-								sts.Status.CurrentReplicas = sts.Status.Replicas
-								sts.Status.UpdateRevision = "1"
-								sts.Status.CurrentRevision = sts.Status.UpdateRevision
-								sts.Status.ObservedGeneration = sts.GetObjectMeta().GetGeneration()
+						_, found := sts.Spec.Template.ObjectMeta.Annotations[api.RestartedAtAnnotation]
+						g.Expect(found).To(BeTrue())
+						// Imitate statefulset_controller
+						if sts.Status.UpdateRevision != "1" {
+							sts.Status.UpdatedReplicas = sts.Status.Replicas
+							sts.Status.ReadyReplicas = sts.Status.Replicas
+							sts.Status.CurrentReplicas = sts.Status.Replicas
+							sts.Status.UpdateRevision = "1"
+							sts.Status.CurrentRevision = sts.Status.UpdateRevision
+							sts.Status.ObservedGeneration = sts.GetObjectMeta().GetGeneration()
 
-								Expect(k8sClient.Status().Update(context.TODO(), &sts)).Should(Succeed())
-							}
-						} else if !found {
-							return false
+							g.Expect(k8sClient.Status().Update(context.TODO(), &sts)).Should(Succeed())
 						}
 					}
-					return true
-				}, "5s", "50ms").Should(BeTrue())
+				}, "5s", "50ms").Should(Succeed())
 
 				_ = waitForTaskCompletion(taskKey)
 			})
@@ -859,8 +856,8 @@ var _ = Describe("CassandraTask controller tests", func() {
 				task.Spec.Jobs[0].Arguments.Fast = true
 				Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
-				Eventually(func() bool {
-					Expect(k8sClient.List(context.TODO(), &stsAll, client.MatchingLabels(map[string]string{cassdcapi.DatacenterLabel: testDc.Name}), client.InNamespace(testNamespaceName))).To(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.List(context.TODO(), &stsAll, client.MatchingLabels(map[string]string{cassdcapi.DatacenterLabel: testDc.Name}), client.InNamespace(testNamespaceName))).To(Succeed())
 
 					inflight := 0
 
@@ -872,45 +869,42 @@ var _ = Describe("CassandraTask controller tests", func() {
 						}
 					}
 
-					Expect(inflight).To(BeNumerically("<=", 1))
+					g.Expect(inflight).To(BeNumerically("<=", 1))
 
 					for _, sts := range stsAll.Items {
-						if _, found := sts.Spec.Template.ObjectMeta.Annotations[api.RestartedAtAnnotation]; found {
-							// Imitate statefulset_controller
-							stsPods := &corev1.PodList{}
-							Expect(k8sClient.List(context.TODO(), stsPods, client.InNamespace(testNamespaceName), client.MatchingLabels(sts.Spec.Selector.MatchLabels))).To(Succeed())
-							if len(stsPods.Items) == 0 {
-								// Recreate the pods
-								for i := 0; i < int(*sts.Spec.Replicas); i++ {
-									createPod(testNamespaceName, sts.Spec.Template.Labels[cassdcapi.ClusterLabel], sts.Spec.Template.Labels[cassdcapi.DatacenterLabel], sts.Spec.Template.Labels[cassdcapi.RackLabel], i)
-									// Read the Pod, update it with the annotation, and update it
-									pod := &corev1.Pod{}
-									podKey := types.NamespacedName{
-										Name:      fmt.Sprintf("%s-%d", sts.Name, i),
-										Namespace: testNamespaceName,
-									}
-									Expect(k8sClient.Get(context.TODO(), podKey, pod)).To(Succeed())
-									metav1.SetMetaDataAnnotation(&pod.ObjectMeta, api.RestartedAtAnnotation, time.Now().Format(time.RFC3339))
-									Expect(k8sClient.Update(context.TODO(), pod)).To(Succeed())
+						_, found := sts.Spec.Template.ObjectMeta.Annotations[api.RestartedAtAnnotation]
+						g.Expect(found).To(BeTrue())
+						// Imitate statefulset_controller
+						stsPods := &corev1.PodList{}
+						g.Expect(k8sClient.List(context.TODO(), stsPods, client.InNamespace(testNamespaceName), client.MatchingLabels(sts.Spec.Selector.MatchLabels))).To(Succeed())
+						if len(stsPods.Items) == 0 {
+							// Recreate the pods
+							for i := 0; i < int(*sts.Spec.Replicas); i++ {
+								createPod(testNamespaceName, sts.Spec.Template.Labels[cassdcapi.ClusterLabel], sts.Spec.Template.Labels[cassdcapi.DatacenterLabel], sts.Spec.Template.Labels[cassdcapi.RackLabel], i)
+								// Read the Pod, update it with the annotation, and update it
+								pod := &corev1.Pod{}
+								podKey := types.NamespacedName{
+									Name:      fmt.Sprintf("%s-%d", sts.Name, i),
+									Namespace: testNamespaceName,
 								}
+								g.Expect(k8sClient.Get(context.TODO(), podKey, pod)).To(Succeed())
+								metav1.SetMetaDataAnnotation(&pod.ObjectMeta, api.RestartedAtAnnotation, time.Now().Format(time.RFC3339))
+								g.Expect(k8sClient.Update(context.TODO(), pod)).To(Succeed())
 							}
+						}
 
-							if sts.Status.UpdateRevision != "1" {
-								sts.Status.UpdatedReplicas = sts.Status.Replicas
-								sts.Status.ReadyReplicas = sts.Status.Replicas
-								sts.Status.CurrentReplicas = sts.Status.Replicas
-								sts.Status.UpdateRevision = "1"
-								sts.Status.CurrentRevision = sts.Status.UpdateRevision
-								sts.Status.ObservedGeneration = sts.GetObjectMeta().GetGeneration()
+						if sts.Status.UpdateRevision != "1" {
+							sts.Status.UpdatedReplicas = sts.Status.Replicas
+							sts.Status.ReadyReplicas = sts.Status.Replicas
+							sts.Status.CurrentReplicas = sts.Status.Replicas
+							sts.Status.UpdateRevision = "1"
+							sts.Status.CurrentRevision = sts.Status.UpdateRevision
+							sts.Status.ObservedGeneration = sts.GetObjectMeta().GetGeneration()
 
-								Expect(k8sClient.Status().Update(context.TODO(), &sts)).Should(Succeed())
-							}
-						} else if !found {
-							return false
+							g.Expect(k8sClient.Status().Update(context.TODO(), &sts)).Should(Succeed())
 						}
 					}
-					return true
-				}, "5s", "50ms").Should(BeTrue())
+				}, "5s", "50ms").Should(Succeed())
 
 				_ = waitForTaskCompletion(taskKey)
 			})

--- a/internal/controllers/control/jobs.go
+++ b/internal/controllers/control/jobs.go
@@ -67,6 +67,8 @@ func (r *CassandraTaskReconciler) restartSts(taskConfig *TaskConfiguration, sts 
 		return sts[i].Name < sts[j].Name
 	})
 
+	logger := log.FromContext(taskConfig.Context)
+
 	restartTime := taskConfig.TaskStartTime.Format(time.RFC3339)
 
 	if taskConfig.Arguments.RackName != "" {
@@ -86,7 +88,6 @@ func (r *CassandraTaskReconciler) restartSts(taskConfig *TaskConfiguration, sts 
 		}
 		if st.Spec.Template.Annotations[api.RestartedAtAnnotation] == restartTime {
 			// This one has been called to restart already - is it ready?
-
 			status := st.Status
 			if status.CurrentRevision == status.UpdateRevision &&
 				status.UpdatedReplicas == status.Replicas &&
@@ -104,9 +105,40 @@ func (r *CassandraTaskReconciler) restartSts(taskConfig *TaskConfiguration, sts 
 			// This is still restarting
 			return ctrl.Result{RequeueAfter: JobRunningRequeue}, nil
 		}
+
 		st.Spec.Template.Annotations[api.RestartedAtAnnotation] = restartTime
 		if err := r.Update(taskConfig.Context, &st); err != nil {
 			return ctrl.Result{}, err
+		}
+
+		if taskConfig.Arguments.Fast {
+			for _, stToCheck := range sts {
+				status := stToCheck.Status
+				if stToCheck.Name != st.Name {
+					// If any other rack has pods down, we cannot continue with this fast path
+					if int(status.Replicas-status.ReadyReplicas) > 0 {
+						logger.Info("Cannot continue with rack-at-once restart since another rack has pods down", "statefulset", stToCheck.Name)
+						return ctrl.Result{RequeueAfter: JobRunningRequeue}, nil
+					}
+					continue
+				}
+			}
+
+			// Fetch the pods of the StatefulSet and send a drain command to all of them at once
+			pods, err := r.getStatefulSetPods(taskConfig.Context, taskConfig.Datacenter, &st)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			for _, pod := range pods {
+				if err := r.Delete(taskConfig.Context, &pod); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+			metav1.SetMetaDataAnnotation(&st.Spec.Template.ObjectMeta, api.RestartedAtAnnotation, restartTime)
+			if err := r.Update(taskConfig.Context, &st); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 
 		return ctrl.Result{RequeueAfter: JobRunningRequeue}, nil

--- a/internal/controllers/control/jobs.go
+++ b/internal/controllers/control/jobs.go
@@ -106,11 +106,6 @@ func (r *CassandraTaskReconciler) restartSts(taskConfig *TaskConfiguration, sts 
 			return ctrl.Result{RequeueAfter: JobRunningRequeue}, nil
 		}
 
-		st.Spec.Template.Annotations[api.RestartedAtAnnotation] = restartTime
-		if err := r.Update(taskConfig.Context, &st); err != nil {
-			return ctrl.Result{}, err
-		}
-
 		if taskConfig.Arguments.Fast {
 			force := taskConfig.Arguments.Force
 			for _, stToCheck := range sts {
@@ -124,13 +119,16 @@ func (r *CassandraTaskReconciler) restartSts(taskConfig *TaskConfiguration, sts 
 					continue
 				}
 			}
+		}
 
-			// Fetch the pods of the StatefulSet and delete all of them at once
-			metav1.SetMetaDataAnnotation(&st.Spec.Template.ObjectMeta, api.RestartedAtAnnotation, restartTime)
-			if err := r.Update(taskConfig.Context, &st); err != nil {
-				return ctrl.Result{}, err
-			}
+		// Fetch the pods of the StatefulSet and delete all of them at once
+		metav1.SetMetaDataAnnotation(&st.Spec.Template.ObjectMeta, api.RestartedAtAnnotation, restartTime)
+		if err := r.Update(taskConfig.Context, &st); err != nil {
+			return ctrl.Result{}, err
+		}
 
+		if taskConfig.Arguments.Fast {
+			// We have already checked if we have force or not and that other racks are healthy
 			pods, err := r.getStatefulSetPods(taskConfig.Context, taskConfig.Datacenter, &st)
 			if err != nil {
 				return ctrl.Result{}, err

--- a/internal/envtest/statefulset_controller.go
+++ b/internal/envtest/statefulset_controller.go
@@ -273,5 +273,6 @@ func createPVC(ctx context.Context, cli client.Client, mountName string, pod *co
 func (r *StatefulSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.StatefulSet{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&corev1.Pod{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -377,7 +377,6 @@ type User struct {
 func parseListRoles(body []byte) ([]User, error) {
 	var users []User
 	if err := json.Unmarshal(body, &users); err != nil {
-		fmt.Printf("Received an error: %v\n", err)
 		return nil, err
 	}
 	return users, nil

--- a/pkg/httphelper/server_test_utils.go
+++ b/pkg/httphelper/server_test_utils.go
@@ -79,6 +79,7 @@ func FakeExecutorServerWithDetails(callDetails *CallDetails) (*httptest.Server, 
 				r.URL.Path == "/api/v1/ops/node/rebuild" ||
 				r.URL.Path == "/api/v1/ops/tables/sstables/upgrade" ||
 				r.URL.Path == "/api/v0/ops/node/move" ||
+				r.URL.Path == "/api/v0/ops/node/drain" ||
 				r.URL.Path == "/api/v1/ops/tables/compact" ||
 				r.URL.Path == "/api/v1/ops/tables/scrub" ||
 				r.URL.Path == "/api/v1/ops/tables/flush" ||

--- a/pkg/reconciliation/handler_reconcile_test.go
+++ b/pkg/reconciliation/handler_reconcile_test.go
@@ -92,7 +92,6 @@ func TestReconcile(t *testing.T) {
 		}}
 		pod.Labels[api.CassNodeState] = "Started"
 		pod.Status.PodIP = fmt.Sprintf("192.168.1.%d", i)
-		fmt.Printf("Adding pod %s\n", pod.Name)
 		trackObjects = append(trackObjects, pod)
 	}
 

--- a/tests/rolling_restart/rolling_restart_suite_test.go
+++ b/tests/rolling_restart/rolling_restart_suite_test.go
@@ -6,10 +6,10 @@ package rolling_restart
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/k8ssandra/cass-operator/tests/kustomize"
@@ -18,13 +18,14 @@ import (
 )
 
 var (
-	testName   = "Rolling Restart"
-	namespace  = "test-rolling-restart"
-	dcName     = "dc2"
-	dcYaml     = "../testdata/default-single-rack-2-node-dc.yaml"
-	taskYaml   = "../testdata/tasks/rolling_restart.yaml"
-	dcResource = fmt.Sprintf("CassandraDatacenter/%s", dcName)
-	ns         = ginkgo_util.NewWrapper(testName, namespace)
+	testName     = "Rolling Restart"
+	namespace    = "test-rolling-restart"
+	dcName       = "dc2"
+	dcYaml       = "../testdata/default-single-rack-2-node-dc.yaml"
+	taskYaml     = "../testdata/tasks/rolling_restart.yaml"
+	fastTaskYaml = "../testdata/tasks/rolling_restart_fast.yaml"
+	dcResource   = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	ns           = ginkgo_util.NewWrapper(testName, namespace)
 )
 
 func TestLifecycle(t *testing.T) {
@@ -105,6 +106,106 @@ var _ = Describe(testName, func() {
 				WithFlag("field-selector", "status.phase=Running").
 				FormatOutput(json)
 			ns.WaitForOutputPatternAndLog(step, k, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`, 360)
+		})
+		Specify("cassandratask can be used with fast path", func() {
+			// Scale the datacenter to 3 racks and 6 nodes
+			step := "scaling datacenter to 3 racks"
+			json := `{"spec":{"size":6,"racks":[{"name":"r1"},{"name":"r2"},{"name":"r3"}]}}`
+			ns.ExecAndLog(step, kubectl.PatchMerge(dcResource, json))
+
+			ns.WaitForDatacenterReady(dcName)
+
+			step = "creating a cassandra task to do rolling restart (fast)"
+			ns.ExecAndLog(step, kubectl.ApplyFiles(fastTaskYaml))
+
+			// Wait for the task to be completed
+			ns.WaitForCompleteTask("rolling-restart-fast")
+			ns.WaitForDatacenterReady(dcName) // Should be instant check
+
+			step = "verify all pods have restartedAt annotation"
+			ns.Log(step)
+			podNames := ns.GetDatacenterReadyPodNames(dcName)
+			Expect(podNames).To(HaveLen(6), "Expected 6 ready pods")
+
+			for _, podName := range podNames {
+				json = `jsonpath={.metadata.annotations.control\.k8ssandra\.io/restartedAt}`
+				k := kubectl.Get("pod", podName).FormatOutput(json)
+				val, err := ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to get restartedAt annotation for pod %s", podName)
+				Expect(val).To(MatchRegexp(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`),
+					fmt.Sprintf("Pod %s should have valid restartedAt annotation", podName))
+			}
+
+			step = "verify pods were restarted in correct order (rack by rack)"
+			ns.Log(step)
+
+			// Group pods by rack and collect their start times for comparison
+			rackStartTimes := make(map[string][]time.Time)
+			for _, podName := range podNames {
+				json = `jsonpath={.metadata.labels.cassandra\.datastax\.com/rack}`
+				k := kubectl.Get("pod", podName).FormatOutput(json)
+				rackName, err := ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to get rack label for pod %s", podName)
+				Expect(rackName).ToNot(BeEmpty(), "Pod %s should have rack label", podName)
+
+				// Parse the timestamp from pod's start time status
+				json = `jsonpath={.status.startTime}`
+				k = kubectl.Get("pod", podName).FormatOutput(json)
+				startTimeStr, err := ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to get startTime for pod %s", podName)
+				Expect(startTimeStr).To(MatchRegexp(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`),
+					fmt.Sprintf("Pod %s should have valid startTime", podName))
+				startTime, err := time.Parse(time.RFC3339, startTimeStr)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to parse startTime timestamp for pod %s", podName)
+
+				rackStartTimes[rackName] = append(rackStartTimes[rackName], startTime)
+			}
+
+			// Verify we have 3 racks with 2 pods each
+			Expect(rackStartTimes).To(HaveLen(3), "Expected 3 racks")
+			Expect(rackStartTimes["r1"]).To(HaveLen(2), "Expected 2 pods in rack r1")
+			Expect(rackStartTimes["r2"]).To(HaveLen(2), "Expected 2 pods in rack r2")
+			Expect(rackStartTimes["r3"]).To(HaveLen(2), "Expected 2 pods in rack r3")
+
+			// Calculate the maximum start time for each rack (when the last pod in the rack started)
+			getMaxTime := func(times []time.Time) time.Time {
+				maxTime := times[0]
+				for _, t := range times {
+					if t.After(maxTime) {
+						maxTime = t
+					}
+				}
+				return maxTime
+			}
+
+			// Calculate the minimum start time for each rack (when the first pod in the rack started)
+			getMinTime := func(times []time.Time) time.Time {
+				minTime := times[0]
+				for _, t := range times {
+					if t.Before(minTime) {
+						minTime = t
+					}
+				}
+				return minTime
+			}
+
+			maxR1Time := getMaxTime(rackStartTimes["r1"])
+			maxR2Time := getMaxTime(rackStartTimes["r2"])
+
+			minR2Time := getMinTime(rackStartTimes["r2"])
+			minR3Time := getMinTime(rackStartTimes["r3"])
+
+			// Verify rack restart order: all pods in r1 should start before any pod in r2,
+			// and all pods in r2 should start before any pod in r3
+			Expect(maxR1Time.Before(minR2Time) || maxR1Time.Equal(minR2Time)).To(BeTrue(),
+				fmt.Sprintf("Rack r1 should complete restart (max: %v) before rack r2 starts (min: %v)",
+					maxR1Time, minR2Time))
+			Expect(maxR2Time.Before(minR3Time) || maxR2Time.Equal(minR3Time)).To(BeTrue(),
+				fmt.Sprintf("Rack r2 should complete restart (max: %v) before rack r3 starts (min: %v)",
+					maxR2Time, minR3Time))
+
+			ns.Log(fmt.Sprintf("Verified restart order - r1 max: %v, r2 min: %v, r2 max: %v, r3 min: %v",
+				maxR1Time, minR2Time, maxR2Time, minR3Time))
 		})
 	})
 })

--- a/tests/testdata/default-single-rack-2-node-dc.yaml
+++ b/tests/testdata/default-single-rack-2-node-dc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster2
   serverType: cassandra
-  serverVersion: "4.0.4"
+  serverVersion: "5.0.6"
   managementApiAuth:
     insecure: {}
   size: 2

--- a/tests/testdata/tasks/rolling_restart_fast.yaml
+++ b/tests/testdata/tasks/rolling_restart_fast.yaml
@@ -1,0 +1,13 @@
+apiVersion: control.k8ssandra.io/v1alpha1
+kind: CassandraTask
+metadata:
+  name: rolling-restart-fast
+spec:
+  datacenter:
+    name: dc2
+    namespace: test-rolling-restart
+  jobs:
+    - name: restart-run
+      command: restart
+      args:
+        fast: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new parameter "fast" as job argument to the rolling restart. This restarts an entire rack at once, thus allowing parallel shutdown and startup. This should significantly improve the rolling restart speed.

**Which issue(s) this PR fixes**:
Fixes #841

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
