### PR TITLE
Add support for setting digest in the ImageConfig and Image types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [FEATURE] [#838](https://github.com/k8ssandra/cass-operator/issues/838) If cass-operator is not deployed in clusterScoped mode, disable features that require such rights and continue functioning correctly otherwise. 
 * [ENHANCEMENT] [#848](https://github.com/k8ssandra/cass-operator/issues/848) Detect more error cases in the PVC resizing operation and notify the user with an event and a change in the Datacenter status.
+* [ENHANCEMENT] [#846](https://github.com/k8ssandra/cass-operator/issues/846) Detect the usage of a digest in the ImageConfig tag field and correctly deploy it without requiring a separate tag to be set. In previous versions, setting tag to for example: `v1.0@sha256:hash` would be required to deploy with digest only.
 
 ## v1.27.1
 

--- a/apis/config/v1beta2/imageconfig_types_test.go
+++ b/apis/config/v1beta2/imageconfig_types_test.go
@@ -104,6 +104,25 @@ func TestImage_ApplyOverrides(t *testing.T) {
 				PullSecret: "my-secret",
 			},
 		},
+		{
+			name: "digest override",
+			original: &Image{
+				Registry:   "docker.io",
+				Repository: "library",
+				Name:       "cassandra",
+				Tag:        "4.0.0",
+			},
+			overrides: &Image{
+				Digest: "sha256:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3f6ce540cc88fb1cf6fbb4e26",
+			},
+			expected: &Image{
+				Registry:   "docker.io",
+				Repository: "library",
+				Name:       "cassandra",
+				Tag:        "4.0.0",
+				Digest:     "sha256:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3f6ce540cc88fb1cf6fbb4e26",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -164,6 +183,25 @@ func TestImage_String(t *testing.T) {
 				Name:       "cassandra",
 			},
 			expected: "docker.io/library/cassandra:",
+		},
+		{
+			name: "tag is digest",
+			image: Image{
+				Registry:   "docker.io",
+				Repository: "library",
+				Name:       "cassandra",
+				Tag:        "sha256:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3f6ce540cc88fb1cf6fbb4e26",
+			},
+			expected: "docker.io/library/cassandra@sha256:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3f6ce540cc88fb1cf6fbb4e26",
+		},
+		{
+			name: "digest field takes precedence",
+			image: Image{
+				Name:   "cassandra",
+				Tag:    "4.0.0",
+				Digest: "sha256:2d711642b726b04401627ca9fbac32f5da7d61d74a0f5120e7131095d5f14f3f",
+			},
+			expected: "cassandra@sha256:2d711642b726b04401627ca9fbac32f5da7d61d74a0f5120e7131095d5f14f3f",
 		},
 	}
 

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -250,23 +250,23 @@ func TestRepositoryAndNamespaceOverride(t *testing.T) {
 	imageConfig.DefaultImages = &configv1beta1.DefaultImages{
 		ImageComponents: map[string]configv1beta1.ImageComponent{
 			configv1beta1.DSEImageComponent: {
-				Repository: "cr.dtsx.io/datastax/dse-mgmtapi-6_8",
+				Repository: "docker.io/datastax/dse-mgmtapi-6_8",
 			},
 		},
 	}
 	path, err = registry.GetCassandraImage("dse", "6.8.44")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/datastax/dse-mgmtapi-6_8:6.8.44", path)
+	assert.Equal("docker.io/datastax/dse-mgmtapi-6_8:6.8.44", path)
 
 	imageConfig.ImageNamespace = ptr.To("internal")
 	path, err = registry.GetCassandraImage("dse", "6.8.44")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/internal/dse-mgmtapi-6_8:6.8.44", path)
+	assert.Equal("docker.io/internal/dse-mgmtapi-6_8:6.8.44", path)
 
 	imageConfig.ImageNamespace = ptr.To("")
 	path, err = registry.GetCassandraImage("dse", "6.8.44")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/dse-mgmtapi-6_8:6.8.44", path)
+	assert.Equal("docker.io/dse-mgmtapi-6_8:6.8.44", path)
 }
 
 func TestImageConfigByteParsing(t *testing.T) {

--- a/pkg/images/images_v1beta2_test.go
+++ b/pkg/images/images_v1beta2_test.go
@@ -62,7 +62,7 @@ func TestDefaultImageConfigParsingV2(t *testing.T) {
 	assert.NotNil(imageConfig.Images)
 	assert.Contains(registry.GetSystemLoggerImage(), "k8ssandra/system-logger:")
 	assert.Contains(registry.GetConfigBuilderImage(), "datastax/cass-config-builder:")
-	assert.Contains(registry.GetClientImage(), "k8ssandra/k8ssandra-client:")
+	assert.Contains(registry.GetClientImage(), "k8ssandra/k8ssandra-client@sha256:")
 
 	assert.Equal("ghcr.io", imageConfig.Types["cassandra"].Registry)
 	assert.Equal("k8ssandra", imageConfig.Types["cassandra"].Repository)
@@ -70,7 +70,7 @@ func TestDefaultImageConfigParsingV2(t *testing.T) {
 
 	path, err := registry.GetCassandraImage("dse", "6.8.47")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/datastax/dse-mgmtapi-6_8:6.8.47-ubi", path)
+	assert.Equal("docker.io/datastax/dse-mgmtapi-6_8:6.8.47-ubi", path)
 
 	path, err = registry.GetCassandraImage("hcd", "1.0.0")
 	assert.NoError(err)
@@ -96,11 +96,10 @@ func TestImageConfigParsingV2(t *testing.T) {
 	assert.NotNil(imageConfig.Images)
 	assert.Equal("ghcr.io/k8ssandra/system-logger:latest", registry.GetSystemLoggerImage())
 	assert.Contains(registry.GetConfigBuilderImage(), "datastax/cass-config-builder:")
-	assert.Contains(registry.GetClientImage(), "k8ssandra/k8ssandra-client:")
+	assert.Contains(registry.GetClientImage(), "k8ssandra/k8ssandra-client@sha256:")
 
 	assert.Equal("ghcr.io", imageConfig.Types["cassandra"].Registry)
 	assert.Equal("k8ssandra", imageConfig.Types["cassandra"].Repository)
-	assert.Equal("cr.dtsx.io", imageConfig.Types["dse"].Registry)
 	assert.Equal("datastax", imageConfig.Types["dse"].Repository)
 
 	assert.Equal("docker.io", *imageConfig.Defaults.Registry)
@@ -109,7 +108,7 @@ func TestImageConfigParsingV2(t *testing.T) {
 
 	path, err := registry.GetCassandraImage("dse", "6.8.43")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/datastax/dse-mgmtapi-6_8:6.8.43-ubi", path)
+	assert.Equal("docker.io/datastax/dse-mgmtapi-6_8:6.8.43-ubi", path)
 }
 
 func TestExtendedImageConfigParsingV2(t *testing.T) {
@@ -251,14 +250,14 @@ apiVersion: config.k8ssandra.io/v1beta2
 kind: ImageConfig
 types:
   dse:
-    repository: cr.dtsx.io/datastax
+    repository: docker.io/datastax
     name: dse-mgmtapi-6_8
 `
 	registry, err = newTestImageRegistryV2([]byte(yamlConfig))
 	require.NoError(t, err)
 	path, err = registry.GetCassandraImage("dse", "6.8.44")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/datastax/dse-mgmtapi-6_8:6.8.44", path)
+	assert.Equal("docker.io/datastax/dse-mgmtapi-6_8:6.8.44", path)
 
 	yamlConfig = `
 apiVersion: config.k8ssandra.io/v1beta2
@@ -267,7 +266,7 @@ overrides:
   repository: internal
 types:
   dse:
-    registry: cr.dtsx.io
+    registry: docker.io
     repository: datastax
     name: dse-mgmtapi-6_8
 `
@@ -275,7 +274,7 @@ types:
 	require.NoError(t, err)
 	path, err = registry.GetCassandraImage("dse", "6.8.44")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/internal/dse-mgmtapi-6_8:6.8.44", path)
+	assert.Equal("docker.io/internal/dse-mgmtapi-6_8:6.8.44", path)
 
 	yamlConfig = `
 apiVersion: config.k8ssandra.io/v1beta2
@@ -284,7 +283,7 @@ overrides:
   repository: ""
 types:
   dse:
-    registry: cr.dtsx.io
+    registry: docker.io
     repository: "datastax"
     name: dse-mgmtapi-6_8
 `
@@ -292,7 +291,7 @@ types:
 	require.NoError(t, err)
 	path, err = registry.GetCassandraImage("dse", "6.8.44")
 	assert.NoError(err)
-	assert.Equal("cr.dtsx.io/dse-mgmtapi-6_8:6.8.44", path)
+	assert.Equal("docker.io/dse-mgmtapi-6_8:6.8.44", path)
 }
 
 func TestImageConfigByteParsingV2(t *testing.T) {

--- a/tests/testdata/image_config_parsing_v2.yaml
+++ b/tests/testdata/image_config_parsing_v2.yaml
@@ -16,6 +16,7 @@ images:
     repository: "k8ssandra"
     name: "k8ssandra-client"
     tag: "v0.8.3"
+    digest: "sha256:93a57444c14cec724942103543db6bb140ea444dca19b001701cc736b9e0d959"
     # pullSecret: "k8ssandra-client-pull-secret" # Use of pullSecret removes the default pullSecrets for this image
     # pullPolicy: Always
   medusa: 
@@ -53,7 +54,6 @@ types:
     suffix: "-ubi"
     pullPolicy: IfNotPresent
   dse:
-    registry: "cr.dtsx.io"
     repository: "datastax"
     name: "dse-mgmtapi-6_8"
     suffix: "-ubi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add support for deploying with digest information instead of only tags with digest as suffix.

**Which issue(s) this PR fixes**:
Fixes #846 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
