### PR TITLE
Better PVC resize error detection, no ClusterRole mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [FEATURE] [#838](https://github.com/k8ssandra/cass-operator/issues/838) If cass-operator is not deployed in clusterScoped mode, disable features that require such rights and continue functioning correctly otherwise. 
+* [ENHANCEMENT] [#848](https://github.com/k8ssandra/cass-operator/issues/848) Detect more error cases in the PVC resizing operation and notify the user with an event and a change in the Datacenter status.
+
 ## v1.27.1
 
 * [CHANGE] [#845](https://github.com/k8ssandra/cass-operator/issues/845) Set default registry to be docker.io on the releases to allow easier modification using new ImageConfig

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,6 +215,8 @@ func main() {
 		DefaultNamespaces: map[string]cache.Config{},
 	}
 
+	clusterScoped := len(ns) == 0
+
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 	if strings.Contains(ns, ",") {
 		setupLog.Info("manager set up with multiple namespaces", "namespaces", ns)
@@ -255,11 +257,12 @@ func main() {
 	}
 
 	if err = (&controllers.CassandraDatacenterReconciler{
-		Client:        mgr.GetClient(),
-		Log:           ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("cass-operator"),
-		ImageRegistry: registry,
+		Client:           mgr.GetClient(),
+		Log:              ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+		Scheme:           mgr.GetScheme(),
+		Recorder:         mgr.GetEventRecorderFor("cass-operator"),
+		ImageRegistry:    registry,
+		ClusterResources: clusterScoped,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CassandraDatacenter")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,14 +5,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -61,7 +61,6 @@ var (
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods;endpoints;endpoints/restricted;services;configmaps;secrets;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=events,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=namespaces,verbs=get
-// +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,namespace=cass-operator,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=discovery.k8s.io,namespace=cass-operator,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
@@ -79,7 +78,8 @@ type CassandraDatacenterReconciler struct {
 	// Putting it here allows us to get it to both places.
 	SecretWatches dynamicwatch.DynamicWatches
 
-	ImageRegistry images.ImageRegistry
+	ImageRegistry    images.ImageRegistry
+	ClusterResources bool
 }
 
 // Reconcile reads that state of the cluster for a Datacenter object
@@ -110,7 +110,7 @@ func (r *CassandraDatacenterReconciler) Reconcile(ctx context.Context, request c
 
 	logger.Info("======== handler::Reconcile has been called")
 
-	rc, err := reconciliation.CreateReconciliationContext(ctx, &request, r.Client, r.Scheme, r.Recorder, r.SecretWatches, r.ImageRegistry)
+	rc, err := reconciliation.CreateReconciliationContext(ctx, &request, r.Client, r.Scheme, r.Recorder, r.SecretWatches, r.ImageRegistry, r.ClusterResources)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -20,6 +20,7 @@ const (
 	LabeledPodAsDecommissioning       string = "LabeledPodAsDecommissioning"
 	DeletedPvc                        string = "DeletedPvc"
 	ResizingPVC                       string = "ResizingPVC"
+	ResizingPVCFailed                 string = "ResizingPVCFailed"
 	UnlabeledPodAsSeed                string = "UnlabeledPodAsSeed"
 	LabeledRackResource               string = "LabeledRackResource"
 	ScalingUpRack                     string = "ScalingUpRack"

--- a/pkg/reconciliation/context.go
+++ b/pkg/reconciliation/context.go
@@ -27,15 +27,16 @@ import (
 
 // ReconciliationContext contains all of the input necessary to calculate a list of ReconciliationActions
 type ReconciliationContext struct {
-	Request        *reconcile.Request
-	Client         client.Client
-	Scheme         *runtime.Scheme
-	Datacenter     *api.CassandraDatacenter
-	NodeMgmtClient httphelper.NodeMgmtClient
-	Recorder       record.EventRecorder
-	ReqLogger      logr.Logger
-	SecretWatches  dynamicwatch.DynamicWatches
-	ImageRegistry  images.ImageRegistry
+	Request          *reconcile.Request
+	Client           client.Client
+	Scheme           *runtime.Scheme
+	Datacenter       *api.CassandraDatacenter
+	NodeMgmtClient   httphelper.NodeMgmtClient
+	Recorder         record.EventRecorder
+	ReqLogger        logr.Logger
+	SecretWatches    dynamicwatch.DynamicWatches
+	ImageRegistry    images.ImageRegistry
+	ClusterResources bool
 
 	// According to golang recommendations the context should not be stored in a struct but given that
 	// this is passed around as a parameter we feel that its a fair compromise. For further discussion
@@ -59,6 +60,7 @@ func CreateReconciliationContext(
 	rec record.EventRecorder,
 	secretWatches dynamicwatch.DynamicWatches,
 	imageRegistry images.ImageRegistry,
+	clusterScoped bool,
 ) (*ReconciliationContext, error) {
 	reqLogger := log.FromContext(ctx)
 	rc := &ReconciliationContext{}
@@ -70,6 +72,7 @@ func CreateReconciliationContext(
 	rc.ReqLogger = reqLogger
 	rc.Ctx = ctx
 	rc.ImageRegistry = imageRegistry
+	rc.ClusterResources = clusterScoped
 
 	rc.ReqLogger = rc.ReqLogger.
 		WithValues("namespace", req.Namespace)

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -3113,6 +3113,7 @@ func TestFindHostIdForIpFromEndpointsData(t *testing.T) {
 
 func TestCheckVolumeClaimSizesValidation(t *testing.T) {
 	rc, _, cleanupMockScr := setupTest()
+	rc.ClusterResources = true
 	defer cleanupMockScr()
 	require := require.New(t)
 
@@ -3341,6 +3342,7 @@ func TestCheckPVCResizing(t *testing.T) {
 func TestCheckRackPodTemplateWithVolumeExpansion(t *testing.T) {
 	require := require.New(t)
 	rc, _, cleanpMockSrc := setupTest()
+	rc.ClusterResources = true
 	defer cleanpMockSrc()
 
 	require.NoError(rc.CalculateRackInformation())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add a running mode that disables the usage of features that require ClusterRoles. Also, improve the detection of PVC resizing failures since we could be missing a validation stage that requires ClusterRole to be present.

Reduce the amount of RBAC requirements for ClusterRole by replacing the PV Capacity poll by trusting the PVC's Capacity status.

**Which issue(s) this PR fixes**:
Fixes #848 
Fixes #838 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
