### PR TITLE
Add IPv6 only smoke test

### DIFF
--- a/.github/actions/run-integ-test/action.yml
+++ b/.github/actions/run-integ-test/action.yml
@@ -12,6 +12,9 @@ inputs:
   serverImage:
     description: "Override server image used in the test file"
     required: false
+  networking:
+    description: "Set networking mode for kind cluster (default: ipv4)"
+    required: false
 
 runs:
   using: "composite"
@@ -36,7 +39,7 @@ runs:
     - name: Create kind cluster
       shell: bash
       run: |
-        hack/cluster.sh
+        hack/cluster.sh ${{ inputs.networking }}
     - name: Install gatekeeper rules
       if: ${{ !env.SKIP_GATEKEEPER }}
       shell: bash

--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -284,10 +284,10 @@ jobs:
             serverType: dse
           # - version: 5.1.0
           #   serverImage: ghcr.io/k8ssandra/cass-management-api:5.1-nightly-latest
-          - version: 4.0.17
+          - version: 4.0.18
             skipGatekeeper: true
         exclude:
-          - version: 4.0.17
+          - version: 4.0.18
             integration_test: "smoke_test_read_only_fs"
       fail-fast: true
     runs-on: ubuntu-latest
@@ -347,7 +347,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: k8s-logs-smoke_test-${{ matrix.version }}
+          name: k8s-logs-smoke_test_ipv6-${{ matrix.version }}
           path: ./build/kubectl_dump
   kind_topolvm_tests:
     name: TopoLVM kind installation with volumeExpansion

--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "4.0.17"
+          - "4.0.18"
         integration_test:
           - cdc_successful # OSS only
           - config_fql
@@ -158,7 +158,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "5.0.3"
+          - "5.0.5"
         integration_test:
           - canary_upgrade
           - podspec_simple
@@ -191,7 +191,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - "5.0.3"
+          - "5.0.5"
         integration_test:
           # Single worker tests:
           - additional_serviceoptions
@@ -268,9 +268,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - "4.0.17"
-          - "4.1.8"
-          - "5.0.3"
+          - "4.0.18"
+          - "4.1.9"
+          - "5.0.5"
           - "6.8.54"
           - "6.9.7"
           # - "5.1.0"
@@ -310,6 +310,39 @@ jobs:
       - uses: ./.github/actions/run-integ-test
         with:
           integration_test: ${{ matrix.integration_test }}
+      - name: Archive k8s logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-logs-smoke_test-${{ matrix.version }}
+          path: ./build/kubectl_dump
+  kind_smoke_ipv6_tests:
+    needs: build_docker_images
+    strategy:
+      matrix:
+        version:
+          - "5.0.5"
+        integration_test:
+          - test_all_the_things
+      fail-fast: true
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+      M_INTEG_DIR: ${{ matrix.integration_test }}
+      M_SERVER_VERSION: ${{ matrix.version }}
+      M_SERVER_IMAGE: ${{ matrix.serverImage }}
+      M_SERVER_TYPE: ${{ matrix.serverType }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+      - uses: ./.github/actions/run-integ-test
+        with:
+          integration_test: ${{ matrix.integration_test }}
+          networking: ipv6
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/config/imageconfig/image_config.yaml
+++ b/config/imageconfig/image_config.yaml
@@ -15,7 +15,7 @@ images:
   k8ssandra-client:
     repository: "k8ssandra"
     name: "k8ssandra-client"
-    tag: "v0.8.3"
+    tag: "3d916941"
     # pullSecret: "k8ssandra-client-pull-secret" # Use of pullSecret removes the default pullSecrets for this image
     # pullPolicy: Always
 # -- defaults are used when other no override is present for the configured image or image type. All these values can be overridden under any image or image type.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
We do not test if the operator works in IPv6 only environment. This e2e test should track such behavior (such as config builder issues in k8ssandra-client)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
