### PR TITLE
Use VolumeMounts from PodTemplateSpec as the final directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#862](https://github.com/k8ssandra/cass-operator/issues/862) If volumeMount was provided in PodTemplateSpec and AdditionalVolumes, the latter would override the PodTemplateSpec one. This was unintentional, the PodTemplateSpec selection should be the final one.
+
 ## v1.28.0
 
 * [FEATURE] [#838](https://github.com/k8ssandra/cass-operator/issues/838) If cass-operator is not deployed in clusterScoped mode, disable features that require such rights and continue functioning correctly otherwise. 

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 	kubectl delete --ignore-not-found=$(ignore-not-found) -k config/crd
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize cert-manager ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	LOG_IMG=${LOG_IMG} yq eval -i '.images.system-logger = env(LOG_IMG)' config/manager/image_config.yaml
 	TAG=${TAG} yq eval -i '.images.system-logger.tag = env(TAG)' config/imageconfig/image_config.yaml
@@ -240,6 +240,10 @@ ifneq ($(strip $(NAMESPACE)),)
 	cd tests/kustomize && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
 endif
 	kubectl delete -k tests/$(TEST_DIR)
+
+.PHONY: reload
+reload: ## Deploy new build of cass-operator in development
+	kubectl rollout restart deployment.apps/cass-operator-controller-manager -n cass-operator
 
 ##@ Tools / Dependencies
 

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -891,9 +891,9 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 		MountPath: "/var/lib/vector",
 	}
 
-	volumeMounts = combineVolumeMountSlices([]corev1.VolumeMount{cassServerLogsMount, vectorMount}, loggerContainer.VolumeMounts)
+	volumeMounts = combineVolumeMountSlices([]corev1.VolumeMount{cassServerLogsMount, vectorMount}, generateStorageConfigVolumesMount(dc))
 
-	loggerContainer.VolumeMounts = combineVolumeMountSlices(volumeMounts, generateStorageConfigVolumesMount(dc))
+	loggerContainer.VolumeMounts = combineVolumeMountSlices(volumeMounts, loggerContainer.VolumeMounts)
 
 	loggerContainer.Resources = *getResourcesOrDefault(&dc.Spec.SystemLoggerResources, &DefaultsLoggerContainer)
 

--- a/tests/test_mtls_mgmt_api/test_mtls_mgmt_api_suite_test.go
+++ b/tests/test_mtls_mgmt_api/test_mtls_mgmt_api_suite_test.go
@@ -80,6 +80,16 @@ var _ = Describe(testName, func() {
 			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
 			ns.WaitForDatacenterReady(dcName)
 
+			// Verify the server-system-logger and cassandra container have different mount paths for certs
+			step = "verifying cert volume mount paths"
+			json = "jsonpath={.spec.containers[?(@.name=='cassandra')].volumeMounts[?(@.name=='management-api-client-certs')].mountPath}"
+			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "/management-api-client-certs", 30)
+
+			json = "jsonpath={.spec.containers[?(@.name=='server-system-logger')].volumeMounts[?(@.name=='management-api-client-certs')].mountPath}"
+			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "/management-api-certs", 30)
+
 			// TODO FIXME: re-enable this when the following issue is fixed:
 			// https://github.com/datastax/management-api-for-apache-cassandra/issues/42
 			// logOutput := ""

--- a/tests/testdata/oss-one-node-dc-with-mtls.yaml
+++ b/tests/testdata/oss-one-node-dc-with-mtls.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterName: cluster1
   serverType: cassandra
-  serverVersion: "3.11.7"
+  serverVersion: "5.0.6"
   managementApiAuth:
     manual:
       clientSecretName: mgmt-api-client-credentials
@@ -19,9 +19,23 @@ spec:
       resources:
         requests:
           storage: 1Gi
+    additionalVolumes:
+      - mountPath: /management-api-client-certs
+        name: management-api-client-certs
+        volumeSource:
+          secret:
+            secretName: mgmt-api-client-credentials
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: cassandra
+        - name: server-system-logger
+          volumeMounts:
+          - mountPath: /management-api-certs
+            name: management-api-client-certs
   racks:
     - name: r1
   config:
-    jvm-options:
+    jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes the bug where we used the VolumeMount value from AdditionalVolumes instead of what was provided in the PodTemplateSpec. This prevented from mounting different paths for the same AdditionalVolume in different containers.

**Which issue(s) this PR fixes**:
Fixes #862 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
