### PR TITLE
Add management-api-server-certs-volume volumeMount to all containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container
 * [BUGFIX] [#862](https://github.com/k8ssandra/cass-operator/issues/862) If volumeMount was provided in PodTemplateSpec and AdditionalVolumes, the latter would override the PodTemplateSpec one. This was unintentional, the PodTemplateSpec selection should be the final one.
 
 ## v1.28.0

--- a/pkg/httphelper/security.go
+++ b/pkg/httphelper/security.go
@@ -240,18 +240,6 @@ func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(endp
 }
 
 func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *corev1.PodTemplateSpec) error {
-	// find the container
-	var container *corev1.Container = nil
-	for i := range pod.Spec.Containers {
-		if pod.Spec.Containers[i].Name == "cassandra" {
-			container = &pod.Spec.Containers[i]
-		}
-	}
-
-	if container == nil {
-		return fmt.Errorf("could not find cassandra container")
-	}
-
 	// Add volume containing certificates
 	secretVolumeName := "management-api-server-certs-volume"
 	secretVolume := corev1.Volume{
@@ -276,11 +264,22 @@ func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *core
 		MountPath: "/management-api-certs",
 	}
 
-	if container.VolumeMounts == nil {
-		container.VolumeMounts = []corev1.VolumeMount{}
+	var cassContainer *corev1.Container = nil
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if pod.Spec.Containers[i].Name == "cassandra" {
+			cassContainer = container
+		}
+		if container.VolumeMounts == nil {
+			container.VolumeMounts = []corev1.VolumeMount{}
+		}
+
+		container.VolumeMounts = append(container.VolumeMounts, secretVolumeMount)
 	}
 
-	container.VolumeMounts = append(container.VolumeMounts, secretVolumeMount)
+	if cassContainer == nil {
+		return fmt.Errorf("could not find cassandra container")
+	}
 
 	// Configure Management API to use certificates
 	envVars := []corev1.EnvVar{
@@ -296,59 +295,46 @@ func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *core
 			Name:  "MGMT_API_TLS_KEY_FILE",
 			Value: tlsKey,
 		},
-		// TODO remove the below stuff post 1.0
-		{
-			Name:  "DSE_MGMT_TLS_CA_CERT_FILE",
-			Value: caCertPath,
-		},
-		{
-			Name:  "DSE_MGMT_TLS_CERT_FILE",
-			Value: tlsCrt,
-		},
-		{
-			Name:  "DSE_MGMT_TLS_KEY_FILE",
-			Value: tlsKey,
-		},
 	}
 
-	if container.Env == nil {
-		container.Env = []corev1.EnvVar{}
+	if cassContainer.Env == nil {
+		cassContainer.Env = []corev1.EnvVar{}
 	}
 
-	container.Env = append(envVars, container.Env...)
+	cassContainer.Env = append(envVars, cassContainer.Env...)
 
 	// Update Liveness probe to account for mutual auth (can't just use HTTP probe now)
-	if container.LivenessProbe == nil {
-		container.LivenessProbe = &corev1.Probe{
+	if cassContainer.LivenessProbe == nil {
+		cassContainer.LivenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{},
 		}
 	}
 
-	livenessTimeout := int(container.LivenessProbe.TimeoutSeconds)
+	livenessTimeout := int(cassContainer.LivenessProbe.TimeoutSeconds)
 	if livenessTimeout < 1 {
 		livenessTimeout = DefaultTimeout
 	}
 
-	container.LivenessProbe.HTTPGet = nil
-	container.LivenessProbe.TCPSocket = nil
-	container.LivenessProbe.Exec = provider.BuildMgmtApiGetAction(LivenessEndpoint, livenessTimeout)
+	cassContainer.LivenessProbe.HTTPGet = nil
+	cassContainer.LivenessProbe.TCPSocket = nil
+	cassContainer.LivenessProbe.Exec = provider.BuildMgmtApiGetAction(LivenessEndpoint, livenessTimeout)
 
 	// Update Readiness probe to account for mutual auth (can't just use HTTP probe now)
 	// TODO: Get endpoint from configured HTTPGet probe
-	if container.ReadinessProbe == nil {
-		container.ReadinessProbe = &corev1.Probe{
+	if cassContainer.ReadinessProbe == nil {
+		cassContainer.ReadinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{},
 		}
 	}
 
-	readinessTimeout := int(container.ReadinessProbe.TimeoutSeconds)
+	readinessTimeout := int(cassContainer.ReadinessProbe.TimeoutSeconds)
 	if readinessTimeout < 1 {
 		readinessTimeout = DefaultTimeout
 	}
 
-	container.ReadinessProbe.HTTPGet = nil
-	container.ReadinessProbe.TCPSocket = nil
-	container.ReadinessProbe.Exec = provider.BuildMgmtApiGetAction(ReadinessEndpoint, readinessTimeout)
+	cassContainer.ReadinessProbe.HTTPGet = nil
+	cassContainer.ReadinessProbe.TCPSocket = nil
+	cassContainer.ReadinessProbe.Exec = provider.BuildMgmtApiGetAction(ReadinessEndpoint, readinessTimeout)
 
 	return nil
 }

--- a/pkg/reconciliation/construct_statefulset.go
+++ b/pkg/reconciliation/construct_statefulset.go
@@ -130,7 +130,9 @@ func newStatefulSetForCassandraDatacenter(
 		template.Spec.NodeSelector = utils.MergeMap(map[string]string{}, dc.Spec.NodeSelector)
 	}
 
-	_ = httphelper.AddManagementApiServerSecurity(dc, template)
+	if err := httphelper.AddManagementApiServerSecurity(dc, template); err != nil {
+		return nil, err
+	}
 
 	result := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/k8ssandra/cass-operator/pkg/httphelper"
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/utils"
 	"github.com/stretchr/testify/require"
@@ -767,4 +768,57 @@ func TestMinReadySecondsChange(t *testing.T) {
 	assert.NoError(err, "failed to build statefulset")
 
 	assert.Equal(int32(10), sts.Spec.MinReadySeconds)
+}
+
+func TestAddManagementApiServerSecurity(t *testing.T) {
+	require := require.New(t)
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dc1",
+		},
+		Spec: api.CassandraDatacenterSpec{
+			ClusterName:   "pleasenobob",
+			ServerType:    "cassandra",
+			ServerVersion: "5.0.6",
+			ManagementApiAuth: api.ManagementApiAuthConfig{
+				Manual: &api.ManagementApiAuthManualConfig{
+					ClientSecretName: "mgmt-api-client-credentials",
+					ServerSecretName: "mgmt-api-server-credentials",
+				},
+			},
+			Racks: []api.Rack{
+				{
+					Name: "default",
+				},
+			},
+		},
+	}
+	podTemplateSpec, err := buildPodTemplateSpec(dc, dc.Spec.Racks[0], false, imageRegistry)
+	require.NoError(err, "failed to build PodTemplateSpec")
+	require.NoError(httphelper.AddManagementApiServerSecurity(dc, podTemplateSpec), "failed to add management api certs")
+
+	volumes := podTemplateSpec.Spec.Volumes
+	require.Len(volumes, 7, "expected 7 volumes in PodTemplateSpec")
+
+	foundServerCertVolume := false
+	for _, v := range volumes {
+		if v.Name == "management-api-server-certs-volume" {
+			foundServerCertVolume = true
+			require.NotNil(v.Secret, "expected server cert volume to be a secret volume")
+			require.Equal(dc.Spec.ManagementApiAuth.Manual.ServerSecretName, v.Secret.SecretName, "unexpected server cert secret name")
+		}
+	}
+	require.True(foundServerCertVolume, "did not find management api server certs")
+
+	for _, c := range podTemplateSpec.Spec.Containers {
+		foundServerCertsMount := false
+		require.True(len(c.VolumeMounts) >= 1, "expected at least one volume mount in container %s", c.Name)
+		for _, vm := range c.VolumeMounts {
+			if vm.Name == "management-api-server-certs-volume" {
+				require.Equal("/management-api-certs", vm.MountPath, "unexpected mount path for management api server certs")
+				foundServerCertsMount = true
+			}
+		}
+		require.True(foundServerCertsMount, "did not find management api server certs volume mount in container %s", c.Name)
+	}
 }

--- a/tests/test_mtls_mgmt_api/test_mtls_mgmt_api_suite_test.go
+++ b/tests/test_mtls_mgmt_api/test_mtls_mgmt_api_suite_test.go
@@ -88,7 +88,7 @@ var _ = Describe(testName, func() {
 
 			json = "jsonpath={.spec.containers[?(@.name=='server-system-logger')].volumeMounts[?(@.name=='management-api-client-certs')].mountPath}"
 			k = kubectl.Get("pod/cluster1-dc1-r1-sts-0").FormatOutput(json)
-			ns.WaitForOutputAndLog(step, k, "/management-api-certs", 30)
+			ns.WaitForOutputAndLog(step, k, "/management-api-certs-client", 30) // This is intentionally "wrong" to verify the correct priority of volumeMount processing
 
 			// TODO FIXME: re-enable this when the following issue is fixed:
 			// https://github.com/datastax/management-api-for-apache-cassandra/issues/42

--- a/tests/testdata/oss-one-node-dc-with-mtls.yaml
+++ b/tests/testdata/oss-one-node-dc-with-mtls.yaml
@@ -31,7 +31,7 @@ spec:
         - name: cassandra
         - name: server-system-logger
           volumeMounts:
-          - mountPath: /management-api-certs
+          - mountPath: /management-api-certs-client
             name: management-api-client-certs
   racks:
     - name: r1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Modifies the server-certs mounting to include all the containers, not just the cassandra container. This allows the usage with Vector and Medusa also. 

**Which issue(s) this PR fixes**:
Fixes #865 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
