### PR TITLE
Add new parameter --metrics-secure-auth to set if auth/authz is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container
+* [ENHANCEMENT] [#868](https://github.com/k8ssandra/cass-operator/issues/868) Add new flag to the controller, --metrics-secure-auth to enable/disable the authentication/authorization of metrics endpoint. Default is disabled (TLS is still enabled by default)
 * [BUGFIX] [#862](https://github.com/k8ssandra/cass-operator/issues/862) If volumeMount was provided in PodTemplateSpec and AdditionalVolumes, the latter would override the PodTemplateSpec one. This was unintentional, the PodTemplateSpec selection should be the final one.
 
 ## v1.28.0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
+	var secureMetricsAuth bool
 	var enableHTTP2 bool
 	var configFile string
 	var tlsOpts []func(*tls.Config)
@@ -89,6 +90,9 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+	flag.BoolVar(&secureMetricsAuth, "metrics-secure-auth", false,
+		"If set, the metrics endpoint is secured with authentication and authorization. "+
+			"Only applies when --metrics-secure=true. Use --metrics-secure-auth=true to also enable authentication and authorization.")
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
@@ -162,7 +166,7 @@ func main() {
 		TLSOpts:       tlsOpts,
 	}
 
-	if secureMetrics {
+	if secureMetrics && secureMetricsAuth {
 		// FilterProvider is used to protect the metrics endpoint with authn/authz.
 		// These configurations ensure that only authorized users and service accounts
 		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
@@ -256,6 +260,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := setupCacheIndexers(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to set up field indexers")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.CassandraDatacenterReconciler{
 		Client:           mgr.GetClient(),
 		Log:              ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
@@ -279,24 +288,6 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CassandraTask")
-		os.Exit(1)
-	}
-
-	if err := mgr.GetCache().IndexField(ctx, &corev1.Pod{}, "spec.volumes.persistentVolumeClaim.claimName", func(obj client.Object) []string {
-		pod, ok := obj.(*corev1.Pod)
-		if !ok {
-			return nil
-		}
-
-		var pvcNames []string
-		for _, volume := range pod.Spec.Volumes {
-			if volume.PersistentVolumeClaim != nil {
-				pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
-			}
-		}
-		return pvcNames
-	}); err != nil {
-		setupLog.Error(err, "unable to set up field indexer")
 		os.Exit(1)
 	}
 
@@ -335,17 +326,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := mgr.GetCache().IndexField(ctx, &corev1.Event{}, "involvedObject.name", func(obj client.Object) []string {
-		event := obj.(*corev1.Event)
-		if event.InvolvedObject.Kind == "Pod" {
-			return []string{event.InvolvedObject.Name}
-		}
-		return []string{}
-	}); err != nil {
-		setupLog.Error(err, "unable to set up event index")
-		os.Exit(1)
-	}
-
 	setupLog.Info("starting manager")
 	startErrCh := make(chan error, 1)
 	go func() {
@@ -364,6 +344,37 @@ func main() {
 	case <-ctx.Done():
 		// graceful shutdown
 	}
+}
+
+func setupCacheIndexers(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(ctx, &corev1.Pod{}, "spec.volumes.persistentVolumeClaim.claimName", func(obj client.Object) []string {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			return nil
+		}
+
+		var pvcNames []string
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil {
+				pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
+			}
+		}
+		return pvcNames
+	}); err != nil {
+		return err
+	}
+
+	if err := mgr.GetCache().IndexField(ctx, &corev1.Event{}, "involvedObject.name", func(obj client.Object) []string {
+		event := obj.(*corev1.Event)
+		if event.InvolvedObject.Kind == "Pod" {
+			return []string{event.InvolvedObject.Name}
+		}
+		return []string{}
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func setupImageRegistry(ctx context.Context, cfg *rest.Config, operConfig *configv1beta1.OperatorConfig) (images.ImageRegistry, error) {

--- a/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook.go
+++ b/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook.go
@@ -134,7 +134,11 @@ func ValidateSingleDatacenter(dc *api.CassandraDatacenter) error {
 	isCassandra3 := dc.Spec.ServerType == "cassandra" && strings.HasPrefix(dc.Spec.ServerVersion, "3.")
 
 	var c map[string]interface{}
-	_ = json.Unmarshal(dc.Spec.Config, &c)
+	if dc.Spec.Config != nil {
+		if err := json.Unmarshal(dc.Spec.Config, &c); err != nil {
+			return fmt.Errorf("unable to parse config json: %v", err)
+		}
+	}
 
 	_, hasJvmOptions := c["jvm-options"]
 	_, hasJvmServerOptions := c["jvm-server-options"]

--- a/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook_test.go
+++ b/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook_test.go
@@ -397,6 +397,48 @@ func Test_ValidateSingleDatacenter(t *testing.T) {
 			},
 			errString: "",
 		},
+		{
+			name: "Valid config should be allowed",
+			dc: &api.CassandraDatacenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exampleDC",
+				},
+				Spec: api.CassandraDatacenterSpec{
+					ServerType:    "cassandra",
+					ServerVersion: "5.0.6",
+					Config: json.RawMessage(`
+					{
+						"cassandra-yaml": {},
+						"jvm-server-options": {
+							"key1": "value1"
+						}
+					}
+					`),
+				},
+			},
+			errString: "",
+		},
+		{
+			name: "Invalid JSON/YAML in the config should be caught",
+			dc: &api.CassandraDatacenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exampleDC",
+				},
+				Spec: api.CassandraDatacenterSpec{
+					ServerType:    "cassandra",
+					ServerVersion: "5.0.6",
+					Config: json.RawMessage(`
+					{
+						"cassandra-yaml": {}
+						"jvm-server-options": {
+							"key1": "value1"
+						}
+					}
+					`),
+				},
+			},
+			errString: "unable to parse config json: invalid character '\"' after object key:value pair",
+		},
 	}
 
 	for _, tt := range tests {
@@ -962,9 +1004,9 @@ func CreateCassDc(serverType string) *api.CassandraDatacenter {
 	}
 
 	if serverType == "dse" {
-		dc.Spec.ServerVersion = "6.8.13"
+		dc.Spec.ServerVersion = "6.9.16"
 	} else {
-		dc.Spec.ServerVersion = "4.0.1"
+		dc.Spec.ServerVersion = "5.0.6"
 	}
 
 	return dc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new parameter to allow enabling/disabling /metrics auth & authz. 

Also, fix webhook not catching the error when trying to use Config parameter with broken JSON.

**Which issue(s) this PR fixes**:
Fixes #868 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
