### PR TITLE
default retry policy for cassandratask has changed to onfailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
-* [FEATURE] [#885](https://github.com/k8ssandra/cass-operator/issues/885) Add the ability to define retryCount in CassandraTasks
-* [FEATURE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) Added EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack
 * [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container
 * [CHANGE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) The default retry policy for CassandraTask has changed to OnFailure
+* [FEATURE] [#885](https://github.com/k8ssandra/cass-operator/issues/885) Add the ability to define retryCount in CassandraTasks
+* [FEATURE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) Added EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack
 * [ENHANCEMENT] [#841](https://github.com/k8ssandra/cass-operator/issues/841) Add the ability for the rolling restart to restart an entire rack at once. This speeds up the rolling restart process in a cluster that has large amount of nodes in a single rack.
 * [ENHANCEMENT] [#861](https://github.com/k8ssandra/cass-operator/issues/861) CassandraTasks have now configurable pod concurrency. maxConcurrentPods will determine how many pods in the same rack (never multiple racks) can be processed in parallel. Also, state of the processed pods is now moved to the CassandraTask status with some additional information.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [FEATURE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) Added EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack
+* [CHANGE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) The default retry policy for CassandraTask has changed to OnFailure
 * [FEATURE] [#885](https://github.com/k8ssandra/cass-operator/issues/885) Add the ability to define retryCount in CassandraTasks
 * [ENHANCEMENT] [#861](https://github.com/k8ssandra/cass-operator/issues/861) CassandraTasks have now configurable pod concurrency. maxConcurrentPods will determine how many pods in the same rack (never multiple racks) can be processed in parallel. Also, state of the processed pods is now moved to the CassandraTask status with some additional information.
 * [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
-* [FEATURE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) Added EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack
-* [CHANGE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) The default retry policy for CassandraTask has changed to OnFailure
 * [FEATURE] [#885](https://github.com/k8ssandra/cass-operator/issues/885) Add the ability to define retryCount in CassandraTasks
-* [ENHANCEMENT] [#861](https://github.com/k8ssandra/cass-operator/issues/861) CassandraTasks have now configurable pod concurrency. maxConcurrentPods will determine how many pods in the same rack (never multiple racks) can be processed in parallel. Also, state of the processed pods is now moved to the CassandraTask status with some additional information.
+* [FEATURE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) Added EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack
 * [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container
+* [CHANGE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) The default retry policy for CassandraTask has changed to OnFailure
 * [ENHANCEMENT] [#841](https://github.com/k8ssandra/cass-operator/issues/841) Add the ability for the rolling restart to restart an entire rack at once. This speeds up the rolling restart process in a cluster that has large amount of nodes in a single rack.
+* [ENHANCEMENT] [#861](https://github.com/k8ssandra/cass-operator/issues/861) CassandraTasks have now configurable pod concurrency. maxConcurrentPods will determine how many pods in the same rack (never multiple racks) can be processed in parallel. Also, state of the processed pods is now moved to the CassandraTask status with some additional information.
 
 ## v1.28.1
 

--- a/apis/control/v1alpha1/cassandratask_types.go
+++ b/apis/control/v1alpha1/cassandratask_types.go
@@ -48,7 +48,7 @@ type CassandraTaskTemplate struct {
 	// Jobs defines the jobs this task will execute (and their order)
 	Jobs []CassandraJob `json:"jobs,omitempty"`
 
-	// RestartPolicy indicates the behavior n case of failure. Default is Never.
+	// RestartPolicy indicates the behavior n case of failure. Default is OnFailure.
 	// +optional
 	RestartPolicy corev1.RestartPolicy `json:"restartPolicy,omitempty"`
 

--- a/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_cassandratasks.yaml
@@ -183,7 +183,7 @@ spec:
                 type: integer
               restartPolicy:
                 description: RestartPolicy indicates the behavior n case of failure.
-                  Default is Never.
+                  Default is OnFailure.
                 type: string
               retries:
                 description: |-

--- a/config/crd/bases/control.k8ssandra.io_scheduledtasks.yaml
+++ b/config/crd/bases/control.k8ssandra.io_scheduledtasks.yaml
@@ -171,7 +171,7 @@ spec:
                     type: string
                   restartPolicy:
                     description: RestartPolicy indicates the behavior n case of failure.
-                      Default is Never.
+                      Default is OnFailure.
                     type: string
                   retries:
                     description: |-

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -371,7 +371,7 @@ func setDefaults(cassTask *api.CassandraTask) {
 	}
 
 	if cassTask.Spec.RestartPolicy == "" {
-		cassTask.Spec.RestartPolicy = corev1.RestartPolicyNever
+		cassTask.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 	}
 
 	if cassTask.Spec.ConcurrencyPolicy == "" {

--- a/internal/controllers/control/cassandratask_controller_test.go
+++ b/internal/controllers/control/cassandratask_controller_test.go
@@ -592,7 +592,9 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 			It("Runs a cleanup task against the datacenter pods", func() {
 				By("Creating a task for cleanup")
-				taskKey := createTask(api.CommandCleanup, testNamespaceName)
+				taskKey, task := buildTask(api.CommandCleanup, testNamespaceName)
+				task.Spec.RestartPolicy = corev1.RestartPolicyNever
+				Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
 				completedTask := waitForTaskCompletion(taskKey)
 
@@ -606,7 +608,9 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 			It("Runs a upgradesstables task against the datacenter pods", func() {
 				By("Creating a task for upgradesstables")
-				taskKey := createTask(api.CommandUpgradeSSTables, testNamespaceName)
+				taskKey, task := buildTask(api.CommandUpgradeSSTables, testNamespaceName)
+				task.Spec.RestartPolicy = corev1.RestartPolicyNever
+				Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
 				completedTask := waitForTaskCompletion(taskKey)
 
@@ -650,6 +654,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 				By("Creating a task for flush")
 				taskKey, task := buildTask(api.CommandFlush, testNamespaceName)
 				task.Spec.Jobs[0].Arguments.KeyspaceName = "ks1"
+				task.Spec.RestartPolicy = corev1.RestartPolicyNever
 				Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
 				completedTask := waitForTaskCompletion(taskKey)
@@ -666,6 +671,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 				By("Creating a task for garbagecollect")
 				taskKey, task := buildTask(api.CommandGarbageCollect, testNamespaceName)
 				task.Spec.Jobs[0].Arguments.KeyspaceName = "ks1"
+				task.Spec.RestartPolicy = corev1.RestartPolicyNever
 				Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
 				completedTask := waitForTaskCompletion(taskKey)

--- a/internal/controllers/control/cassandratask_controller_test.go
+++ b/internal/controllers/control/cassandratask_controller_test.go
@@ -474,30 +474,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 		})
 		Context("Failing jobs", func() {
 			When("In a datacenter", func() {
-				It("Should fail once when no retryPolicy is set", func() {
-					By("Creating fake mgmt-api server")
-					callDetails := httphelper.NewCallDetails()
-					mockServer, err := httphelper.FakeExecutorServerWithDetailsFails(callDetails)
-					testFailedNamespaceName := fmt.Sprintf("test-task-failed-%d", rand.Int31())
-					Expect(err).ToNot(HaveOccurred())
-					mockServer.Start()
-					defer mockServer.Close()
-
-					By("create datacenter", createDatacenter("dc1", testFailedNamespaceName))
-					By("Create a task for cleanup")
-					taskKey := createTask(api.CommandCleanup, testFailedNamespaceName)
-
-					completedTask := waitForTaskCompletion(taskKey)
-
-					Expect(callDetails.URLCounts["/api/v1/ops/keyspace/cleanup"]).To(Equal(nodeCount))
-					Expect(callDetails.URLCounts["/api/v0/ops/executor/job"]).To(BeNumerically(">=", nodeCount))
-					Expect(callDetails.URLCounts["/api/v0/metadata/versions/features"]).To(BeNumerically(">=", nodeCount))
-
-					Expect(completedTask.Status.Failed).To(BeNumerically("==", nodeCount))
-					Expect(completedTask.Status.Conditions[2].Type).To(Equal(string(api.JobFailed)))
-					Expect(completedTask.Status.Conditions[2].Message).To(Equal("9 pods failed during processing"))
-				})
-				It("If retryPolicy is set, we should see a retry", func() {
+				It("If retryPolicy is not set, should use OnFailure by default", func() {
 					By("Creating fake mgmt-api server")
 					callDetails := httphelper.NewCallDetails()
 					mockServer, err := httphelper.FakeExecutorServerWithDetailsFails(callDetails)
@@ -509,7 +486,6 @@ var _ = Describe("CassandraTask controller tests", func() {
 					By("create datacenter", createDatacenter("dc1", testFailedNamespaceName))
 					By("Creating a task for cleanup")
 					taskKey, task := buildTask(api.CommandCleanup, testFailedNamespaceName)
-					task.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 					Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
 
 					completedTask := waitForTaskCompletion(taskKey)
@@ -518,6 +494,31 @@ var _ = Describe("CassandraTask controller tests", func() {
 					Expect(callDetails.URLCounts["/api/v1/ops/keyspace/cleanup"]).To(Equal(2 * nodeCount))
 					Expect(callDetails.URLCounts["/api/v0/ops/executor/job"]).To(BeNumerically(">=", 2*nodeCount))
 					Expect(callDetails.URLCounts["/api/v0/metadata/versions/features"]).To(BeNumerically(">=", 2*nodeCount))
+
+					Expect(completedTask.Status.Failed).To(BeNumerically("==", nodeCount))
+					Expect(completedTask.Status.Conditions[2].Type).To(Equal(string(api.JobFailed)))
+					Expect(completedTask.Status.Conditions[2].Message).To(Equal("9 pods failed during processing"))
+				})
+				It("Should run once when retryPolicy is Never", func() {
+					By("Creating fake mgmt-api server")
+					callDetails := httphelper.NewCallDetails()
+					mockServer, err := httphelper.FakeExecutorServerWithDetailsFails(callDetails)
+					testFailedNamespaceName := fmt.Sprintf("test-task-failed-%d", rand.Int31())
+					Expect(err).ToNot(HaveOccurred())
+					mockServer.Start()
+					defer mockServer.Close()
+
+					By("create datacenter", createDatacenter("dc1", testFailedNamespaceName))
+					By("Create a task for cleanup")
+					taskKey, task := buildTask(api.CommandCleanup, testFailedNamespaceName)
+					task.Spec.RestartPolicy = corev1.RestartPolicyNever
+					Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
+
+					completedTask := waitForTaskCompletion(taskKey)
+
+					Expect(callDetails.URLCounts["/api/v1/ops/keyspace/cleanup"]).To(Equal(nodeCount))
+					Expect(callDetails.URLCounts["/api/v0/ops/executor/job"]).To(BeNumerically(">=", nodeCount))
+					Expect(callDetails.URLCounts["/api/v0/metadata/versions/features"]).To(BeNumerically(">=", nodeCount))
 
 					Expect(completedTask.Status.Failed).To(BeNumerically("==", nodeCount))
 					Expect(completedTask.Status.Conditions[2].Type).To(Equal(string(api.JobFailed)))

--- a/internal/controllers/control/cassandratask_controller_test.go
+++ b/internal/controllers/control/cassandratask_controller_test.go
@@ -485,8 +485,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 					By("create datacenter", createDatacenter("dc1", testFailedNamespaceName))
 					By("Creating a task for cleanup")
-					taskKey, task := buildTask(api.CommandCleanup, testFailedNamespaceName)
-					Expect(k8sClient.Create(context.Background(), task)).Should(Succeed())
+					taskKey := createTask(api.CommandCleanup, testFailedNamespaceName)
 
 					completedTask := waitForTaskCompletion(taskKey)
 

--- a/tests/scheduled_task/scheduled_task_suite_test.go
+++ b/tests/scheduled_task/scheduled_task_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/k8ssandra/cass-operator/tests/kustomize"
 	ginkgo_util "github.com/k8ssandra/cass-operator/tests/util/ginkgo"
@@ -90,6 +91,12 @@ var _ = Describe(testName, func() {
 				WithLabel(dcLabel).
 				FormatOutput(json)
 			ns.WaitForOutputAndLog(step, k, dcName, 60)
+
+			step = "verify CassandraTask has RestartPolicy OnFailure by default"
+			json = "jsonpath={.items[0].spec.restartPolicy}"
+			k = kubectl.Get("CassandraTask").FormatOutput(json)
+			restartPolicy := ns.OutputAndLog(step, k)
+			Expect(restartPolicy).To(BeEquivalentTo(string(corev1.RestartPolicyOnFailure)))
 
 			step = "verify LastExecution is updated after task completion"
 			json = "jsonpath={.status.lastExecution}"


### PR DESCRIPTION
**What this PR does**:
- It changes default retry policy for `CassandraTask` CRD to OnFailure

**Which issue(s) this PR fixes**:
Fixes #850 

**Checklist**
- [x] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
