### PR TITLE
Per rack clenup annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [FEATURE] [#850](https://github.com/k8ssandra/cass-operator/issues/850) Added EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack
 * [FEATURE] [#885](https://github.com/k8ssandra/cass-operator/issues/885) Add the ability to define retryCount in CassandraTasks
 * [ENHANCEMENT] [#861](https://github.com/k8ssandra/cass-operator/issues/861) CassandraTasks have now configurable pod concurrency. maxConcurrentPods will determine how many pods in the same rack (never multiple racks) can be processed in parallel. Also, state of the processed pods is now moved to the CassandraTask status with some additional information.
 * [CHANGE] [#865](https://github.com/k8ssandra/cass-operator/issues/865) Add VolumeMount for the management-api-server-certs-volume volume to all containers instead of only cassandra container

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -84,6 +84,9 @@ const (
 	// Allow disabling the creation of PodDisruptionBudget for the datacenter
 	DisablePodDisruptionBudgetAnnotation = "cassandra.datastax.com/disable-pdb-creation"
 
+	// EnableParallelCleanupWithinRackAnnotation speeds up post-scale-out cleanup by processing nodes in parallel within a rack.
+	EnableParallelCleanupWithinRackAnnotation = "cassandra.datastax.com/enable-parallel-cleanup-within-rack"
+
 	AllowUpdateAlways AllowUpdateType = "always"
 	AllowUpdateOnce   AllowUpdateType = "once"
 

--- a/config/samples/example-cassandradatacenter-full.yaml
+++ b/config/samples/example-cassandradatacenter-full.yaml
@@ -29,6 +29,8 @@ metadata:
     cassandra.datastax.com/delete-pvc: "true"
     # Disable PDB creation for this datacenter.
     cassandra.datastax.com/disable-pdb-creation: "false"
+    # Speeds up post-scale-out cleanup by processing nodes in parallel within a rack.
+    cassandra.datastax.com/enable-parallel-cleanup-within-rack: "false"
 spec:
   # Desired number of Cassandra nodes.
   size: 9

--- a/config/samples/example-cassandratask-full.yaml
+++ b/config/samples/example-cassandratask-full.yaml
@@ -14,7 +14,7 @@ spec:
   # Run the task no earlier than this time (omit to start immediately).
   scheduledTime: "2024-06-01T12:00:00Z"
   # Restart policy for the Job pods spawned by this task (Never | OnFailure).
-  restartPolicy: Never
+  restartPolicy: OnFailure
   # Cleanup TTL in seconds after task completion (0 disables auto-cleanup).
   ttlSecondsAfterFinished: 86400
   # Concurrency policy for tasks running against the same cluster (Allow | Forbid).

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2506,17 +2506,8 @@ func (rc *ReconciliationContext) createCleanupTask() error {
 	return rc.Client.Status().Patch(rc.Ctx, dc, dcPatch)
 }
 
-//func (rc *ReconciliationContext) calculateMaxConcurrentPods() *int {
-//	return ptr.To(rc.desiredRackInformation[0].NodeCount) // we have validation above, not sure if we need to check length
-//}
-
 func (rc *ReconciliationContext) calculateMaxConcurrentPods() *int {
-	var maxConcurrentPods *int
-	rackInfos := rc.desiredRackInformation
-	if len(rackInfos) > 0 {
-		maxConcurrentPods = ptr.To(rackInfos[0].NodeCount)
-	}
-	return maxConcurrentPods
+	return ptr.To(rc.desiredRackInformation[0].NodeCount)
 }
 
 func (rc *ReconciliationContext) activeTaskCompleted(task *taskapi.CassandraTask) result.ReconcileResult {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -2443,7 +2444,7 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 		}
 
 		// Create the cleanup task
-		if err := rc.createTask(taskapi.CommandCleanup); err != nil {
+		if err := rc.createCleanupTask(); err != nil {
 			return result.Error(err)
 		}
 
@@ -2455,9 +2456,14 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 	return result.Continue()
 }
 
-func (rc *ReconciliationContext) createTask(command taskapi.CassandraCommand) error {
-	generatedName := fmt.Sprintf("%s-%d", command, time.Now().Unix())
+func (rc *ReconciliationContext) createCleanupTask() error {
+	generatedName := fmt.Sprintf("%s-%d", taskapi.CommandCleanup, time.Now().Unix())
 	dc := rc.Datacenter
+
+	var maxConcurrentPods *int
+	if metav1.HasAnnotation(rc.Datacenter.ObjectMeta, api.EnableParallelCleanupWithinRackAnnotation) {
+		maxConcurrentPods = rc.calculateMaxConcurrentPods()
+	}
 
 	task := &taskapi.CassandraTask{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2473,10 +2479,11 @@ func (rc *ReconciliationContext) createTask(command taskapi.CassandraCommand) er
 			CassandraTaskTemplate: taskapi.CassandraTaskTemplate{
 				Jobs: []taskapi.CassandraJob{
 					{
-						Name:    fmt.Sprintf("%s-%s", command, rc.Datacenter.Name),
-						Command: command,
+						Name:    fmt.Sprintf("%s-%s", taskapi.CommandCleanup, rc.Datacenter.Name),
+						Command: taskapi.CommandCleanup,
 					},
 				},
+				MaxConcurrentPods: maxConcurrentPods,
 			},
 		},
 		Status: taskapi.CassandraTaskStatus{},
@@ -2497,6 +2504,19 @@ func (rc *ReconciliationContext) createTask(command taskapi.CassandraCommand) er
 	rc.Datacenter.Status.AddTaskToTrack(task.ObjectMeta)
 
 	return rc.Client.Status().Patch(rc.Ctx, dc, dcPatch)
+}
+
+//func (rc *ReconciliationContext) calculateMaxConcurrentPods() *int {
+//	return ptr.To(rc.desiredRackInformation[0].NodeCount) // we have validation above, not sure if we need to check length
+//}
+
+func (rc *ReconciliationContext) calculateMaxConcurrentPods() *int {
+	var maxConcurrentPods *int
+	rackInfos := rc.desiredRackInformation
+	if len(rackInfos) > 0 {
+		maxConcurrentPods = ptr.To(rackInfos[0].NodeCount)
+	}
+	return maxConcurrentPods
 }
 
 func (rc *ReconciliationContext) activeTaskCompleted(task *taskapi.CassandraTask) result.ReconcileResult {

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1849,6 +1849,7 @@ func TestCleanupAfterScaling(t *testing.T) {
 	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
 	assert.Equal(taskapi.CommandCleanup, task.Spec.Jobs[0].Command)
 	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
+	assert.Nil(task.Spec.MaxConcurrentPods)
 }
 
 func TestCleanupAfterScalingWithTracker(t *testing.T) {
@@ -1891,6 +1892,33 @@ func TestCleanupAfterScalingWithTracker(t *testing.T) {
 	r = rc.cleanupAfterScaling()
 	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
 	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
+	assert.Nil(task.Spec.MaxConcurrentPods)
+}
+
+func TestCleanupAfterScalingWithParallelAnnotation(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	assert := assert.New(t)
+
+	mockClient := mocks.NewClient(t)
+	rc.Client = mockClient
+	_ = rc.CalculateRackInformation()
+	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.EnableParallelCleanupWithinRackAnnotation, "true")
+
+	var task *taskapi.CassandraTask
+	// 1. Create task - return ok
+	k8sMockClientCreate(rc.Client.(*mocks.Client), nil).
+		Run(func(args mock.Arguments) {
+			arg := args.Get(1).(*taskapi.CassandraTask)
+			task = arg
+		}).
+		Times(1)
+
+	r := rc.cleanupAfterScaling()
+	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
+	assert.Equal(taskapi.CommandCleanup, task.Spec.Jobs[0].Command)
+	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
+	assert.Equal(*task.Spec.MaxConcurrentPods, rc.desiredRackInformation[0].NodeCount)
 }
 
 func TestStripPassword(t *testing.T) {

--- a/tests/scale_up/scale_up_suite_test.go
+++ b/tests/scale_up/scale_up_suite_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/k8ssandra/cass-operator/tests/kustomize"
@@ -111,10 +110,30 @@ var _ = Describe(testName, func() {
 			// Also verify that we have exactly 3 tasks, no more
 			ns.CheckForCassandraTasks(dcName, "cleanup", false, 3)
 
+			step = "add annotation to enable parallel cleanup within rack"
+			json = "{\"metadata\": {\"annotations\": {\"cassandra.datastax.com/enable-parallel-cleanup-within-rack\": \"true\"}}}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
+			ns.WaitForDatacenterReady(dcName)
+
+			step = "scale up to 6 nodes"
+			json = "{\"spec\": {\"size\": 6}}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
+			ns.WaitForDatacenterReady(dcName)
+
+			step = fmt.Sprintf("checking that cassandratask has expected number of maxConcurrentPods")
+			json = "jsonpath={.items[?(@.spec.maxConcurrentPods)].spec.maxConcurrentPods}"
+			k = kubectl.Get("cassandratask").
+				WithLabel(fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "6", 20)
+			ns.WaitForCompletedCassandraTasks(dcName, "cleanup", 4)
+
 			step = "check recorded host IDs"
 			ns.Log(step)
 			nodeStatusesHostIds := ns.GetNodeStatusesHostIds(dcName)
-			Expect(nodeStatusesHostIds).To(HaveLen(5))
+			Expect(nodeStatusesHostIds).To(HaveLen(6))
 
 			step = "deleting the dc"
 			k = kubectl.DeleteFromFiles(testFile)

--- a/tests/scale_up/scale_up_suite_test.go
+++ b/tests/scale_up/scale_up_suite_test.go
@@ -122,7 +122,7 @@ var _ = Describe(testName, func() {
 			ns.ExecAndLog(step, k)
 			ns.WaitForDatacenterReady(dcName)
 
-			step = fmt.Sprintf("checking that cassandratask has expected number of maxConcurrentPods")
+			step = "checking that cassandratask has expected number of maxConcurrentPods"
 			json = "jsonpath={.items[?(@.spec.maxConcurrentPods)].spec.maxConcurrentPods}"
 			k = kubectl.Get("cassandratask").
 				WithLabel(fmt.Sprintf("cassandra.datastax.com/datacenter=%s", dcName)).


### PR DESCRIPTION
**What this PR does**:
- Adds EnableParallelCleanupWithinRack annotation which speeds up post-scale-out cleanup by processing nodes in parallel within a rack


**Which issue(s) this PR fixes**:
Fixes #850 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
