### PR TITLE
prevent infinite loop when seed refresh times out during node failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#887](https://github.com/k8ssandra/cass-operator/issues/887) Prevents infinite loop when seed refresh times out during node failures, allowing the operator to recover.
+
 ## v1.29.0
 
 * [CHANGE] [#875](https://github.com/k8ssandra/cass-operator/issues/875) Update to Go 1.25, Kubernetes 1.34 and UBI10 as the base image. Also, Vector to 0.53.0 and other smaller dependency updates. Deprecate CDC support.

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -704,18 +704,21 @@ func (rc *ReconciliationContext) CheckRackStoppedState() result.ReconcileResult 
 }
 
 // checkSeedLabels loops over all racks and makes sure that the proper pods are labelled as seeds.
-func (rc *ReconciliationContext) checkSeedLabels() (int, error) {
+func (rc *ReconciliationContext) checkSeedLabels() (seedCount int, didSeedsChange bool, err error) {
 	rc.ReqLogger.Info("reconcile_racks::CheckSeedLabels")
-	seedCount := 0
+	seedCount = 0
 	for idx := range rc.desiredRackInformation {
 		rackInfo := rc.desiredRackInformation[idx]
-		n, err := rc.labelSeedPods(rackInfo)
+		n, didRackSeedsChange, err := rc.labelSeedPods(rackInfo)
 		seedCount += n
 		if err != nil {
-			return 0, err
+			return 0, false, err
+		}
+		if didRackSeedsChange {
+			didSeedsChange = true
 		}
 	}
-	return seedCount, nil
+	return seedCount, didSeedsChange, nil
 }
 
 func shouldUseFastPath(dc *api.CassandraDatacenter, seedCount int) bool {
@@ -759,17 +762,15 @@ func (rc *ReconciliationContext) CheckPodsReady(endpointData httphelper.CassMeta
 
 	// get the nodes labelled as seeds before we start any nodes
 
-	seedCount, err := rc.checkSeedLabels()
+	seedCount, didSeedsChange, err := rc.checkSeedLabels()
 	if err != nil {
 		return result.Error(err)
 	}
-	err = rc.refreshSeeds()
-	if err != nil {
-		rc.ReqLogger.Error(err,
-			"failed to refresh seeds, but continuing reconciliation",
-			"seedCount", seedCount,
-			"totalPods", len(rc.dcPods),
-		)
+	if didSeedsChange {
+		err = rc.refreshSeeds()
+		if err != nil {
+			return result.Error(err)
+		}
 	}
 
 	// step 0 - fastpath
@@ -1480,8 +1481,8 @@ func (rc *ReconciliationContext) isClusterHealthy() bool {
 
 // labelSeedPods iterates over all pods for a statefulset and makes sure the right number of
 // ready pods are labelled as seeds, so that they are picked up by the headless seed service
-// Returns the number of ready seeds.
-func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, error) {
+// Returns the number of ready seeds and informs if rack seeds were updated.
+func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (count int, didSeedsChange bool, err error) {
 	logger := rc.ReqLogger.WithName("labelSeedPods")
 
 	rackPods := rc.rackPods(rackInfo.RackName)
@@ -1489,7 +1490,7 @@ func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, 
 	sort.SliceStable(rackPods, func(i, j int) bool {
 		return rackPods[i].Name < rackPods[j].Name
 	})
-	count := 0
+	count = 0
 	for _, pod := range rackPods {
 		patch := client.MergeFrom(pod.DeepCopy())
 
@@ -1528,16 +1529,17 @@ func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, 
 		}
 
 		if shouldUpdate {
+			didSeedsChange = true
 			pod.SetLabels(newLabels)
 			if err := rc.Client.Patch(rc.Ctx, pod, patch); err != nil {
 				logger.Error(
 					err, "Unable to update pod with seed label",
 					"pod", pod.Name)
-				return 0, err
+				return 0, false, err
 			}
 		}
 	}
-	return count, nil
+	return count, didSeedsChange, nil
 }
 
 // GetStatefulSetForRack returns the statefulset for the rack

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -502,7 +502,7 @@ func (rc *ReconciliationContext) CheckRackPodTemplateDetails(force bool, failedR
 			desiredSts.DeepCopyInto(statefulSet)
 
 			rc.Recorder.Eventf(rc.Datacenter, corev1.EventTypeNormal, events.UpdatingRack,
-				"Updating rack %s", rackName, "force", force)
+				"Updating rack %s force=%t", rackName, force)
 
 			if err := rc.setConditionStatus(api.DatacenterUpdating, corev1.ConditionTrue); err != nil {
 				return result.Error(err)

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -765,7 +765,11 @@ func (rc *ReconciliationContext) CheckPodsReady(endpointData httphelper.CassMeta
 	}
 	err = rc.refreshSeeds()
 	if err != nil {
-		return result.Error(err)
+		rc.ReqLogger.Error(err,
+			"failed to refresh seeds, but continuing reconciliation",
+			"seedCount", seedCount,
+			"totalPods", len(rc.dcPods),
+		)
 	}
 
 	// step 0 - fastpath
@@ -2139,6 +2143,13 @@ func (rc *ReconciliationContext) createStartSequence() []*corev1.Pod {
 		for podRankWithinRack := maxPodRankInThisRack; podRankWithinRack >= 0; podRankWithinRack-- {
 			podName := getStatefulSetPodNameForIdx(statefulSet, int32(podRankWithinRack))
 			pod := rc.getDCPodByName(podName)
+			if pod == nil {
+				rc.ReqLogger.Info("pod not found in datacenter pod list, skipping",
+					"podName", podName,
+					"rack", rackInfo.RackName,
+					"reason", "pod may be terminating or StatefulSet controller hasn't caught up")
+				continue
+			}
 			if !isServerReady(pod) {
 				if isServerReadyToStart(pod) && isMgmtApiRunning(pod) {
 					if utils.IndexOfString(rc.Datacenter.Status.FailedStarts, podName) > -1 {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -41,6 +41,8 @@ var (
 	ResultShouldRequeueSoon reconcile.Result = reconcile.Result{RequeueAfter: 2 * time.Second}
 
 	QuietDurationFunc func(int) time.Duration = func(secs int) time.Duration { return time.Duration(secs) * time.Second }
+
+	errPodNotFound = fmt.Errorf("pod not found, most likely statefulset controller has not caught up yet")
 )
 
 const (
@@ -704,9 +706,11 @@ func (rc *ReconciliationContext) CheckRackStoppedState() result.ReconcileResult 
 }
 
 // checkSeedLabels loops over all racks and makes sure that the proper pods are labelled as seeds.
-func (rc *ReconciliationContext) checkSeedLabels() (seedCount int, didSeedsChange bool, err error) {
+// Returns the number of ready seeds across all racks and informs whether seed labels changed.
+func (rc *ReconciliationContext) checkSeedLabels() (int, bool, error) {
 	rc.ReqLogger.Info("reconcile_racks::CheckSeedLabels")
-	seedCount = 0
+	didSeedsChange := false
+	seedCount := 0
 	for idx := range rc.desiredRackInformation {
 		rackInfo := rc.desiredRackInformation[idx]
 		n, didRackSeedsChange, err := rc.labelSeedPods(rackInfo)
@@ -1481,8 +1485,8 @@ func (rc *ReconciliationContext) isClusterHealthy() bool {
 
 // labelSeedPods iterates over all pods for a statefulset and makes sure the right number of
 // ready pods are labelled as seeds, so that they are picked up by the headless seed service
-// Returns the number of ready seeds and informs if rack seeds were updated.
-func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (count int, didSeedsChange bool, err error) {
+// Returns the number of ready seeds and informs whether rack seeds were changed.
+func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (int, bool, error) {
 	logger := rc.ReqLogger.WithName("labelSeedPods")
 
 	rackPods := rc.rackPods(rackInfo.RackName)
@@ -1490,7 +1494,8 @@ func (rc *ReconciliationContext) labelSeedPods(rackInfo *RackInformation) (count
 	sort.SliceStable(rackPods, func(i, j int) bool {
 		return rackPods[i].Name < rackPods[j].Name
 	})
-	count = 0
+	count := 0
+	didSeedsChange := false
 	for _, pod := range rackPods {
 		patch := client.MergeFrom(pod.DeepCopy())
 
@@ -2086,7 +2091,7 @@ RackLoop:
 			podName := getStatefulSetPodNameForIdx(statefulSet, int32(maxPodRankInThisRack))
 			pod := rc.getDCPodByName(podName)
 			if pod == nil {
-				return false, fmt.Errorf("pod %s not found, most likely statefulset controller has not caught up yet", podName)
+				return false, fmt.Errorf("pod %s: %w", podName, errPodNotFound)
 			}
 			if !isServerReady(pod) {
 				if isServerReadyToStart(pod) && isMgmtApiRunning(pod) {
@@ -2120,7 +2125,10 @@ RackLoop:
 func (rc *ReconciliationContext) startAllNodes(endpointData httphelper.CassMetadataEndpoints) (bool, error) {
 	rc.ReqLogger.Info("reconcile_racks::startAllNodes")
 
-	podsToStart := rc.createStartSequence()
+	podsToStart, err := rc.createStartSequence()
+	if err != nil {
+		return false, fmt.Errorf("failed to create start sequence: %w", err)
+	}
 	for _, pod := range podsToStart {
 		notReady, err := rc.startNode(pod, false, endpointData)
 		if notReady || err != nil {
@@ -2131,7 +2139,7 @@ func (rc *ReconciliationContext) startAllNodes(endpointData httphelper.CassMetad
 	return false, nil
 }
 
-func (rc *ReconciliationContext) createStartSequence() []*corev1.Pod {
+func (rc *ReconciliationContext) createStartSequence() ([]*corev1.Pod, error) {
 	rc.ReqLogger.Info("reconcile_racks::createStartSequence")
 
 	pods := make([]*corev1.Pod, 0)
@@ -2146,11 +2154,7 @@ func (rc *ReconciliationContext) createStartSequence() []*corev1.Pod {
 			podName := getStatefulSetPodNameForIdx(statefulSet, int32(podRankWithinRack))
 			pod := rc.getDCPodByName(podName)
 			if pod == nil {
-				rc.ReqLogger.Info("pod not found in datacenter pod list, skipping",
-					"podName", podName,
-					"rack", rackInfo.RackName,
-					"reason", "pod may be terminating or StatefulSet controller hasn't caught up")
-				continue
+				return nil, fmt.Errorf("pod %s: %w", podName, errPodNotFound)
 			}
 			if !isServerReady(pod) {
 				if isServerReadyToStart(pod) && isMgmtApiRunning(pod) {
@@ -2181,7 +2185,7 @@ func (rc *ReconciliationContext) createStartSequence() []*corev1.Pod {
 	sort.Slice(failedPods, podSortFunc)
 	pods = append(pods, failedPods...)
 
-	return pods
+	return pods, nil
 }
 
 // hasAdditionalSeeds returns true if the datacenter has at least one additional seed.

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -4159,8 +4159,8 @@ func TestCheckDcPodDisruptionBudget(t *testing.T) {
 func TestRefreshSeeds(t *testing.T) {
 	assert := assert.New(t)
 	const (
-		initialSeedCount = 3
-		updatedSeedCount = 1 // Triggers seed list change detection
+		initialSeedCount = 3 // all 3 pods labeled as seeds
+		reducedSeedCount = 1 // reducing to 1 triggers seed refresh across datacenter
 	)
 	prepareReconciliationCtx := func() (*ReconciliationContext, httphelper.CassMetadataEndpoints, func()) {
 		rc, _, cleanupMockScr := setupTest()
@@ -4210,9 +4210,7 @@ func TestRefreshSeeds(t *testing.T) {
 	t.Run("Seeds have changed, refreshSeeds is executed", func(t *testing.T) {
 		rc, epData, cleanup := prepareReconciliationCtx()
 		defer cleanup()
-
-		rc.desiredRackInformation[0].SeedCount = updatedSeedCount
-
+		rc.desiredRackInformation[0].SeedCount = reducedSeedCount
 		successResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader("OK")),
@@ -4272,7 +4270,7 @@ func TestRefreshSeeds(t *testing.T) {
 	t.Run("Seeds have changed, but refreshSeeds fails", func(t *testing.T) {
 		rc, epData, cleanup := prepareReconciliationCtx()
 		defer cleanup()
-		rc.desiredRackInformation[0].SeedCount = updatedSeedCount
+		rc.desiredRackInformation[0].SeedCount = reducedSeedCount
 		respError := errors.New("internal error")
 		mockHttpClient := mocks.NewHttpClient(t)
 		mockHttpClient.On("Do",

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -2369,6 +2369,7 @@ func TestStartingSequenceBuilder(t *testing.T) {
 	type podStart struct {
 		started      bool
 		failedStarts int
+		missing      bool
 	}
 
 	pod := func(started bool) podStart {
@@ -2379,12 +2380,17 @@ func TestStartingSequenceBuilder(t *testing.T) {
 		return podStart{started: started, failedStarts: failedStarts}
 	}
 
+	podMissing := func() podStart {
+		return podStart{missing: true}
+	}
+
 	type racks map[string][]podStart
 
 	tests := []struct {
 		name  string
 		racks racks
 		want  []string
+		err   error
 	}{
 		{
 			name: "balanced racks, all started",
@@ -2440,6 +2446,25 @@ func TestStartingSequenceBuilder(t *testing.T) {
 			},
 			want: []string{"rack3-1", "rack2-0"},
 		},
+		{
+			name: "unbalanced racks, some pods not started",
+			racks: racks{
+				"rack1": {pod(true), pod(true), pod(true)},
+				"rack2": {pod(false), pod(true)},
+				"rack3": {pod(true), pod(false), pod(true)},
+			},
+			want: []string{"rack3-1", "rack2-0"},
+		},
+		{
+			name: "balanced racks, some of the pods not found",
+			racks: racks{
+				"rack1": {pod(true), pod(true), podMissing()},
+				"rack2": {pod(true), pod(true), pod(true)},
+				"rack3": {pod(true), pod(true), pod(true)},
+			},
+			want: []string{},
+			err:  fmt.Errorf("pod %s: %w", "rack1-2", errPodNotFound),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2481,15 +2506,18 @@ func TestStartingSequenceBuilder(t *testing.T) {
 					if pod.failedStarts > 0 {
 						rc.Datacenter.Status.FailedStarts = append(rc.Datacenter.Status.FailedStarts, p.Name)
 					}
-					rc.dcPods = append(rc.dcPods, p)
+					if !pod.missing {
+						rc.dcPods = append(rc.dcPods, p)
+					}
 				}
 			}
-			podStartingSeq := rc.createStartSequence()
+			podStartingSeq, err := rc.createStartSequence()
 			got := []string{}
 			for _, pod := range podStartingSeq {
 				got = append(got, pod.Name)
 			}
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.err, err)
 		})
 	}
 }
@@ -4158,10 +4186,8 @@ func TestCheckDcPodDisruptionBudget(t *testing.T) {
 
 func TestRefreshSeeds(t *testing.T) {
 	assert := assert.New(t)
-	const (
-		initialSeedCount = 3 // all 3 pods labeled as seeds
-		reducedSeedCount = 1 // reducing to 1 triggers seed refresh across datacenter
-	)
+	initialSeedCount := 3 // all 3 pods labeled as seeds
+	reducedSeedCount := 1 // reducing to 1 triggers seed refresh across datacenter
 	prepareReconciliationCtx := func() (*ReconciliationContext, httphelper.CassMetadataEndpoints, func()) {
 		rc, _, cleanupMockScr := setupTest()
 		desiredStatefulSet, _ := newStatefulSetForCassandraDatacenter(

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -4155,3 +4155,141 @@ func TestCheckDcPodDisruptionBudget(t *testing.T) {
 	pdb = &policyv1.PodDisruptionBudget{}
 	require.NoError(rc.Client.Get(rc.Ctx, pdbName, pdb))
 }
+
+func TestRefreshSeeds(t *testing.T) {
+	assert := assert.New(t)
+	const (
+		initialSeedCount = 3
+		updatedSeedCount = 1 // Triggers seed list change detection
+	)
+	prepareReconciliationCtx := func() (*ReconciliationContext, httphelper.CassMetadataEndpoints, func()) {
+		rc, _, cleanupMockScr := setupTest()
+		desiredStatefulSet, _ := newStatefulSetForCassandraDatacenter(
+			nil,
+			"default",
+			rc.Datacenter,
+			initialSeedCount,
+			imageRegistry)
+		desiredStatefulSet.Status.ReadyReplicas = *desiredStatefulSet.Spec.Replicas
+		trackObjects := []runtime.Object{
+			desiredStatefulSet,
+			rc.Datacenter,
+		}
+		mockPods := mockReadyPodsForStatefulSet(desiredStatefulSet, rc.Datacenter.Spec.ClusterName, rc.Datacenter.Name)
+		for idx := range mockPods {
+			mp := mockPods[idx]
+			metav1.SetMetaDataLabel(&mp.ObjectMeta, api.SeedNodeLabel, "true")
+			trackObjects = append(trackObjects, mp)
+		}
+		rc.Client = fake.NewClientBuilder().WithStatusSubresource(rc.Datacenter).WithRuntimeObjects(trackObjects...).Build()
+		epData := httphelper.CassMetadataEndpoints{
+			Entity: []httphelper.EndpointState{},
+		}
+		for i := 0; i < int(*desiredStatefulSet.Spec.Replicas); i++ {
+			ep := httphelper.EndpointState{
+				RpcAddress: fmt.Sprintf("192.168.1.%d", i+1),
+				Status:     "UN",
+			}
+			epData.Entity = append(epData.Entity, ep)
+		}
+
+		nextRack := &RackInformation{}
+		nextRack.RackName = desiredStatefulSet.Labels[api.RackLabel]
+		nextRack.NodeCount = int(*desiredStatefulSet.Spec.Replicas)
+		nextRack.SeedCount = initialSeedCount
+
+		rackInfo := []*RackInformation{nextRack}
+		rc.desiredRackInformation = rackInfo
+		rc.statefulSets = make([]*appsv1.StatefulSet, len(rackInfo))
+		rc.statefulSets[0] = desiredStatefulSet
+		rc.clusterPods = mockPods
+		rc.dcPods = mockPods
+		return rc, epData, cleanupMockScr
+	}
+
+	t.Run("Seeds have changed, refreshSeeds is executed", func(t *testing.T) {
+		rc, epData, cleanup := prepareReconciliationCtx()
+		defer cleanup()
+
+		rc.desiredRackInformation[0].SeedCount = updatedSeedCount
+
+		successResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("OK")),
+		}
+		mockHttpClient := mocks.NewHttpClient(t)
+		mockHttpClient.On("Do",
+			mock.MatchedBy(func(req *http.Request) bool {
+				return req != nil && req.URL.Path == "/api/v0/ops/seeds/reload"
+			})).
+			Return(successResp, nil).
+			Times(initialSeedCount)
+		mockHttpClient.On("Do",
+			mock.MatchedBy(func(req *http.Request) bool {
+				return req != nil && req.URL.Path == "/api/v0/probes/cluster"
+			})).
+			Return(successResp, nil).
+			Times(initialSeedCount)
+		rc.NodeMgmtClient = httphelper.NodeMgmtClient{
+			Client:   mockHttpClient,
+			Log:      rc.ReqLogger,
+			Protocol: "http",
+		}
+
+		reconcileResult := rc.CheckPodsReady(epData)
+
+		assert.Equal(result.Continue(), reconcileResult)
+		mockHttpClient.AssertExpectations(t)
+	})
+
+	t.Run("Seeds haven't changed, refreshSeeds is not executed", func(t *testing.T) {
+		rc, epData, cleanup := prepareReconciliationCtx()
+		defer cleanup()
+		mockHttpClient := mocks.NewHttpClient(t)
+		successResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("OK")),
+		}
+		// no calls with '/api/v0/ops/seeds/reload'
+		mockHttpClient.On("Do",
+			mock.MatchedBy(func(req *http.Request) bool {
+				return req != nil && req.URL.Path == "/api/v0/probes/cluster"
+			})).
+			Return(successResp, nil).
+			Times(initialSeedCount)
+		rc.NodeMgmtClient = httphelper.NodeMgmtClient{
+			Client:   mockHttpClient,
+			Log:      rc.ReqLogger,
+			Protocol: "http",
+		}
+
+		reconcileResult := rc.CheckPodsReady(epData)
+
+		assert.Equal(result.Continue(), reconcileResult)
+		mockHttpClient.AssertExpectations(t)
+	})
+
+	t.Run("Seeds have changed, but refreshSeeds fails", func(t *testing.T) {
+		rc, epData, cleanup := prepareReconciliationCtx()
+		defer cleanup()
+		rc.desiredRackInformation[0].SeedCount = updatedSeedCount
+		respError := errors.New("internal error")
+		mockHttpClient := mocks.NewHttpClient(t)
+		mockHttpClient.On("Do",
+			mock.MatchedBy(func(req *http.Request) bool {
+				return req != nil && req.URL.Path == "/api/v0/ops/seeds/reload"
+			})).
+			Return(&http.Response{}, respError).
+			Once()
+		rc.NodeMgmtClient = httphelper.NodeMgmtClient{
+			Client:   mockHttpClient,
+			Log:      rc.ReqLogger,
+			Protocol: "http",
+		}
+
+		reconcileResult := rc.CheckPodsReady(epData)
+
+		assert.Equal(result.Error(respError), reconcileResult)
+		mockHttpClient.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
**What this PR does**:
Prevents infinite loop when seed refresh times out during node failures, allowing the operator to recover.

**Which issue(s) this PR fixes**:
Fixes #887 

**Checklist**
- [X] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
