### PR TITLE
Parallel node replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [BUGFIX] [#899](https://github.com/k8ssandra/cass-operator/issues/899) Skip webhook startup when the manager is launched without `--webhook-cert-path` (Helm chart behavior).
 * [BUGFIX] [#887](https://github.com/k8ssandra/cass-operator/issues/887) Prevents infinite loop when seed refresh times out during node failures, allowing the operator to recover.
+* [ENHANCEMENT] [#873](https://github.com/k8ssandra/cass-operator/issues/873) Allow replacing multiple previously bootstrapped nodes in parallel. Also, the CassandraTask to replace pod accepts RackName as alternative to PodName as filtering rule.
 
 ## v1.29.0
 

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.19.0
 OPERATOR_SDK_VERSION ?= 1.42.0
 HELM_VERSION ?= 3.19.4
 OPM_VERSION ?= 1.61.0
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.10.1
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -4,7 +4,11 @@ set -o errexit
 # 1. Create registry container unless it already exists
 reg_name='kind-registry'
 reg_port='5001'
-if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+if docker inspect "${reg_name}" >/dev/null 2>&1; then
+  if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}")" != 'true' ]; then
+    docker start "${reg_name}"
+  fi
+else
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --network bridge --name "${reg_name}" \
     registry:2

--- a/hack/cluster.sh
+++ b/hack/cluster.sh
@@ -22,7 +22,7 @@ fi
 # https://github.com/kubernetes-sigs/kind/issues/2875
 # https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 # See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
-cat <<EOF | kind create cluster --config=-
+cat <<EOF | kind create cluster --image=kindest/node:v1.34.3 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -89,6 +89,7 @@ type TaskConfiguration struct {
 	TaskStartTime *metav1.Time
 	Datacenter    *cassapi.CassandraDatacenter
 	Context       context.Context
+	Job           api.CassandraCommand
 
 	// Input parameters
 	RestartPolicy     corev1.RestartPolicy
@@ -301,6 +302,18 @@ func (r *CassandraTaskReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		nextRunTime := deletionTime.Sub(timeNow.Time)
 		res.RequeueAfter = nextRunTime
 		logger.V(1).Info("This task has completed, scheduling for deletion in " + nextRunTime.String())
+	}
+
+	podSucceeded := 0
+	for _, podStatus := range cassTask.Status.PodStatuses {
+		if podStatus.Status == api.PodCompleted {
+			podSucceeded++
+		}
+	}
+
+	if cassTask.Spec.Jobs[0].Command == api.CommandReplaceNode && podSucceeded > completed {
+		// This is to offset one-off error from cache timings with replace node's Pod deletion
+		completed = podSucceeded
 	}
 
 	cassTask.Status.Succeeded = completed
@@ -532,6 +545,7 @@ JobDefinition:
 			MaxConcurrentPods: cassTask.Spec.MaxConcurrentPods,
 			Retries:           cassTask.Spec.Retries,
 			PodFilter:         genericPodFilter,
+			Job:               job.Command,
 		}
 
 		// Process all the reconcileEveryPodTasks
@@ -609,29 +623,6 @@ JobDefinition:
 			if err = r.Status().Update(ctx, cassTask); err != nil {
 				return ctrl.Result{}, failed, completed, err
 			}
-		}
-
-		if job.Command == api.CommandReplaceNode {
-			// Special handling for replace process since it targets a single pod
-			if err := r.replacePreProcess(taskConfig); err != nil {
-				return ctrl.Result{}, failed, completed, err
-			}
-			nodeMgmtClient, err := httphelper.NewMgmtClient(ctx, r.Client, dc, nil)
-			if err != nil {
-				return ctrl.Result{}, failed, completed, err
-			}
-
-			pod := &corev1.Pod{}
-			if err := r.Get(taskConfig.Context, types.NamespacedName{Name: taskConfig.Arguments.PodName, Namespace: dc.Namespace}, pod); err != nil {
-				return ctrl.Result{}, failed, completed, err
-			}
-			if err := r.replacePod(nodeMgmtClient, pod, taskConfig); err != nil {
-				return ctrl.Result{}, failed, completed, err
-			}
-
-			completed++
-			res = ctrl.Result{}
-			break
 		}
 
 		var podTaskRes ctrl.Result
@@ -757,7 +748,7 @@ func (r *CassandraTaskReconciler) startPodTask(
 		status.StartTime = ptr.To(metav1.Now())
 	}
 
-	if features.Supports(taskConfig.AsyncFeature) {
+	if taskConfig.Job != api.CommandReplaceNode && features.Supports(taskConfig.AsyncFeature) {
 		jobId, err := taskConfig.AsyncFunc(nodeMgmtClient, pod, taskConfig)
 		if err != nil {
 			return err
@@ -774,7 +765,7 @@ func (r *CassandraTaskReconciler) startPodTask(
 			status.Status = api.PodError
 		}
 
-		if taskConfig.SyncFeature != "" {
+		if taskConfig.Job != api.CommandReplaceNode && taskConfig.SyncFeature != "" {
 			if !features.Supports(taskConfig.SyncFeature) {
 				err := fmt.Errorf("this job isn't supported by the target pod")
 				logger.Error(err, "Pod doesn't support this feature", "Pod", pod, "Feature", taskConfig.SyncFeature)
@@ -800,13 +791,24 @@ func (r *CassandraTaskReconciler) startPodTask(
 					<-jobRunner
 				}()
 
-				if err = taskConfig.SyncFunc(nodeMgmtClient, pod, taskConfig); err != nil {
-					// We only log, nothing else to do - we won't even retry this pod.
-					logger.Error(err, "executing the sync task failed", "Pod", pod)
-					status.Error = err.Error()
-					status.Status = api.PodError
-				} else {
-					status.Status = api.PodCompleted
+				if taskConfig.PreProcessFunc != nil {
+					if err := taskConfig.PreProcessFunc(taskConfig); err != nil {
+						logger.Error(err, "executing preprocessing functionality failed", "Pod", pod)
+						status.Error = err.Error()
+						status.Status = api.PodError
+					}
+				}
+
+				if status.Error == "" {
+					if err = taskConfig.SyncFunc(nodeMgmtClient, pod, taskConfig); err != nil {
+						// We only log, nothing else to do - we won't even retry this pod.
+						logger.Error(err, "executing the sync task failed", "Pod", pod)
+						status.Error = err.Error()
+						status.Status = api.PodError
+					} else {
+						status.Status = api.PodCompleted
+						status.CompletionTime = ptr.To(metav1.Now())
+					}
 				}
 
 				cassTask := &api.CassandraTask{}

--- a/internal/controllers/control/cassandratask_controller_test.go
+++ b/internal/controllers/control/cassandratask_controller_test.go
@@ -37,7 +37,7 @@ var (
 func createDatacenter(dcName, namespace string) func() {
 	return func() {
 		By("Create Datacenter, pods and set dc status to Ready")
-		clusterName = fmt.Sprintf("test-%s", dcName)
+		clusterName = "test"
 		testNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
@@ -59,7 +59,7 @@ func createDatacenter(dcName, namespace string) func() {
 			Spec: cassdcapi.CassandraDatacenterSpec{
 				ClusterName:   clusterName,
 				ServerType:    "cassandra",
-				ServerVersion: "4.0.5",
+				ServerVersion: "5.0.6",
 				Size:          int32(nodeCount),
 			},
 			Status: cassdcapi.CassandraDatacenterStatus{},
@@ -569,7 +569,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 					Expect(callDetails.URLCounts["/api/v0/ops/executor/job"]).To(BeNumerically(">=", 3*nodeCount))
 					Expect(callDetails.URLCounts["/api/v0/metadata/versions/features"]).To(BeNumerically(">=", 3*nodeCount))
 				})
-				It("Replace a node in the datacenter without specifying the pod", func() {
+				It("Replace a node in the datacenter without specifying the pod or rack", func() {
 					testFailedNamespaceName := fmt.Sprintf("test-task-failed-%d", rand.Int31())
 					By("creating a datacenter", createDatacenter("dc1", testFailedNamespaceName))
 					By("Creating a task for replacenode")
@@ -581,7 +581,7 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 					Expect(completedTask.Status.Failed).To(BeNumerically(">=", 1))
 					Expect(completedTask.Status.Conditions[2].Type).To(Equal(string(api.JobFailed)))
-					Expect(completedTask.Status.Conditions[2].Message).To(Equal("terminal error: valid pod_name to replace is required"))
+					Expect(completedTask.Status.Conditions[2].Message).To(Equal("terminal error: replace requires either rack_name or pod_name to be set as a filtering rule"))
 				})
 			})
 		})
@@ -660,10 +660,33 @@ var _ = Describe("CassandraTask controller tests", func() {
 
 				completedTask := waitForTaskCompletion(taskKey)
 
-				// verifyPodsHaveAnnotations(testNamespaceName, string(task.UID))
 				Expect(completedTask.Status.Succeeded).To(BeNumerically(">=", 1))
 			})
+			It("Replaces a rack in the datacenter", func() {
+				By("Creating a task for replacenode")
+				taskKey, task := buildTask(api.CommandReplaceNode, testNamespaceName)
+				task.Spec.Jobs[0].Arguments.RackName = "r1"
+				Expect(k8sClient.Create(context.TODO(), task)).Should(Succeed())
 
+				for i := range 3 {
+					podKey := types.NamespacedName{
+						Name:      fmt.Sprintf("%s-%s-r1-sts-%d", clusterName, testDatacenterName, i),
+						Namespace: testNamespaceName,
+					}
+
+					Eventually(func() bool {
+						pod := &corev1.Pod{}
+						err := k8sClient.Get(context.TODO(), podKey, pod)
+						return err != nil && errors.IsNotFound(err)
+					}, 3*time.Second).Should(BeTrue())
+
+					createPod(testNamespaceName, clusterName, testDatacenterName, "r1", i)
+				}
+
+				completedTask := waitForTaskCompletion(taskKey)
+
+				Expect(completedTask.Status.Succeeded).To(BeNumerically("==", 3))
+			})
 			It("Runs a flush task against the datacenter pods", func() {
 				By("Creating a task for flush")
 				taskKey, task := buildTask(api.CommandFlush, testNamespaceName)

--- a/internal/controllers/control/jobs.go
+++ b/internal/controllers/control/jobs.go
@@ -183,46 +183,29 @@ func upgradesstables(taskConfig *TaskConfiguration) {
 func (r *CassandraTaskReconciler) replacePod(nodeMgmtClient httphelper.NodeMgmtClient, pod *corev1.Pod, taskConfig *TaskConfiguration) error {
 	logger := log.FromContext(taskConfig.Context)
 
-	// We check the podStartTime to prevent replacing the pod multiple times since annotations are removed when we delete the pod
-	podStartTime := pod.GetCreationTimestamp()
-	uid := pod.UID
-	podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
-	if podStartTime.Before(taskConfig.TaskStartTime) {
-		if isCassandraUp(pod) {
-			// Verify the cassandra pod is healthy before trying the drain
-			if err := nodeMgmtClient.CallDrainEndpoint(pod); err != nil {
-				logger.Error(err, "Failed to drain pod", "pod", pod.Name)
-			}
+	if isCassandraUp(pod) {
+		// Verify the cassandra pod is healthy before trying the drain
+		if err := nodeMgmtClient.CallDrainEndpoint(pod); err != nil {
+			logger.Error(err, "Failed to drain pod", "pod", pod.Name)
 		}
+	}
 
-		// Get all the PVCs that the pod is using?
-		pvcs, err := r.getPodPVCs(taskConfig.Context, taskConfig.Datacenter.Namespace, pod)
-		if err != nil {
-			return err
-		}
+	// Get all the PVCs that the pod is using?
+	pvcs, err := r.getPodPVCs(taskConfig.Context, taskConfig.Datacenter.Namespace, pod)
+	if err != nil {
+		return err
+	}
 
-		// Delete the PVCs .. without waiting (set status to terminating - finalizer will block)
-		for _, pvc := range pvcs {
-			if err := r.Delete(taskConfig.Context, pvc); err != nil {
-				return err
-			}
-		}
-
-		// Finally, delete the pod
-		if err := r.Delete(taskConfig.Context, pod); err != nil {
+	// Delete the PVCs .. without waiting (set status to terminating - finalizer will block)
+	for _, pvc := range pvcs {
+		if err := r.Delete(taskConfig.Context, pvc); err != nil {
 			return err
 		}
 	}
 
-	for i := 0; i < 10; i++ {
-		time.Sleep(1 * time.Second)
-		newPod := &corev1.Pod{}
-		if err := r.Get(taskConfig.Context, podKey, newPod); err != nil {
-			continue
-		}
-		if uid != newPod.UID {
-			break
-		}
+	// Finally, delete the pod
+	if err := r.Delete(taskConfig.Context, pod); err != nil {
+		return err
 	}
 
 	return nil
@@ -230,25 +213,55 @@ func (r *CassandraTaskReconciler) replacePod(nodeMgmtClient httphelper.NodeMgmtC
 
 func (r *CassandraTaskReconciler) replaceValidator(taskConfig *TaskConfiguration) (bool, error) {
 	// Check that arguments has replaceable pods and that those pods are actually existing pods
+
+	if taskConfig.Arguments.PodName == "" && taskConfig.Arguments.RackName == "" {
+		return false, fmt.Errorf("replace requires either rack_name or pod_name to be set as a filtering rule")
+	}
+
+	if taskConfig.Arguments.RackName != "" {
+		validRack := false
+		for _, rack := range taskConfig.Datacenter.Spec.Racks {
+			if rack.Name == taskConfig.Arguments.RackName {
+				validRack = true
+				break
+			}
+		}
+		if !validRack {
+			return false, fmt.Errorf("%s is not a valid rack name", taskConfig.Arguments.RackName)
+		}
+	}
+
 	if taskConfig.Arguments.PodName != "" {
 		pods, err := r.getDatacenterPods(taskConfig.Context, taskConfig.Datacenter)
 		if err != nil {
 			return true, err
 		}
+		validPod := false
 		for _, pod := range pods {
 			if pod.Name == taskConfig.Arguments.PodName {
-				return true, nil
+				validPod = true
+				break
 			}
+		}
+		if !validPod {
+			return false, fmt.Errorf("valid pod_name to replace is required")
 		}
 	}
 
-	return false, fmt.Errorf("valid pod_name to replace is required")
+	return true, nil
 }
 
 func requiredPodFilter(pod *corev1.Pod, taskConfig *TaskConfiguration) bool {
-	// If pod isn't in the to be replaced pods, return false
+	rackName := taskConfig.Arguments.RackName
 	podName := taskConfig.Arguments.PodName
-	return pod.Name == podName
+
+	// If no filters are provided, reject everything
+	if rackName == "" && podName == "" {
+		return false
+	}
+
+	// Otherwise follow normal genericPodFilter
+	return genericPodFilter(pod, taskConfig)
 }
 
 func genericPodFilter(pod *corev1.Pod, taskConfig *TaskConfiguration) bool {
@@ -268,13 +281,31 @@ func genericPodFilter(pod *corev1.Pod, taskConfig *TaskConfiguration) bool {
 // replacePreProcess adds enough information to CassandraDatacenter to ensure cass-operator knows this pod is being replaced
 func (r *CassandraTaskReconciler) replacePreProcess(taskConfig *TaskConfiguration) error {
 	dc := taskConfig.Datacenter
+	patch := client.MergeFrom(dc.DeepCopy())
+
+	podsToReplace := make([]string, 0, 1)
 	podName := taskConfig.Arguments.PodName
+	if podName != "" {
+		podsToReplace = append(podsToReplace, podName)
+	} else if taskConfig.Arguments.RackName != "" {
+		pods, err := r.getDatacenterPods(taskConfig.Context, taskConfig.Datacenter)
+		if err != nil {
+			return err
+		}
+
+		for _, pod := range pods {
+			if pod.Labels[cassapi.RackLabel] == taskConfig.Arguments.RackName {
+				podsToReplace = append(podsToReplace, pod.Name)
+			}
+		}
+	}
+
 	dc.Status.NodeReplacements = utils.AppendValuesToStringArrayIfNotPresent(
-		dc.Status.NodeReplacements, podName)
+		dc.Status.NodeReplacements, podsToReplace...)
 
 	r.setDatacenterCondition(dc, cassapi.NewDatacenterCondition(cassapi.DatacenterReplacingNodes, corev1.ConditionTrue))
 
-	return r.Client.Status().Update(taskConfig.Context, dc)
+	return r.Client.Status().Patch(taskConfig.Context, dc, patch)
 }
 
 func (r *CassandraTaskReconciler) setDatacenterCondition(dc *cassapi.CassandraDatacenter, condition *cassapi.DatacenterCondition) {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1945,10 +1945,6 @@ func (rc *ReconciliationContext) startBootstrappedNodes(endpointData httphelper.
 
 	for _, pod := range rc.dcPods {
 		if _, ok := rc.Datacenter.Status.NodeStatuses[pod.Name]; ok {
-			// Verify pod is not going to be replaced
-			if utils.IndexOfString(rc.Datacenter.Status.NodeReplacements, pod.Name) > -1 {
-				continue
-			}
 			notReady, err := rc.startNode(pod, false, endpointData)
 			if err != nil {
 				return startingNodes, err

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -2083,7 +2083,6 @@ func TestStartBootstrappedNodes(t *testing.T) {
 		wantNotReady bool
 		nodeStatus   racks
 		wantEvents   []string
-		replacements []string
 	}{
 		// First check all the normal cases where we have no dead already bootstrapped nodes
 		{
@@ -2203,21 +2202,6 @@ func TestStartBootstrappedNodes(t *testing.T) {
 			wantEvents:   []string{"Normal StartingCassandra Starting Cassandra for pod rack1-1"},
 		},
 		{
-			name: "balanced racks, failed already bootstrapped to be replaced and a non-bootstrapped one",
-			racks: racks{
-				"rack1": {true, false, true},
-				"rack2": {true, true, true},
-				"rack3": {true, true, false},
-			},
-			nodeStatus: racks{
-				"rack1": {true, true, true},
-				"rack2": {true, true, true},
-				"rack3": {true, true, false},
-			},
-			wantNotReady: false,
-			replacements: []string{"rack1-1"},
-		},
-		{
 			name: "starting back from stopped state, all the nodes should be started at the same time",
 			racks: racks{
 				"rack1": {false, false},
@@ -2247,10 +2231,6 @@ func TestStartBootstrappedNodes(t *testing.T) {
 				}
 			}
 			rc.Datacenter.Status.NodeStatuses = nodeStatuses
-			if len(tt.replacements) > 0 {
-				rc.Datacenter.Status.NodeReplacements = tt.replacements
-			}
-
 			for _, rackName := range []string{"rack1", "rack2", "rack3"} {
 				rackPods := tt.racks[rackName]
 				sts := &appsv1.StatefulSet{

--- a/tests/kustomize/kustomization.yaml
+++ b/tests/kustomize/kustomization.yaml
@@ -1,5 +1,5 @@
 # This is the default kustomize template for tests.
-namespace: test-scheduled-task
+namespace: kustomize
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -138,7 +138,7 @@ var _ = Describe(testName, func() {
 
 			ns.WaitForOperatorReady()
 
-			step := "creating a datacenter resource with 3 racks/3 nodes"
+			step := "creating a datacenter resource with 3 racks/6 nodes"
 			testFile, err := ginkgo_util.CreateTestFile(dcYaml)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -199,7 +199,7 @@ var _ = Describe(testName, func() {
 
 			// Ensure that all pods up and running when ReplacingNodes gets unset
 			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionFalse))
-			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(3))
+			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
 
 			step = "wait for the pod to return to life"
 			json = "jsonpath={.status.containerStatuses[?(.name=='cassandra')].ready}"
@@ -237,7 +237,7 @@ var _ = Describe(testName, func() {
 			// Wait for the task to be completed
 			ns.WaitForCompleteTask("replace-node")
 			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionFalse))
-			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(3))
+			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
 
 			step = "wait for the pod to return to life"
 			json = "jsonpath={.status.containerStatuses[?(.name=='cassandra')].ready}"
@@ -264,18 +264,9 @@ var _ = Describe(testName, func() {
 			oldPvByPod := make(map[string]string, len(rackPodNames))
 			newPvByPod := make(map[string]string, len(rackPodNames))
 
-			// This is to ensure we have enough nodes to see multiple replaces instead of just filtering change
-			step := "scale up to 6 nodes"
-			patch := `{"spec":{"size":6}}`
-			k := kubectl.PatchMerge(dcResource, patch)
-			ns.ExecAndLog(step, k)
-
-			ns.WaitForDatacenterCondition(dcName, "ScaleUp", string(corev1.ConditionFalse))
-			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
-
 			for _, podName := range rackPodNames {
 				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
-				k = kubectl.Get("pod", podName).FormatOutput(json)
+				k := kubectl.Get("pod", podName).FormatOutput(json)
 				pvcName, err := ns.Output(k)
 				Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podName, err)
 
@@ -285,8 +276,8 @@ var _ = Describe(testName, func() {
 				Expect(err).ToNot(HaveOccurred(), "Failed to get PV name for PVC %s: %v", pvcName, err)
 			}
 
-			step = "creating a cassandra task to replace nodes in rack r1"
-			k = kubectl.ApplyFiles(taskYamlRack)
+			step := "creating a cassandra task to replace nodes in rack r1"
+			k := kubectl.ApplyFiles(taskYamlRack)
 			ns.ExecAndLog(step, k)
 
 			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionTrue))

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -158,7 +158,6 @@ var _ = Describe(testName, func() {
 			k = kubectl.Get("pod", podNameToReplace).FormatOutput(json)
 			pvcName := ns.OutputAndLog(step, k)
 
-			step = "find PVC volume"
 			json = "jsonpath={.spec.volumeName}"
 			k = kubectl.Get("pvc", pvcName).FormatOutput(json)
 			pvName, err := ns.Output(k)
@@ -215,13 +214,11 @@ var _ = Describe(testName, func() {
 		})
 		Specify("cassandratask can be used to replace a node", func() {
 			// Get PVC id
-			step := "retrieve the persistent volume claim"
 			json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 			k := kubectl.Get("pod", podNameToReplace).FormatOutput(json)
 			pvcName, err := ns.Output(k)
 			Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podNameToReplace, err)
 
-			step = "find PVC volume"
 			json = "jsonpath={.spec.volumeName}"
 			k = kubectl.Get("pvc", pvcName).FormatOutput(json)
 			pvName, err := ns.Output(k)
@@ -231,7 +228,7 @@ var _ = Describe(testName, func() {
 			ns.KillCassandra(podNameToReplace)
 
 			// Create CassandraTask that should replace a node
-			step = "creating a cassandra task to replace a node"
+			step := "creating a cassandra task to replace a node"
 			k = kubectl.ApplyFiles(taskYaml)
 			ns.ExecAndLog(step, k)
 
@@ -251,13 +248,11 @@ var _ = Describe(testName, func() {
 			verifyAllPodsAreCorrect()
 
 			// Verify the PV id is different
-			step = "retrieve the persistent volume claim after pod replace"
 			json = "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 			k = kubectl.Get("pod", podNameToReplace).FormatOutput(json)
 			pvcName, err = ns.Output(k)
 			Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podNameToReplace, err)
 
-			step = "find PVC volume"
 			json = "jsonpath={.spec.volumeName}"
 			k = kubectl.Get("pvc", pvcName).FormatOutput(json)
 			newPvName, err := ns.Output(k)
@@ -279,13 +274,11 @@ var _ = Describe(testName, func() {
 			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
 
 			for _, podName := range rackPodNames {
-				step = fmt.Sprintf("retrieve the persistent volume claim for %s", podName)
 				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 				k = kubectl.Get("pod", podName).FormatOutput(json)
 				pvcName, err := ns.Output(k)
 				Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podName, err)
 
-				step = fmt.Sprintf("find PVC volume for %s", podName)
 				json = "jsonpath={.spec.volumeName}"
 				k = kubectl.Get("pvc", pvcName).FormatOutput(json)
 				oldPvByPod[podName], err = ns.Output(k)
@@ -303,13 +296,11 @@ var _ = Describe(testName, func() {
 			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
 
 			for _, podName := range rackPodNames {
-				step = fmt.Sprintf("retrieve the persistent volume claim after replace for %s", podName)
 				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 				k = kubectl.Get("pod", podName).FormatOutput(json)
 				pvcName, err := ns.Output(k)
 				Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podName, err)
 
-				step = fmt.Sprintf("find PVC volume after replace for %s", podName)
 				json = "jsonpath={.spec.volumeName}"
 				k = kubectl.Get("pvc", pvcName).FormatOutput(json)
 				newPvByPod[podName], err = ns.Output(k)

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -28,6 +28,7 @@ var (
 	podNameToReplace = podNames[2]
 	dcYaml           = "../testdata/default-three-rack-three-node-dc-4x.yaml"
 	taskYaml         = "../testdata/tasks/replace_node_task.yaml"
+	taskYamlRack     = "../testdata/tasks/replace_node_task_rack.yaml"
 	dcResource       = fmt.Sprintf("CassandraDatacenter/%s", dcName)
 	ns               = ginkgo_util.NewWrapper(testName, namespace)
 )
@@ -257,6 +258,59 @@ var _ = Describe(testName, func() {
 			newPvName := ns.OutputAndLog(step, k)
 
 			Expect(pvName).ToNot(Equal(newPvName), "Expected PV volume to be different after node replace")
+		})
+		Specify("cassandratask can be used to replace a rack", func() {
+			rackPodNames := []string{"cluster1-dc1-r1-sts-0", "cluster1-dc1-r1-sts-1"}
+			oldPvByPod := make(map[string]string, len(rackPodNames))
+			newPvByPod := make(map[string]string, len(rackPodNames))
+
+			// This is to ensure we have enough nodes to see multiple replaces instead of just filtering change
+			step := "scale up to 6 nodes"
+			patch := `{"spec":{"size":6}}`
+			k := kubectl.PatchMerge(dcResource, patch)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterCondition(dcName, "ScaleUp", string(corev1.ConditionFalse))
+			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
+
+			for _, podName := range rackPodNames {
+				step = fmt.Sprintf("retrieve the persistent volume claim for %s", podName)
+				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
+				k = kubectl.Get("pod", podName).FormatOutput(json)
+				pvcName := ns.OutputAndLog(step, k)
+
+				step = fmt.Sprintf("find PVC volume for %s", podName)
+				json = "jsonpath={.spec.volumeName}"
+				k = kubectl.Get("pvc", pvcName).FormatOutput(json)
+				oldPvByPod[podName] = ns.OutputAndLog(step, k)
+			}
+
+			step = "creating a cassandra task to replace nodes in rack r1"
+			k = kubectl.ApplyFiles(taskYamlRack)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionTrue))
+
+			ns.WaitForCompleteTask("replace-node-rack")
+			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionFalse))
+			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
+
+			for _, podName := range rackPodNames {
+				step = fmt.Sprintf("retrieve the persistent volume claim after replace for %s", podName)
+				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
+				k = kubectl.Get("pod", podName).FormatOutput(json)
+				pvcName := ns.OutputAndLog(step, k)
+
+				step = fmt.Sprintf("find PVC volume after replace for %s", podName)
+				json = "jsonpath={.spec.volumeName}"
+				k = kubectl.Get("pvc", pvcName).FormatOutput(json)
+				newPvByPod[podName] = ns.OutputAndLog(step, k)
+			}
+
+			for _, podName := range rackPodNames {
+				Expect(oldPvByPod[podName]).ToNot(Equal(newPvByPod[podName]),
+					"Expected PV volume to be different after rack replace for pod %s", podName)
+			}
 		})
 	})
 })

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -24,7 +24,7 @@ var (
 	testName         = "Node Replace"
 	namespace        = "test-node-replace"
 	dcName           = "dc1"
-	podNames         = []string{"cluster1-dc1-r1-sts-0", "cluster1-dc1-r2-sts-0", "cluster1-dc1-r3-sts-0"}
+	podNames         = []string{"cluster1-dc1-r1-sts-0", "cluster1-dc1-r1-sts-1", "cluster1-dc1-r2-sts-0", "cluster1-dc1-r2-sts-1", "cluster1-dc1-r3-sts-0", "cluster1-dc1-r3-sts-1"}
 	podNameToReplace = podNames[2]
 	dcYaml           = "../testdata/default-three-rack-three-node-dc-4x.yaml"
 	taskYaml         = "../testdata/tasks/replace_node_task.yaml"

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -25,7 +25,7 @@ var (
 	namespace        = "test-node-replace"
 	dcName           = "dc1"
 	podNames         = []string{"cluster1-dc1-r1-sts-0", "cluster1-dc1-r1-sts-1", "cluster1-dc1-r2-sts-0", "cluster1-dc1-r2-sts-1", "cluster1-dc1-r3-sts-0", "cluster1-dc1-r3-sts-1"}
-	podNameToReplace = podNames[2]
+	podNameToReplace = "cluster1-dc1-r3-sts-0"
 	dcYaml           = "../testdata/default-three-rack-three-node-dc-4x.yaml"
 	taskYaml         = "../testdata/tasks/replace_node_task.yaml"
 	taskYamlRack     = "../testdata/tasks/replace_node_task_rack.yaml"

--- a/tests/node_replace/node_replace_suite_test.go
+++ b/tests/node_replace/node_replace_suite_test.go
@@ -116,8 +116,9 @@ func verifyAllPodsAreCorrect() {
 
 			// Make sure that NodeStatus reflects the HostID for the replacement pod. Otherwise subsequent replaces will fail as the CassandraDatacenter has stale information
 			k := kubectl.Get("pod", podNameToReplace).FormatOutput("jsonpath={.status.podIP}")
-			step = "get podIP"
-			podIP := ns.OutputAndLog(step, k)
+			// step = "get podIP"
+			podIP, err := ns.Output(k)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get pod IP for pod %s: %v", podNameToReplace, err)
 			if podName == podNameToReplace && podIP == nodeInfo.Address {
 				step = "verify nodeStatus HostID is up to date"
 				json := fmt.Sprintf("jsonpath={.status.nodeStatuses['%s'].hostID}", podNameToReplace)
@@ -160,7 +161,8 @@ var _ = Describe(testName, func() {
 			step = "find PVC volume"
 			json = "jsonpath={.spec.volumeName}"
 			k = kubectl.Get("pvc", pvcName).FormatOutput(json)
-			pvName := ns.OutputAndLog(step, k)
+			pvName, err := ns.Output(k)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get PV name")
 
 			ns.DisableGossipWaitNotReady(podNameToReplace)
 			ns.WaitForPodNotStarted(podNameToReplace)
@@ -194,7 +196,7 @@ var _ = Describe(testName, func() {
 			// Now we can delete the pod. The statefulset controller _should_
 			// create both a new pod and a new PVC for us.
 			k = kubectl.Delete("pod", podNameToReplace)
-			ns.ExecAndLog(step, k)
+			ns.ExecVPanic(k)
 
 			// Ensure that all pods up and running when ReplacingNodes gets unset
 			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionFalse))
@@ -216,12 +218,14 @@ var _ = Describe(testName, func() {
 			step := "retrieve the persistent volume claim"
 			json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 			k := kubectl.Get("pod", podNameToReplace).FormatOutput(json)
-			pvcName := ns.OutputAndLog(step, k)
+			pvcName, err := ns.Output(k)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podNameToReplace, err)
 
 			step = "find PVC volume"
 			json = "jsonpath={.spec.volumeName}"
 			k = kubectl.Get("pvc", pvcName).FormatOutput(json)
-			pvName := ns.OutputAndLog(step, k)
+			pvName, err := ns.Output(k)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get PV name for PVC %s: %v", pvcName, err)
 
 			// Kill the Cassandra instance (emulate fsync failure or similar)
 			ns.KillCassandra(podNameToReplace)
@@ -250,13 +254,14 @@ var _ = Describe(testName, func() {
 			step = "retrieve the persistent volume claim after pod replace"
 			json = "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 			k = kubectl.Get("pod", podNameToReplace).FormatOutput(json)
-			pvcName = ns.OutputAndLog(step, k)
+			pvcName, err = ns.Output(k)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podNameToReplace, err)
 
 			step = "find PVC volume"
 			json = "jsonpath={.spec.volumeName}"
 			k = kubectl.Get("pvc", pvcName).FormatOutput(json)
-			newPvName := ns.OutputAndLog(step, k)
-
+			newPvName, err := ns.Output(k)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get PV name for PVC %s: %v", pvcName, err)
 			Expect(pvName).ToNot(Equal(newPvName), "Expected PV volume to be different after node replace")
 		})
 		Specify("cassandratask can be used to replace a rack", func() {
@@ -277,12 +282,14 @@ var _ = Describe(testName, func() {
 				step = fmt.Sprintf("retrieve the persistent volume claim for %s", podName)
 				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 				k = kubectl.Get("pod", podName).FormatOutput(json)
-				pvcName := ns.OutputAndLog(step, k)
+				pvcName, err := ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podName, err)
 
 				step = fmt.Sprintf("find PVC volume for %s", podName)
 				json = "jsonpath={.spec.volumeName}"
 				k = kubectl.Get("pvc", pvcName).FormatOutput(json)
-				oldPvByPod[podName] = ns.OutputAndLog(step, k)
+				oldPvByPod[podName], err = ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get PV name for PVC %s: %v", pvcName, err)
 			}
 
 			step = "creating a cassandra task to replace nodes in rack r1"
@@ -291,7 +298,7 @@ var _ = Describe(testName, func() {
 
 			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionTrue))
 
-			ns.WaitForCompleteTask("replace-node-rack")
+			ns.WaitForCompleteTaskTimeout("replace-node-rack", 720)
 			ns.WaitForDatacenterCondition(dcName, "ReplacingNodes", string(corev1.ConditionFalse))
 			Expect(ns.GetDatacenterReadyPodNames(dcName)).To(HaveLen(6))
 
@@ -299,12 +306,14 @@ var _ = Describe(testName, func() {
 				step = fmt.Sprintf("retrieve the persistent volume claim after replace for %s", podName)
 				json := "jsonpath={.spec.volumes[?(.name=='server-data')].persistentVolumeClaim.claimName}"
 				k = kubectl.Get("pod", podName).FormatOutput(json)
-				pvcName := ns.OutputAndLog(step, k)
+				pvcName, err := ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get PVC name for pod %s: %v", podName, err)
 
 				step = fmt.Sprintf("find PVC volume after replace for %s", podName)
 				json = "jsonpath={.spec.volumeName}"
 				k = kubectl.Get("pvc", pvcName).FormatOutput(json)
-				newPvByPod[podName] = ns.OutputAndLog(step, k)
+				newPvByPod[podName], err = ns.Output(k)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get PV name for PVC %s: %v", pvcName, err)
 			}
 
 			for _, podName := range rackPodNames {

--- a/tests/testdata/default-three-rack-three-node-dc-4x.yaml
+++ b/tests/testdata/default-three-rack-three-node-dc-4x.yaml
@@ -9,7 +9,7 @@ spec:
   serverVersion: 4.1.6
   managementApiAuth:
     insecure: {}
-  size: 3
+  size: 6
   storageConfig:
       cassandraDataVolumeClaimSpec:
         storageClassName: standard
@@ -27,9 +27,9 @@ spec:
       initial_heap_size: "512m"
       max_heap_size: "512m"
       additional-jvm-opts:
-      - -Dcassandra.system_distributed_replication_dc_names=dc1
-      - -Dcassandra.system_distributed_replication_per_dc=3
-      - -Dcassandra.system_traces_replication_dc_names=dc1
-      - -Dcassandra.system_traces_replication_per_dc=3
-      - -Dcassandra.system_auth_replication_dc_names=dc1
+      - -Dcassandra.system_distributed_replication_dc_names=My_Super_Dc
+      - -Dcassandra.system_distributed_replication_per_dc=1
+      - -Dcassandra.system_traces_replication_dc_names=My_Super_Dc
+      - -Dcassandra.system_traces_replication_per_dc=1
+      - -Dcassandra.system_auth_replication_dc_names=My_Super_Dc
       - -Dcassandra.system_auth_replication_per_dc=3

--- a/tests/testdata/default-three-rack-three-node-dc-4x.yaml
+++ b/tests/testdata/default-three-rack-three-node-dc-4x.yaml
@@ -26,3 +26,10 @@ spec:
     jvm-server-options:
       initial_heap_size: "512m"
       max_heap_size: "512m"
+      additional-jvm-opts:
+      - -Dcassandra.system_distributed_replication_dc_names=dc1
+      - -Dcassandra.system_distributed_replication_per_dc=3
+      - -Dcassandra.system_traces_replication_dc_names=dc1
+      - -Dcassandra.system_traces_replication_per_dc=3
+      - -Dcassandra.system_auth_replication_dc_names=dc1
+      - -Dcassandra.system_auth_replication_per_dc=3

--- a/tests/testdata/tasks/replace_node_task_rack.yaml
+++ b/tests/testdata/tasks/replace_node_task_rack.yaml
@@ -1,0 +1,13 @@
+apiVersion: control.k8ssandra.io/v1alpha1
+kind: CassandraTask
+metadata:
+  name: replace-node-rack
+spec:
+  datacenter:
+    name: dc1
+    namespace: test-node-replace
+  jobs:
+    - name: replace-run
+      command: replacenode
+      args:
+        rack: r1

--- a/tests/util/ginkgo/lib.go
+++ b/tests/util/ginkgo/lib.go
@@ -696,12 +696,16 @@ func (ns *NsWrapper) WaitForCompletedCassandraTasks(dcName, command string, coun
 }
 
 func (ns *NsWrapper) WaitForCompleteTask(taskName string) {
+	ns.WaitForCompleteTaskTimeout(taskName, 360)
+}
+
+func (ns *NsWrapper) WaitForCompleteTaskTimeout(taskName string, seconds int) {
 	step := "checking that cassandratask status CompletionTime has a value"
 	json := "jsonpath={.status.completionTime}"
 	k := kubectl.Get("cassandratask", taskName).
 		FormatOutput(json)
 
-	ns.WaitForOutputPatternAndLog(step, k, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`, 360)
+	ns.WaitForOutputPatternAndLog(step, k, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`, seconds)
 }
 
 func (ns *NsWrapper) ExpectDatacenterNameStatusUpdated(dcName, dcNameOverride string) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Allow replace nodes to take an entire rack as filtering instead of only pod name. 
* Enable fastpath starting to accept replaceable nodes for parallel starting sequence.

Note, this does not prevent anyone from replacing nodes from multiple racks at the same time if they remove the safeguards. In other words, allowing parallel task execution and each one replacing different things. A single task can't do more than single rack, but multiple tasks can of course avoid this as they're not bound to each other.

**Which issue(s) this PR fixes**:
Fixes #873 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
