### PR TITLE
Disable webhook server if no TLS cert path is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#899](https://github.com/k8ssandra/cass-operator/issues/899) Skip webhook startup when the manager is launched without `--webhook-cert-path` (Helm chart behavior).
+
 ## v1.29.0
 
 * [CHANGE] [#875](https://github.com/k8ssandra/cass-operator/issues/875) Update to Go 1.25, Kubernetes 1.34 and UBI10 as the base image. Also, Vector to 0.53.0 and other smaller dependency updates. Deprecate CDC support.

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 .PHONY: test
 test: manifests generate fmt vet lint envtest ## Run tests.
 	# Old unit tests first - these use mocked client / fakeclient
-	go test ./pkg/... -coverprofile cover-pkg.out
+	go test -v ./cmd/... ./pkg/... -coverprofile cover-pkg.out
 	# Then the envtest ones
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./apis/... ./internal/... -coverprofile cover.out
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -128,32 +128,16 @@ func main() {
 	// Create watchers for metrics and webhooks certificates
 	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
 
-	// Initial webhook TLS options
-	webhookTLSOpts := tlsOpts
-
-	if len(webhookCertPath) > 0 {
-		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
-			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
-
-		var err error
-		webhookCertWatcher, err = certwatcher.New(
-			filepath.Join(webhookCertPath, webhookCertName),
-			filepath.Join(webhookCertPath, webhookCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
-			os.Exit(1)
-		}
-
-		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
-			config.GetCertificate = webhookCertWatcher.GetCertificate
-		})
+	webhookServer, webhookCertWatcher, webhookEnabled, err := setupWebhookServer(
+		webhookCertPath,
+		webhookCertName,
+		webhookCertKey,
+		tlsOpts,
+	)
+	if err != nil {
+		setupLog.Error(err, "Failed to initialize webhook certificate watcher")
+		os.Exit(1)
 	}
-
-	webhookServer := webhook.NewServer(webhook.Options{
-		TLSOpts: webhookTLSOpts,
-	})
-
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,
 		SecureServing: secureMetrics,
@@ -190,10 +174,15 @@ func main() {
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
-		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b569adb7.cassandra.datastax.com",
+	}
+
+	if webhookEnabled {
+		options.WebhookServer = webhookServer
+	} else {
+		setupLog.Info("webhooks disabled because --webhook-cert-path was not provided")
 	}
 
 	options.Cache = cache.Options{
@@ -258,9 +247,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = apiwebhook.SetupCassandraDatacenterWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "CassandraDatacenter")
-		os.Exit(1)
+	if webhookEnabled {
+		if err = apiwebhook.SetupCassandraDatacenterWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CassandraDatacenter")
+			os.Exit(1)
+		}
 	}
 
 	if err = (&controlcontrollers.CassandraTaskReconciler{
@@ -324,6 +315,32 @@ func main() {
 	case <-ctx.Done():
 		// graceful shutdown
 	}
+}
+
+func setupWebhookServer(webhookCertPath, webhookCertName, webhookCertKey string, tlsOpts []func(*tls.Config)) (webhook.Server, *certwatcher.CertWatcher, bool, error) {
+	if len(webhookCertPath) == 0 {
+		return nil, nil, false, nil
+	}
+
+	setupLog.Info("Initializing webhook certificate watcher using provided certificates",
+		"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
+
+	webhookCertWatcher, err := certwatcher.New(
+		filepath.Join(webhookCertPath, webhookCertName),
+		filepath.Join(webhookCertPath, webhookCertKey),
+	)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	webhookTLSOpts := append([]func(*tls.Config){}, tlsOpts...)
+	webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
+		config.GetCertificate = webhookCertWatcher.GetCertificate
+	})
+
+	return webhook.NewServer(webhook.Options{
+		TLSOpts: webhookTLSOpts,
+	}), webhookCertWatcher, true, nil
 }
 
 func setupCacheIndexers(ctx context.Context, mgr ctrl.Manager) error {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/k8ssandra/cass-operator/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupWebhookServerWithoutCertPath(t *testing.T) {
+	require := require.New(t)
+
+	webhookServer, webhookCertWatcher, webhookEnabled, err := setupWebhookServer("", "tls.crt", "tls.key", nil)
+	require.NoError(err)
+	require.False(webhookEnabled)
+	require.Nil(webhookServer)
+	require.Nil(webhookCertWatcher)
+}
+
+func TestSetupWebhookServerWithCertPath(t *testing.T) {
+	require := require.New(t)
+
+	tmpDir := t.TempDir()
+	keyPEM, certPEM, err := utils.GetNewCAandKey("cassandradatacenter-webhook-service", "test")
+	require.NoError(err)
+
+	require.NoError(os.WriteFile(filepath.Join(tmpDir, "tls.crt"), []byte(certPEM), 0o600))
+	require.NoError(os.WriteFile(filepath.Join(tmpDir, "tls.key"), []byte(keyPEM), 0o600))
+
+	webhookServer, webhookCertWatcher, webhookEnabled, err := setupWebhookServer(tmpDir, "tls.crt", "tls.key", []func(*tls.Config){})
+	require.NoError(err)
+	require.True(webhookEnabled)
+	require.NotNil(webhookCertWatcher)
+
+	defaultServer, ok := webhookServer.(*webhook.DefaultServer)
+	require.True(ok, "expected default webhook server implementation, got %T", webhookServer)
+	require.Len(defaultServer.Options.TLSOpts, 1)
+}

--- a/docs/developer/validating_webhook.md
+++ b/docs/developer/validating_webhook.md
@@ -14,5 +14,5 @@ Validating webhooks have specific requirements in kubernetes:
 explicitly configured in the kubernetes validatingwebhookconfiguration object.
 
 To support the above scenarios, the operator uses cert-manager to take care of generating and
-injecting the certificates. The validating webhook can be disabled in the OperatorConfig, which is
-mounted as a ConfigMap to the container.
+injecting the certificates. The validating webhook is only started when the manager is launched
+with `--webhook-cert-path` set, otherwise webhooks are disabled.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If no TLS cert path was given, we will disable the webhook server as Kubernetes requires the TLS to be set. We want to be explicit with this one instead of relying on the defaults provided in the controller-runtime.

**Which issue(s) this PR fixes**:
Fixes #899 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
