### PR TITLE
Add metrics around all mgmt-api calls in the client.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [ENHANCEMENT] [#888](https://github.com/k8ssandra/cass-operator/issues/888) Add new metrics around all calls to the mgmt-api. This allows to track if some calls are taking longer to execute than expected.
+
 ## v1.29.1
 
 * [BUGFIX] [#899](https://github.com/k8ssandra/cass-operator/issues/899) Skip webhook startup when the manager is launched without `--webhook-cert-path` (Helm chart behavior).

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -18,12 +18,35 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+const (
+	callDurationMetricName = "call_duration_seconds"
+	resultSuccessLabelName = "success"
+	resultErrorLabelName   = "error"
+)
+
+var nodeMgmtCallDurationMetric = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: "cass_operator",
+		Subsystem: "httphelper",
+		Name:      callDurationMetricName,
+		Help:      "Duration of management API calls.",
+		Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30},
+	},
+	[]string{"method", "route", "result"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(nodeMgmtCallDurationMetric)
+}
 
 type NodeMgmtClient struct {
 	Client   HttpClient
@@ -1240,6 +1263,11 @@ func (client *NodeMgmtClient) CallMove(pod *corev1.Pod, newToken string) (string
 
 func callNodeMgmtEndpoint(client *NodeMgmtClient, request nodeMgmtRequest, contentType string) ([]byte, error) {
 	client.Log.Info("client::callNodeMgmtEndpoint")
+	callResult := resultErrorLabelName
+	startTime := time.Now()
+	defer func() {
+		nodeMgmtCallDurationMetric.WithLabelValues(request.method, urlForMetric(request.endpoint), callResult).Observe(time.Since(startTime).Seconds())
+	}()
 
 	port := 8080
 	if request.port > 0 {
@@ -1302,7 +1330,16 @@ func callNodeMgmtEndpoint(client *NodeMgmtClient, request nodeMgmtRequest, conte
 		return nil, reqErr
 	}
 
+	callResult = resultSuccessLabelName
 	return body, nil
+}
+
+func urlForMetric(endpoint string) string {
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		return ""
+	}
+	return parsedEndpoint.Path
 }
 
 type RequestError struct {

--- a/pkg/httphelper/client_test.go
+++ b/pkg/httphelper/client_test.go
@@ -519,14 +519,14 @@ func TestCallDurationMetricSuccess(t *testing.T) {
 		return req.URL.Path == "/api/v0/ops/node/drain" && req.Method == http.MethodPost
 	})).Return(newHttpResponseMarshalled("OK", http.StatusOK), nil).Times(2)
 
-	before := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultSuccessLabelName)
+	before := getHttpHelperCallDurationCount(t, "/api/v0/ops/node/drain", resultSuccessLabelName)
 
 	mgmtClient := newMockMgmtClient(mockHttpClient)
 	require.NoError(mgmtClient.CallDrainEndpoint(goodPod))
 	require.NoError(mgmtClient.CallDrainEndpoint(goodPod))
 	require.True(mockHttpClient.AssertExpectations(t))
 
-	after := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultSuccessLabelName)
+	after := getHttpHelperCallDurationCount(t, "/api/v0/ops/node/drain", resultSuccessLabelName)
 	require.Equal(before+2, after)
 }
 
@@ -535,16 +535,16 @@ func TestCallDurationMetricError(t *testing.T) {
 
 	mockHttpClient := mocks.NewHttpClient(t)
 	mockHttpClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
-		return req.URL.Path == "/api/v0/ops/node/drain" && req.Method == http.MethodPost
+		return req.URL.Path == "/api/v0/ops/seeds/reload" && req.Method == http.MethodPost
 	})).Return(newHttpResponseMarshalled("this is an error", http.StatusInternalServerError), nil).Once()
 
-	before := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultErrorLabelName)
+	before := getHttpHelperCallDurationCount(t, "/api/v0/ops/seeds/reload", resultErrorLabelName)
 
 	mgmtClient := newMockMgmtClient(mockHttpClient)
-	require.Error(mgmtClient.CallDrainEndpoint(goodPod))
+	require.Error(mgmtClient.CallReloadSeedsEndpoint(goodPod))
 	require.True(mockHttpClient.AssertExpectations(t))
 
-	after := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultErrorLabelName)
+	after := getHttpHelperCallDurationCount(t, "/api/v0/ops/seeds/reload", resultErrorLabelName)
 	require.Equal(before+1, after)
 }
 
@@ -562,7 +562,7 @@ func newMockHttpClient(response *http.Response, err error) *mocks.HttpClient {
 	return httpClient
 }
 
-func getHttpHelperCallDurationCount(t *testing.T, method, route, result string) uint64 {
+func getHttpHelperCallDurationCount(t *testing.T, route, result string) uint64 {
 	t.Helper()
 
 	metricName := fmt.Sprintf("cass_operator_httphelper_%s", callDurationMetricName)
@@ -580,7 +580,7 @@ func getHttpHelperCallDurationCount(t *testing.T, method, route, result string) 
 				labels[label.GetName()] = label.GetValue()
 			}
 
-			if labels["method"] == method && labels["route"] == route && labels["result"] == result {
+			if labels["route"] == route && labels["result"] == result {
 				return metric.GetHistogram().GetSampleCount()
 			}
 		}

--- a/pkg/httphelper/client_test.go
+++ b/pkg/httphelper/client_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 )
@@ -509,6 +511,43 @@ func TestDropRole(t *testing.T) {
 	require.True(mockHttpClient.AssertExpectations(t))
 }
 
+func TestCallDurationMetricSuccess(t *testing.T) {
+	require := require.New(t)
+
+	mockHttpClient := mocks.NewHttpClient(t)
+	mockHttpClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.Path == "/api/v0/ops/node/drain" && req.Method == http.MethodPost
+	})).Return(newHttpResponseMarshalled("OK", http.StatusOK), nil).Times(2)
+
+	before := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultSuccessLabelName)
+
+	mgmtClient := newMockMgmtClient(mockHttpClient)
+	require.NoError(mgmtClient.CallDrainEndpoint(goodPod))
+	require.NoError(mgmtClient.CallDrainEndpoint(goodPod))
+	require.True(mockHttpClient.AssertExpectations(t))
+
+	after := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultSuccessLabelName)
+	require.Equal(before+2, after)
+}
+
+func TestCallDurationMetricError(t *testing.T) {
+	require := require.New(t)
+
+	mockHttpClient := mocks.NewHttpClient(t)
+	mockHttpClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		return req.URL.Path == "/api/v0/ops/node/drain" && req.Method == http.MethodPost
+	})).Return(newHttpResponseMarshalled("this is an error", http.StatusInternalServerError), nil).Once()
+
+	before := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultErrorLabelName)
+
+	mgmtClient := newMockMgmtClient(mockHttpClient)
+	require.Error(mgmtClient.CallDrainEndpoint(goodPod))
+	require.True(mockHttpClient.AssertExpectations(t))
+
+	after := getHttpHelperCallDurationCount(t, http.MethodPost, "/api/v0/ops/node/drain", resultErrorLabelName)
+	require.Equal(before+1, after)
+}
+
 func newMockMgmtClient(httpClient *mocks.HttpClient) *NodeMgmtClient {
 	return &NodeMgmtClient{
 		Client:   httpClient,
@@ -521,6 +560,32 @@ func newMockHttpClient(response *http.Response, err error) *mocks.HttpClient {
 	httpClient := new(mocks.HttpClient)
 	httpClient.On("Do", mock.Anything).Return(response, err)
 	return httpClient
+}
+
+func getHttpHelperCallDurationCount(t *testing.T, method, route, result string) uint64 {
+	t.Helper()
+
+	metricName := fmt.Sprintf("cass_operator_httphelper_%s", callDurationMetricName)
+	families, err := metrics.Registry.Gather()
+	require.NoError(t, err)
+
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+
+			if labels["method"] == method && labels["route"] == route && labels["result"] == result {
+				return metric.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
 }
 
 func newHttpResponse(responseBody []byte, status int) *http.Response {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds new Histogram for all metric calls. This can be used to debug slow calls (there shouldn't be any, unless they are sync jobs).

**Which issue(s) this PR fixes**:
Fixes #888 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
