### PR TITLE
Prevent any scaling operations from happening if trackedTask is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#902](https://github.com/k8ssandra/cass-operator/issues/902) Cleanup tracking did not stop the process of requesting a scale down to happen before the task itself was finished. This could cause issues with the cleanup task finishing since nodes it was supposed to clean were deleted.
+
 ## v1.29.1
 
 * [BUGFIX] [#899](https://github.com/k8ssandra/cass-operator/issues/899) Skip webhook startup when the manager is launched without `--webhook-cert-path` (Helm chart behavior).

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -67,6 +67,10 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 		return result.Continue()
 	}
 
+	if _, res := rc.waitForTrackedCleanupTask(); res.Completed() {
+		return res
+	}
+
 	decommRackInfo, err := rc.CalculateRackInfoForDecomm(int(currentSize))
 	if err != nil {
 		logger.Error(err, "error calculating rack info for decommissioning nodes")

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -937,10 +937,6 @@ func (rc *ReconciliationContext) CheckRackScale() result.ReconcileResult {
 		maxReplicas := *statefulSet.Spec.Replicas
 
 		if maxReplicas < desiredNodeCount {
-			if _, res := rc.waitForTrackedCleanupTask(); res.Completed() {
-				return res
-			}
-
 			// Check to see if we are resuming from stopped and update conditions appropriately
 			if dc.GetConditionStatus(api.DatacenterStopped) == corev1.ConditionTrue {
 				if err := rc.setConditionStatus(api.DatacenterStopped, corev1.ConditionFalse); err != nil {

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -937,6 +937,10 @@ func (rc *ReconciliationContext) CheckRackScale() result.ReconcileResult {
 		maxReplicas := *statefulSet.Spec.Replicas
 
 		if maxReplicas < desiredNodeCount {
+			if _, res := rc.waitForTrackedCleanupTask(); res.Completed() {
+				return res
+			}
+
 			// Check to see if we are resuming from stopped and update conditions appropriately
 			if dc.GetConditionStatus(api.DatacenterStopped) == corev1.ConditionTrue {
 				if err := rc.setConditionStatus(api.DatacenterStopped, corev1.ConditionFalse); err != nil {
@@ -2444,16 +2448,8 @@ func (rc *ReconciliationContext) CheckCassandraNodeStatuses() result.ReconcileRe
 
 func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 	if !metav1.HasAnnotation(rc.Datacenter.ObjectMeta, api.NoAutomatedCleanupAnnotation) {
-		if metav1.HasAnnotation(rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation) {
-			// Verify if the cleanup task has completed before moving on the with ScalingUp finished
-			task, err := rc.findActiveTask(taskapi.CommandCleanup)
-			if err != nil {
-				return result.Error(err)
-			}
-
-			if task != nil {
-				return rc.activeTaskCompleted(task)
-			}
+		if trackedTaskFound, res := rc.waitForTrackedCleanupTask(); res.Completed() || trackedTaskFound {
+			return res
 		}
 
 		// Create the cleanup task
@@ -2467,6 +2463,23 @@ func (rc *ReconciliationContext) cleanupAfterScaling() result.ReconcileResult {
 	}
 
 	return result.Continue()
+}
+
+func (rc *ReconciliationContext) waitForTrackedCleanupTask() (bool, result.ReconcileResult) {
+	if !metav1.HasAnnotation(rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation) {
+		return false, result.Continue()
+	}
+
+	task, err := rc.findActiveTask(taskapi.CommandCleanup)
+	if err != nil {
+		return true, result.Error(err)
+	}
+
+	if task != nil {
+		return true, rc.activeTaskCompleted(task)
+	}
+
+	return false, result.Continue()
 }
 
 func (rc *ReconciliationContext) createCleanupTask() error {
@@ -2556,6 +2569,24 @@ func (rc *ReconciliationContext) findActiveTask(command taskapi.CassandraCommand
 	return nil, nil
 }
 
+func (rc *ReconciliationContext) CheckCleanupAfterScaling() result.ReconcileResult {
+	rc.ReqLogger.Info("reconcile_racks::CheckCleanupAfterScaling")
+
+	if rc.Datacenter.GetConditionStatus(api.DatacenterScalingUp) != corev1.ConditionTrue {
+		return result.Continue()
+	}
+
+	if res := rc.cleanupAfterScaling(); res.Completed() {
+		return res
+	}
+
+	if err := rc.setConditionStatus(api.DatacenterScalingUp, corev1.ConditionFalse); err != nil {
+		return result.Error(err)
+	}
+
+	return result.Continue()
+}
+
 func (rc *ReconciliationContext) CheckClearActionConditions() result.ReconcileResult {
 	rc.ReqLogger.Info("reconcile_racks::CheckClearActionConditions")
 	dc := rc.Datacenter
@@ -2571,18 +2602,6 @@ func (rc *ReconciliationContext) CheckClearActionConditions() result.ReconcileRe
 	}
 	conditionsThatShouldBeTrue := []api.DatacenterConditionType{
 		api.DatacenterValid,
-	}
-
-	// Explicitly handle scaling up here because we want to run a cleanup afterwards
-	if dc.GetConditionStatus(api.DatacenterScalingUp) == corev1.ConditionTrue {
-		// Spawn a cleanup task before continuing
-		if res := rc.cleanupAfterScaling(); res.Completed() {
-			return res
-		}
-
-		if err := rc.setConditionStatus(api.DatacenterScalingUp, corev1.ConditionFalse); err != nil {
-			return result.Error(err)
-		}
 	}
 
 	// Make sure that the stopped condition matches the spec, because logically
@@ -2753,6 +2772,10 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 	}
 
 	if recResult := rc.CheckCassandraNodeStatuses(); recResult.Completed() {
+		return recResult.Output()
+	}
+
+	if recResult := rc.CheckCleanupAfterScaling(); recResult.Completed() {
 		return recResult.Output()
 	}
 

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1868,49 +1868,6 @@ func TestCleanupAfterScaling(t *testing.T) {
 	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
 }
 
-func TestCheckRackScale_WaitsForTrackedCleanupTask(t *testing.T) {
-	rc, _, cleanupMockScr := setupTest()
-	defer cleanupMockScr()
-	assert := assert.New(t)
-
-	mockClient := mocks.NewClient(t)
-	rc.Client = mockClient
-
-	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation, "true")
-
-	statefulSet, err := newStatefulSetForCassandraDatacenter(nil, "default", rc.Datacenter, 1, imageRegistry)
-	require.NoError(t, err)
-	rc.statefulSets = []*appsv1.StatefulSet{statefulSet}
-	rc.desiredRackInformation = []*RackInformation{{
-		RackName:  "default",
-		NodeCount: 2,
-	}}
-
-	task := &taskapi.CassandraTask{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cleanup-task",
-			Namespace: rc.Datacenter.Namespace,
-		},
-		Spec: taskapi.CassandraTaskSpec{
-			CassandraTaskTemplate: taskapi.CassandraTaskTemplate{
-				Jobs: []taskapi.CassandraJob{{
-					Command: taskapi.CommandCleanup,
-				}},
-			},
-		},
-	}
-	rc.Datacenter.Status.AddTaskToTrack(task.ObjectMeta)
-
-	k8sMockClientGet(mockClient, nil).
-		Run(func(args mock.Arguments) {
-			task.DeepCopyInto(args.Get(2).(*taskapi.CassandraTask))
-		})
-
-	r := rc.CheckRackScale()
-	assert.Equal(result.RequeueSoon(10), r)
-	assert.Equal(int32(1), *statefulSet.Spec.Replicas)
-}
-
 func TestCheckCleanupAfterScaling_WaitsForTrackedCleanupTask(t *testing.T) {
 	rc, _, cleanupMockScr := setupTest()
 	defer cleanupMockScr()

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1836,50 +1836,23 @@ func TestCleanupAfterScaling(t *testing.T) {
 	mockClient := mocks.NewClient(t)
 	rc.Client = mockClient
 
-	var task *taskapi.CassandraTask
-	// 1. Create task - return ok
-	k8sMockClientCreate(rc.Client.(*mocks.Client), nil).
-		Run(func(args mock.Arguments) {
-			arg := args.Get(1).(*taskapi.CassandraTask)
-			task = arg
-		}).
-		Times(1)
-
-	r := rc.cleanupAfterScaling()
-	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
-	assert.Equal(taskapi.CommandCleanup, task.Spec.Jobs[0].Command)
-	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
-	assert.Nil(task.Spec.MaxConcurrentPods)
-}
-
-func TestCleanupAfterScalingWithTracker(t *testing.T) {
-	rc, _, cleanupMockScr := setupTest()
-	defer cleanupMockScr()
-	assert := assert.New(t)
-
-	// Setup annotation
-
-	mockClient := mocks.NewClient(t)
-	rc.Client = mockClient
-
 	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation, "true")
 
+	rc.Datacenter.SetCondition(*api.NewDatacenterCondition(api.DatacenterScalingUp, corev1.ConditionTrue))
 	var task *taskapi.CassandraTask
-	// 1. Create task - return ok
 	k8sMockClientCreate(rc.Client.(*mocks.Client), nil).
 		Run(func(args mock.Arguments) {
 			arg := args.Get(1).(*taskapi.CassandraTask)
 			task = arg
-		}).
-		Times(1)
+		}).Once()
 
 	k8sMockClientStatusPatch(mockClient.Status().(*mocks.SubResourceClient), nil).Once()
 
-	r := rc.cleanupAfterScaling()
+	r := rc.CheckCleanupAfterScaling()
 	assert.Equal(taskapi.CommandCleanup, task.Spec.Jobs[0].Command)
 	assert.Equal(result.RequeueSoon(10), r, "expected result of result.RequeueSoon(10)")
 	assert.Equal(1, len(rc.Datacenter.Status.TrackedTasks))
-	// 3. GET - return completed task
+
 	k8sMockClientGet(rc.Client.(*mocks.Client), nil).
 		Run(func(args mock.Arguments) {
 			arg := args.Get(2).(*taskapi.CassandraTask)
@@ -1887,38 +1860,138 @@ func TestCleanupAfterScalingWithTracker(t *testing.T) {
 			timeNow := metav1.Now()
 			arg.Status.CompletionTime = &timeNow
 		}).Once()
-	// 4. Patch to datacenter status
+
 	k8sMockClientStatusPatch(mockClient.Status().(*mocks.SubResourceClient), nil).Once()
-	r = rc.cleanupAfterScaling()
+	k8sMockClientStatusUpdate(mockClient.Status().(*mocks.SubResourceClient), nil).Once()
+	r = rc.CheckCleanupAfterScaling()
 	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
 	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
-	assert.Nil(task.Spec.MaxConcurrentPods)
 }
 
-func TestCleanupAfterScalingWithParallelAnnotation(t *testing.T) {
+func TestCheckRackScale_WaitsForTrackedCleanupTask(t *testing.T) {
 	rc, _, cleanupMockScr := setupTest()
 	defer cleanupMockScr()
 	assert := assert.New(t)
 
 	mockClient := mocks.NewClient(t)
 	rc.Client = mockClient
-	_ = rc.CalculateRackInformation()
-	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.EnableParallelCleanupWithinRackAnnotation, "true")
 
-	var task *taskapi.CassandraTask
-	// 1. Create task - return ok
-	k8sMockClientCreate(rc.Client.(*mocks.Client), nil).
+	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation, "true")
+
+	statefulSet, err := newStatefulSetForCassandraDatacenter(nil, "default", rc.Datacenter, 1, imageRegistry)
+	require.NoError(t, err)
+	rc.statefulSets = []*appsv1.StatefulSet{statefulSet}
+	rc.desiredRackInformation = []*RackInformation{{
+		RackName:  "default",
+		NodeCount: 2,
+	}}
+
+	task := &taskapi.CassandraTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cleanup-task",
+			Namespace: rc.Datacenter.Namespace,
+		},
+		Spec: taskapi.CassandraTaskSpec{
+			CassandraTaskTemplate: taskapi.CassandraTaskTemplate{
+				Jobs: []taskapi.CassandraJob{{
+					Command: taskapi.CommandCleanup,
+				}},
+			},
+		},
+	}
+	rc.Datacenter.Status.AddTaskToTrack(task.ObjectMeta)
+
+	k8sMockClientGet(mockClient, nil).
 		Run(func(args mock.Arguments) {
-			arg := args.Get(1).(*taskapi.CassandraTask)
-			task = arg
-		}).
-		Times(1)
+			task.DeepCopyInto(args.Get(2).(*taskapi.CassandraTask))
+		})
 
-	r := rc.cleanupAfterScaling()
-	assert.Equal(result.Continue(), r, "expected result of result.Continue()")
-	assert.Equal(taskapi.CommandCleanup, task.Spec.Jobs[0].Command)
+	r := rc.CheckRackScale()
+	assert.Equal(result.RequeueSoon(10), r)
+	assert.Equal(int32(1), *statefulSet.Spec.Replicas)
+}
+
+func TestCheckCleanupAfterScaling_WaitsForTrackedCleanupTask(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	assert := assert.New(t)
+
+	mockClient := mocks.NewClient(t)
+	rc.Client = mockClient
+
+	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation, "true")
+	rc.Datacenter.SetCondition(api.DatacenterCondition{
+		Status: corev1.ConditionTrue,
+		Type:   api.DatacenterScalingUp,
+	})
+
+	task := &taskapi.CassandraTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cleanup-task",
+			Namespace: rc.Datacenter.Namespace,
+		},
+		Spec: taskapi.CassandraTaskSpec{
+			CassandraTaskTemplate: taskapi.CassandraTaskTemplate{
+				Jobs: []taskapi.CassandraJob{{
+					Command: taskapi.CommandCleanup,
+				}},
+			},
+		},
+	}
+	rc.Datacenter.Status.AddTaskToTrack(task.ObjectMeta)
+
+	k8sMockClientGet(mockClient, nil).
+		Run(func(args mock.Arguments) {
+			task.DeepCopyInto(args.Get(2).(*taskapi.CassandraTask))
+		})
+
+	r := rc.CheckCleanupAfterScaling()
+	assert.Equal(result.RequeueSoon(10), r)
+	assert.Equal(corev1.ConditionTrue, rc.Datacenter.GetConditionStatus(api.DatacenterScalingUp))
+}
+
+func TestCheckCleanupAfterScaling_ClearsScalingUpWhenTrackedCleanupCompletes(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	assert := assert.New(t)
+
+	mockClient := mocks.NewClient(t)
+	rc.Client = mockClient
+
+	metav1.SetMetaDataAnnotation(&rc.Datacenter.ObjectMeta, api.TrackCleanupTasksAnnotation, "true")
+	rc.Datacenter.SetCondition(api.DatacenterCondition{
+		Status: corev1.ConditionTrue,
+		Type:   api.DatacenterScalingUp,
+	})
+
+	task := &taskapi.CassandraTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cleanup-task",
+			Namespace: rc.Datacenter.Namespace,
+		},
+		Spec: taskapi.CassandraTaskSpec{
+			CassandraTaskTemplate: taskapi.CassandraTaskTemplate{
+				Jobs: []taskapi.CassandraJob{{
+					Command: taskapi.CommandCleanup,
+				}},
+			},
+		},
+	}
+	rc.Datacenter.Status.AddTaskToTrack(task.ObjectMeta)
+
+	k8sMockClientGet(mockClient, nil).
+		Run(func(args mock.Arguments) {
+			task.DeepCopyInto(args.Get(2).(*taskapi.CassandraTask))
+			timeNow := metav1.Now()
+			args.Get(2).(*taskapi.CassandraTask).Status.CompletionTime = &timeNow
+		})
+	k8sMockClientStatusPatch(mockClient.Status().(*mocks.SubResourceClient), nil).Once()
+	k8sMockClientStatusUpdate(mockClient.Status().(*mocks.SubResourceClient), nil).Once()
+
+	r := rc.CheckCleanupAfterScaling()
+	assert.Equal(result.Continue(), r)
+	assert.Equal(corev1.ConditionFalse, rc.Datacenter.GetConditionStatus(api.DatacenterScalingUp))
 	assert.Equal(0, len(rc.Datacenter.Status.TrackedTasks))
-	assert.Equal(*task.Spec.MaxConcurrentPods, rc.desiredRackInformation[0].NodeCount)
 }
 
 func TestStripPassword(t *testing.T) {

--- a/tests/scale_down/scale_down_suite_test.go
+++ b/tests/scale_down/scale_down_suite_test.go
@@ -80,26 +80,43 @@ var _ = Describe(testName, func() {
 			k = kubectl.Delete("job", easyStressJobName)
 			ns.ExecAndLog(step, k)
 
-			step = "scale up to 4 nodes"
-			json := "{\"spec\": {\"size\": 4}}"
+			step = "enable tracked cleanup tasks"
+			json := "{\"metadata\": {\"annotations\": {\"cassandra.datastax.com/track-cleanup-tasks\": \"true\"}}}"
+			k = kubectl.PatchMerge(dcResource, json)
+			ns.ExecAndLog(step, k)
+
+			step = "scale up to 6 nodes"
+			json = "{\"spec\": {\"size\": 6}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 
 			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionTrue))
 
-			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 30)
-			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionFalse))
-			ns.WaitForDatacenterOperatorProgress(dcName, "Ready", 360)
-
-			step = "scale down to 3 nodes"
+			step = "scale down to 3 nodes while cleanup task is still running"
 			json = "{\"spec\": {\"size\": 3}}"
 			k = kubectl.PatchMerge(dcResource, json)
 			ns.ExecAndLog(step, k)
 
+			step = "wait for cleanup task to be running"
+			json = "jsonpath={.items[?(@.status.completionTime == \"\")].spec.jobs[0].command}"
+			k = kubectl.Get("CassandraTask").
+				WithLabel(dcLabel).
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "cleanup", 120)
+
+			step = "ensure scale down has not started before cleanup finishes"
+			json = "jsonpath={.items[*].metadata.name}"
+			k = kubectl.Get("pod").
+				WithLabel("cassandra.datastax.com/node-state=Decommissioning").
+				FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, "", 30)
+
+			ns.WaitForCompletedCassandraTasks(dcName, "cleanup", 1)
+			ns.WaitForDatacenterCondition(dcName, "ScalingUp", string(corev1.ConditionFalse))
 			ns.WaitForDatacenterCondition(dcName, "ScalingDown", string(corev1.ConditionTrue))
 
 			podWithDecommissionedNode := "cluster1-dc1-r1-sts-1"
-			podPvcName := "server-data-cluster2-dc1-r1-sts-1"
+			podPvcName := "server-data-cluster1-dc1-r1-sts-1"
 
 			step = "check node status set to decommissioning"
 			json = "jsonpath={.items[*].metadata.name}"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds additional blocks for operations that try to scale the cluster if a tracked task is running and it is expected to waited for. 

**Which issue(s) this PR fixes**:
Fixes #902

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
