### PR TITLE
Change regexp to allow wider version ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [CHANGE] [#905](https://github.com/k8ssandra/cass-operator/issues/905) Relax the ServerVersion checks to structure only without separating OSS/DSE/HCD.
 * [FEATURE] [#893](https://github.com/k8ssandra/cass-operator/issues/893) Add support for maxUnavailable (Kubernetes 1.35 and up). This allows to make changes to the Cassandra pods in parallel, thus speeding up changes in larger clusters. Allows integer or percentage setting, but will never target more than one rack at a time. 
 * [ENHANCEMENT] [#888](https://github.com/k8ssandra/cass-operator/issues/888) Add new metrics around all calls to the mgmt-api. This allows to track if some calls are taking longer to execute than expected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [CHANGE] [#905](https://github.com/k8ssandra/cass-operator/issues/905) Relax the ServerVersion checks to structure only without separating OSS/DSE/HCD.
 * [FEATURE] [#893](https://github.com/k8ssandra/cass-operator/issues/893) Add support for maxUnavailable (Kubernetes 1.35 and up). This allows to make changes to the Cassandra pods in parallel, thus speeding up changes in larger clusters. Allows integer or percentage setting, but will never target more than one rack at a time. 
 * [ENHANCEMENT] [#888](https://github.com/k8ssandra/cass-operator/issues/888) Add new metrics around all calls to the mgmt-api. This allows to track if some calls are taking longer to execute than expected.
+* [ENHANCEMENT] [#873](https://github.com/k8ssandra/cass-operator/issues/873) Allow replacing multiple previously bootstrapped nodes in parallel. Also, the CassandraTask to replace pod accepts RackName as alternative to PodName as filtering rule.
 
 ## v1.29.1
 
 * [BUGFIX] [#899](https://github.com/k8ssandra/cass-operator/issues/899) Skip webhook startup when the manager is launched without `--webhook-cert-path` (Helm chart behavior).
 * [BUGFIX] [#887](https://github.com/k8ssandra/cass-operator/issues/887) Prevents infinite loop when seed refresh times out during node failures, allowing the operator to recover.
-* [ENHANCEMENT] [#873](https://github.com/k8ssandra/cass-operator/issues/873) Allow replacing multiple previously bootstrapped nodes in parallel. Also, the CassandraTask to replace pod accepts RackName as alternative to PodName as filtering rule.
 
 ## v1.29.0
 

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.19.0
 OPERATOR_SDK_VERSION ?= 1.42.0
 HELM_VERSION ?= 3.19.4
 OPM_VERSION ?= 1.61.0
-GOLANGCI_LINT_VERSION ?= v2.10.1
+GOLANGCI_LINT_VERSION ?= v2.11.3
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -121,7 +121,7 @@ type CassandraDatacenterSpec struct {
 
 	// Version string for config builder,
 	// used to generate Cassandra server configuration
-	// +kubebuilder:validation:Pattern=(6\.[89]\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)|(5\.\d+\.\d+)|(1\.\d+\.\d+)
+	// +kubebuilder:validation:Pattern=(\d+\.\d+\.\d+)
 	ServerVersion string `json:"serverVersion"`
 
 	// Cassandra server image name. Use of ImageConfig to match ServerVersion is recommended instead of this value.

--- a/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
+++ b/config/crd/bases/cassandra.datastax.com_cassandradatacenters.yaml
@@ -9883,7 +9883,7 @@ spec:
                 description: |-
                   Version string for config builder,
                   used to generate Cassandra server configuration
-                pattern: (6\.[89]\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)|(5\.\d+\.\d+)|(1\.\d+\.\d+)
+                pattern: (\d+\.\d+\.\d+)
                 type: string
               serviceAccount:
                 description: Deprecated DeprecatedServiceAccount Use ServiceAccountName

--- a/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook.go
+++ b/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
-	"github.com/k8ssandra/cass-operator/pkg/images"
 )
 
 // log is for logging in this package.
@@ -104,29 +103,9 @@ func (v *CassandraDatacenterCustomValidator) ValidateDelete(ctx context.Context,
 
 // ValidateSingleDatacenter checks that no values are improperly set on a CassandraDatacenter
 func ValidateSingleDatacenter(dc *api.CassandraDatacenter) error {
-	// Ensure serverVersion and serverType are compatible
-
-	if dc.Spec.ServerType == "dse" {
-		if !images.IsDseVersionSupported(dc.Spec.ServerVersion) {
-			return attemptedTo("use unsupported DSE version '%s'", dc.Spec.ServerVersion)
-		}
-	}
-
-	if dc.Spec.ServerType == "hcd" {
-		if !images.IsHCDVersionSupported(dc.Spec.ServerVersion) {
-			return attemptedTo("use unsupported HCD version '%s'", dc.Spec.ServerVersion)
-		}
-	}
-
 	if dc.Spec.ServerType == "cassandra" && dc.Spec.DseWorkloads != nil {
 		if dc.Spec.DseWorkloads.AnalyticsEnabled || dc.Spec.DseWorkloads.GraphEnabled || dc.Spec.DseWorkloads.SearchEnabled {
 			return attemptedTo("enable DSE workloads if server type is Cassandra")
-		}
-	}
-
-	if dc.Spec.ServerType == "cassandra" {
-		if !images.IsOssVersionSupported(dc.Spec.ServerVersion) {
-			return attemptedTo("use unsupported Cassandra version '%s'", dc.Spec.ServerVersion)
 		}
 	}
 

--- a/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook_test.go
+++ b/internal/webhooks/cassandra/v1beta1/cassandradatacenter_webhook_test.go
@@ -76,45 +76,6 @@ func Test_ValidateSingleDatacenter(t *testing.T) {
 			errString: "",
 		},
 		{
-			name: "DSE 7.0.0 invalid",
-			dc: &api.CassandraDatacenter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "exampleDC",
-				},
-				Spec: api.CassandraDatacenterSpec{
-					ServerType:    "dse",
-					ServerVersion: "7.0.0",
-				},
-			},
-			errString: "use unsupported DSE version '7.0.0'",
-		},
-		{
-			name: "DSE Invalid",
-			dc: &api.CassandraDatacenter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "exampleDC",
-				},
-				Spec: api.CassandraDatacenterSpec{
-					ServerType:    "dse",
-					ServerVersion: "4.8.0",
-				},
-			},
-			errString: "use unsupported DSE version '4.8.0'",
-		},
-		{
-			name: "DSE 5 Invalid",
-			dc: &api.CassandraDatacenter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "exampleDC",
-				},
-				Spec: api.CassandraDatacenterSpec{
-					ServerType:    "dse",
-					ServerVersion: "5.0.0",
-				},
-			},
-			errString: "use unsupported DSE version '5.0.0'",
-		},
-		{
 			name: "Cassandra valid",
 			dc: &api.CassandraDatacenter{
 				ObjectMeta: metav1.ObjectMeta{
@@ -165,32 +126,6 @@ func Test_ValidateSingleDatacenter(t *testing.T) {
 				},
 			},
 			errString: "",
-		},
-		{
-			name: "Cassandra Invalid",
-			dc: &api.CassandraDatacenter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "exampleDC",
-				},
-				Spec: api.CassandraDatacenterSpec{
-					ServerType:    "cassandra",
-					ServerVersion: "6.8.0",
-				},
-			},
-			errString: "use unsupported Cassandra version '6.8.0'",
-		},
-		{
-			name: "Cassandra Invalid too",
-			dc: &api.CassandraDatacenter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "exampleDC",
-				},
-				Spec: api.CassandraDatacenterSpec{
-					ServerType:    "cassandra",
-					ServerVersion: "7.0.0",
-				},
-			},
-			errString: "use unsupported Cassandra version '7.0.0'",
 		},
 		{
 			name: "Dse Workloads in Cassandra Invalid",

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -6,7 +6,6 @@ package images
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,9 +26,6 @@ type imageRegistry struct {
 }
 
 const (
-	ValidDseVersionRegexp      = "(6\\.[89]\\.\\d+)"
-	ValidHcdVersionRegexp      = "(1\\.\\d+\\.\\d+)"
-	ValidOssVersionRegexp      = "(3\\.11\\.\\d+)|(4\\.\\d+\\.\\d+)|(5\\.\\d+\\.\\d+)"
 	DefaultCassandraRepository = "k8ssandra/cass-management-api"
 	DefaultDSERepository       = "datastax/dse-mgmtapi-6_8"
 	DefaultHCDRepository       = "datastax/hcd"
@@ -71,21 +67,6 @@ func (i *imageRegistry) loadImageConfig(content []byte) (*configv1beta1.ImageCon
 	i.imageConfig = *parsedImageConfig
 
 	return parsedImageConfig, nil
-}
-
-func IsDseVersionSupported(version string) bool {
-	validVersions := regexp.MustCompile(ValidDseVersionRegexp)
-	return validVersions.MatchString(version)
-}
-
-func IsOssVersionSupported(version string) bool {
-	validVersions := regexp.MustCompile(ValidOssVersionRegexp)
-	return validVersions.MatchString(version)
-}
-
-func IsHCDVersionSupported(version string) bool {
-	validVersions := regexp.MustCompile(ValidHcdVersionRegexp)
-	return validVersions.MatchString(version)
 }
 
 func (i *imageRegistry) splitRegistry(image string) (registry string, imageNoRegistry string) {
@@ -230,17 +211,9 @@ func (i *imageRegistry) GetCassandraImage(serverType, version string) (string, e
 
 	switch serverType {
 	case "dse":
-		if !IsDseVersionSupported(version) {
-			return "", fmt.Errorf("server 'dse' and version '%s' do not work together", version)
-		}
 	case "cassandra":
-		if !IsOssVersionSupported(version) {
-			return "", fmt.Errorf("server 'cassandra' and version '%s' do not work together", version)
-		}
 	case "hcd":
-		if !IsHCDVersionSupported(version) {
-			return "", fmt.Errorf("server 'hcd' and version '%s' do not work together", version)
-		}
+		break
 	default:
 		return "", fmt.Errorf("server type '%s' is not supported", serverType)
 	}

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -168,15 +168,6 @@ func TestDefaultRepositories(t *testing.T) {
 	assert.Equal("datastax/dse-mgmtapi-6_8:6.8.17", path)
 }
 
-func TestOssValidVersions(t *testing.T) {
-	assert := assert.New(t)
-	assert.True(IsOssVersionSupported("4.0.0"))
-	assert.True(IsOssVersionSupported("4.1.0"))
-	assert.False(IsOssVersionSupported("4.0"))
-	assert.False(IsOssVersionSupported("4.1"))
-	assert.False(IsOssVersionSupported("6.8.0"))
-}
-
 func TestPullPolicyOverride(t *testing.T) {
 	assert := require.New(t)
 	imageConfigFile := filepath.Join("..", "..", "tests", "testdata", "image_config_parsing.yaml")

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -1581,26 +1581,6 @@ func Test_makeImage(t *testing.T) {
 			errString: "",
 		},
 		{
-			name: "test unknown dse version",
-			args: args{
-				serverImage:   "",
-				serverType:    "dse",
-				serverVersion: "6.7.0",
-			},
-			want:      "",
-			errString: "server 'dse' and version '6.7.0' do not work together",
-		},
-		{
-			name: "test unknown cassandra version",
-			args: args{
-				serverImage:   "",
-				serverType:    "cassandra",
-				serverVersion: "3.10.0",
-			},
-			want:      "",
-			errString: "server 'cassandra' and version '3.10.0' do not work together",
-		},
-		{
 			name: "test fallback",
 			args: args{
 				serverImage:   "",

--- a/tests/webhook_validation/webhook_validation_suite_test.go
+++ b/tests/webhook_validation/webhook_validation_suite_test.go
@@ -81,11 +81,6 @@ var _ = Describe(testName, func() {
 				FormatOutput(json)
 			ns.WaitForOutputAndLog(step, k, "Ready", 30)
 
-			step = "attempt to use invalid dse version"
-			json = "{\"spec\": {\"serverType\": \"dse\", \"serverVersion\": \"6.7.0\"}}"
-			k = kubectl.PatchMerge(dcResource, json)
-			ns.ExecAndLogAndExpectErrorString(step, k,
-				`spec.serverVersion: Invalid value: "6.7.0": spec.serverVersion in body should match '(6\.[89]\.\d+)|(3\.11\.\d+)|(4\.\d+\.\d+)|(5\.\d+\.\d+)|(1\.\d+\.\d+)'`)
 			step = "attempt to change the cluster name"
 			json = "{\"spec\": {\"clusterName\": \"NewName\"}}"
 			k = kubectl.PatchMerge(dcResource, json)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Relaxes the serverVersion validation to allow Cassandra 6.0.x, HCD 2.0.x and similar. We seem to be using the full spectrum of version numbers anyway, it makes no sense to timegate the new major releases behind a new cass-operator release requirement.

**Which issue(s) this PR fixes**:
Fixes #905 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
