### PR TITLE
Split RBAC rights to smaller entitities, remove certain verbs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,11 +23,38 @@ rules:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - endpoints/restricted
+  verbs:
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
-  - pods
   - secrets
   - services
   verbs:
@@ -41,9 +68,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
+  - pods
   verbs:
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -58,7 +58,10 @@ var (
 
 // Kubernetes core
 // +kubebuilder:rbac:groups=apps,namespace=cass-operator,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods;endpoints;endpoints/restricted;services;configmaps;secrets;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=services;secrets;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=endpoints;endpoints/restricted,verbs=list;watch;delete
+// +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=events,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=core,namespace=cass-operator,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -138,8 +138,6 @@ func (t *TaskConfiguration) PreProcess() error {
 //+kubebuilder:rbac:groups=control.k8ssandra.io,namespace=cass-operator,resources=cassandratasks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=control.k8ssandra.io,namespace=cass-operator,resources=cassandratasks/finalizers,verbs=update
 
-//+kubebuilder:rbac:groups=core,namespace=cass-operator,resources=pods;events,verbs=get;list;watch;create;update;patch;delete
-
 func (r *CassandraTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Remove one duplicate RBAC kubebuilder rule, split some rules to separate lines to allow more fine granular settings. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
