### PR TITLE
Re-assert datacenter progress/condition metrics on every reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [BUGFIX] [#936](https://github.com/k8ssandra/cass-operator/issues/936) Re-assert datacenter progress and condition metrics from status on every reconcile so they are not lost on operator restart or leader change.
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 
 ## v1.31.0

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -124,6 +124,18 @@ func UpdateOperatorDatacenterProgressStatusMetric(dc *api.CassandraDatacenter, s
 	DatacenterOperatorStatusVec.WithLabelValues(dc.Namespace, dc.Spec.ClusterName, dc.DatacenterName(), string(state)).Set(1)
 }
 
+// UpdateDatacenterMetricsFromStatus re-asserts the progress and condition gauges from the
+// datacenter's persisted status. These are otherwise only written on a transition, so they are
+// lost on operator restart or leader change until the datacenter changes state again.
+func UpdateDatacenterMetricsFromStatus(dc *api.CassandraDatacenter) {
+	if dc.Status.CassandraOperatorProgress != "" {
+		UpdateOperatorDatacenterProgressStatusMetric(dc, dc.Status.CassandraOperatorProgress)
+	}
+	for _, condition := range dc.Status.Conditions {
+		SetDatacenterConditionMetric(dc, condition.Type, condition.Status)
+	}
+}
+
 // Add CassandraTask status also (how many pods done etc) per task
 // Add podnames to the CassandraTask status that are done? Or waiting?
 

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -78,6 +78,46 @@ func TestMetricAdder(t *testing.T) {
 	require.Error(err)
 }
 
+func TestUpdateDatacenterMetricsFromStatus(t *testing.T) {
+	require := require.New(t)
+
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{Name: "datacenter1", Namespace: "ns"},
+		Spec:       api.CassandraDatacenterSpec{ClusterName: "cluster1"},
+		Status: api.CassandraDatacenterStatus{
+			CassandraOperatorProgress: api.ProgressReady,
+			Conditions: []api.DatacenterCondition{
+				{Type: api.DatacenterReady, Status: corev1.ConditionTrue},
+				{Type: api.DatacenterScalingUp, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	UpdateDatacenterMetricsFromStatus(dc)
+
+	labels := map[string]string{"namespace": "ns", "cluster": "cluster1", "datacenter": "datacenter1"}
+
+	progress, err := GetMetricValue("cass_operator_datacenter_progress", mergeLabels(labels, "progress", string(api.ProgressReady)))
+	require.NoError(err)
+	require.Equal(float64(1), progress)
+
+	ready, err := GetMetricValue("cass_operator_datacenter_status", mergeLabels(labels, "condition", string(api.DatacenterReady)))
+	require.NoError(err)
+	require.Equal(float64(1), ready)
+
+	scalingUp, err := GetMetricValue("cass_operator_datacenter_status", mergeLabels(labels, "condition", string(api.DatacenterScalingUp)))
+	require.NoError(err)
+	require.Equal(float64(0), scalingUp)
+}
+
+func mergeLabels(base map[string]string, key, value string) map[string]string {
+	out := map[string]string{key: value}
+	for k, v := range base {
+		out[k] = v
+	}
+	return out
+}
+
 func TestNamespaceSeparation(t *testing.T) {
 	require := require.New(t)
 	pods := make([]*corev1.Pod, 2)

--- a/pkg/reconciliation/handler.go
+++ b/pkg/reconciliation/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/k8ssandra/cass-operator/internal/result"
 	apiwebhook "github.com/k8ssandra/cass-operator/internal/webhooks/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/pkg/httphelper"
+	"github.com/k8ssandra/cass-operator/pkg/monitoring"
 )
 
 // Use a var so we can mock this function
@@ -50,6 +51,9 @@ func (rc *ReconciliationContext) CalculateReconciliationActions() (reconcile.Res
 	if result := rc.ProcessDeletion(); result.Completed() {
 		return result.Output()
 	}
+
+	// Keep the progress/condition metrics populated across restarts and leader changes.
+	monitoring.UpdateDatacenterMetricsFromStatus(rc.Datacenter)
 
 	if err := rc.addFinalizer(); err != nil {
 		return result.Error(err).Output()


### PR DESCRIPTION
**What this PR does**:

`cass_operator_datacenter_progress` and `cass_operator_datacenter_status` are only written on a state transition (`setOperatorProgressStatus` returns early when unchanged; `setCondition` touches the metric only inside `if updated`) and live in the process-local registry. After an operator restart or a leader-election change, a datacenter already in a steady state never transitions again, so those series disappear until the next change. `cass_operator_datacenter_pods_status` is unaffected because it is re-asserted every reconcile.

This re-asserts the progress and condition gauges from the persisted `dc.Status` once per reconcile, mirroring how pod statuses are handled. Purely additive; no extra Kubernetes API calls.

**Which issue(s) this PR fixes**:
Fixes #936

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)