### PR TITLE
Improve password stripping from error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
+* [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen
 
 ## v1.31.0
 

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -353,6 +353,11 @@ func (client *NodeMgmtClient) CallCreateRoleEndpoint(pod *corev1.Pod, username s
 	if _, err = callNodeMgmtEndpoint(client, request, ""); err != nil {
 		// The error could include a password, strip it
 		strippedErrMsg := strings.ReplaceAll(err.Error(), password, "******")
+		encodedPassword := url.QueryEscape(password)
+		if encodedPassword != password {
+			strippedErrMsg = strings.ReplaceAll(strippedErrMsg, encodedPassword, "******")
+		}
+
 		return errors.New(strippedErrMsg)
 	}
 	return nil

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -1931,6 +1931,29 @@ func TestStripPassword(t *testing.T) {
 	assert.Contains(t, requestURIs[0], "/api/v0/ops/auth/role")
 }
 
+func TestStripPasswordWithUrlEncodedPassword(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+
+	password := "secret+Password"
+	encodedPassword := "secret%2BPassword"
+	client := httphelper.NodeMgmtClient{
+		Client: httpClientDoFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("Post %q: EOF", req.URL.String())
+		}),
+		Log:      rc.ReqLogger,
+		Protocol: "http",
+	}
+
+	pod := makeReloadTestPod()
+
+	err := client.CallCreateRoleEndpoint(pod, "userNameA", password, true)
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), password)
+	assert.NotContains(t, err.Error(), encodedPassword)
+}
+
 func TestNodereplacements(t *testing.T) {
 	assert := assert.New(t)
 	rc, _, cleanupMockScr := setupTest()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If password included characters that were encoded in the error message, the password stripping would not catch them.

**Which issue(s) this PR fixes**:
Fixes #938 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
