### PR TITLE
Refresh metrics on every reconcile, add terminating state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [ENHANCEMENT] [#943](https://github.com/k8ssandra/cass-operator/issues/943) Add terminating state as one of the Pod status metrics
+* [ENHANCEMENT] [#936](https://github.com/k8ssandra/cass-operator/issues/936) Every reconcile of the CassandraDatacenter should refresh the metrics for up-to-date state
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
 * [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/k8ssandra/cass-operator/pkg/dynamicwatch"
 	"github.com/k8ssandra/cass-operator/pkg/images"
+	"github.com/k8ssandra/cass-operator/pkg/monitoring"
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/reconciliation"
 	appsv1 "k8s.io/api/apps/v1"
@@ -162,6 +163,9 @@ func (r *CassandraDatacenterReconciler) Reconcile(ctx context.Context, request c
 	if res.RequeueAfter > 0 && res.RequeueAfter < minimumRequeueTime {
 		res.RequeueAfter = minimumRequeueTime
 	}
+
+	monitoring.RefreshDatacenterMetrics(rc.Datacenter)
+
 	return res, err
 }
 

--- a/internal/controllers/cassandra/cassandradatacenter_controller_test.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/k8ssandra/cass-operator/pkg/monitoring"
 )
 
 const (
@@ -87,6 +88,7 @@ func waitForDatacenterCondition(ctx context.Context, dcName string, condition ca
 		for _, cond := range dc.Status.Conditions {
 			if cond.Type == condition {
 				g.Expect(cond.Status).To(Equal(status))
+				verifyMetricsSet(g, dcName, condition)
 				return
 			}
 		}
@@ -255,6 +257,12 @@ func verifyOwnerReference(g Gomega, ownerRef metav1.OwnerReference, dcName strin
 	g.Expect(ownerRef.Kind).To(Equal("CassandraDatacenter"))
 	g.Expect(ownerRef.Name).To(Equal(dcName))
 	g.Expect(ownerRef.APIVersion).To(Equal("cassandra.datastax.com/v1beta1"))
+}
+
+func verifyMetricsSet(g Gomega, dcName string, condition cassdcapi.DatacenterConditionType) {
+	val, err := monitoring.GetMetricValue("cass_operator_datacenter_status", map[string]string{"datacenter": dcName, "condition": string(condition)})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(val).To(Equal(1.0))
 }
 
 func createStubCassDc(dcName string, nodeCount int32) cassdcapi.CassandraDatacenter {

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -19,6 +19,7 @@ const (
 	PodStatusPending         PodStatus = "Pending"
 	PodStatusError           PodStatus = "Error"
 	PodStatusDecommissioning PodStatus = "Decommissioning"
+	PodStatusTerminating     PodStatus = "Terminating"
 )
 
 func getPodStatus(pod *corev1.Pod) PodStatus {
@@ -35,6 +36,9 @@ func getPodStatus(pod *corev1.Pod) PodStatus {
 		return PodStatusError
 	case corev1.PodRunning:
 	default:
+		if pod.GetDeletionTimestamp() != nil {
+			return PodStatusTerminating
+		}
 	}
 
 	allContainersReady := true

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -107,7 +107,7 @@ func RemoveDatacenterPods(namespace, cluster, datacenter string) {
 	PodStatusVec.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "cluster": cluster, "datacenter": datacenter})
 }
 
-func SetDatacenterConditionMetric(dc *api.CassandraDatacenter, conditionType api.DatacenterConditionType, status corev1.ConditionStatus) {
+func setDatacenterConditionMetric(dc *api.CassandraDatacenter, conditionType api.DatacenterConditionType, status corev1.ConditionStatus) {
 	cond := float64(0)
 	if status == corev1.ConditionTrue {
 		cond = 1
@@ -116,12 +116,20 @@ func SetDatacenterConditionMetric(dc *api.CassandraDatacenter, conditionType api
 	DatacenterStatusVec.WithLabelValues(dc.Namespace, dc.Spec.ClusterName, dc.DatacenterName(), string(conditionType)).Set(cond)
 }
 
-func UpdateOperatorDatacenterProgressStatusMetric(dc *api.CassandraDatacenter, state api.ProgressState) {
+func updateOperatorDatacenterProgressStatusMetric(dc *api.CassandraDatacenter, state api.ProgressState) {
 	// Delete other statuses
 	DatacenterOperatorStatusVec.DeletePartialMatch(prometheus.Labels{"namespace": dc.Namespace, "cluster": dc.Spec.ClusterName, "datacenter": dc.DatacenterName()})
 
 	// Set this one only
 	DatacenterOperatorStatusVec.WithLabelValues(dc.Namespace, dc.Spec.ClusterName, dc.DatacenterName(), string(state)).Set(1)
+}
+
+func RefreshDatacenterMetrics(dc *api.CassandraDatacenter) {
+	for _, cond := range dc.Status.Conditions {
+		setDatacenterConditionMetric(dc, cond.Type, cond.Status)
+	}
+
+	updateOperatorDatacenterProgressStatusMetric(dc, dc.Status.CassandraOperatorProgress)
 }
 
 // Add CassandraTask status also (how many pods done etc) per task

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -73,6 +73,20 @@ func TestMetricAdder(t *testing.T) {
 	require.NoError(err)
 	require.Equal("ready", status)
 
+	now := metav1.Now()
+	pods[1].SetDeletionTimestamp(&now)
+	UpdatePodStatusMetric(pods[1])
+	status, err = getCurrentPodStatus("pod1")
+	require.NoError(err)
+	require.Equal("terminating", status)
+
+	// Decommissioning should be prefered to Terminating if we are decommissioning the pod
+	pods[5].SetDeletionTimestamp(&now)
+	UpdatePodStatusMetric(pods[1])
+	status, err = getCurrentPodStatus("pod5")
+	require.NoError(err)
+	require.Equal("decommissioning", status)
+
 	RemoveDatacenterPods("ns", "cluster1", "datacenter1")
 	_, err = getCurrentPodStatus("pod4")
 	require.Error(err)

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -80,7 +80,7 @@ func TestMetricAdder(t *testing.T) {
 	require.NoError(err)
 	require.Equal("terminating", status)
 
-	// Decommissioning should be prefered to Terminating if we are decommissioning the pod
+	// Decommissioning should be preferred to Terminating if we are decommissioning the pod
 	pods[5].SetDeletionTimestamp(&now)
 	UpdatePodStatusMetric(pods[1])
 	status, err = getCurrentPodStatus("pod5")

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -165,13 +165,13 @@ func TestOperatorStateMetrics(t *testing.T) {
 		Status: api.CassandraDatacenterStatus{},
 	}
 
-	UpdateOperatorDatacenterProgressStatusMetric(dc, api.ProgressUpdating)
+	updateOperatorDatacenterProgressStatusMetric(dc, api.ProgressUpdating)
 
 	status, err := getCurrentDatacenterStatus("dc1")
 	require.NoError(err)
 	require.Equal("Updating", status)
 
-	UpdateOperatorDatacenterProgressStatusMetric(dc, api.ProgressReady)
+	updateOperatorDatacenterProgressStatusMetric(dc, api.ProgressReady)
 
 	status, err = getCurrentDatacenterStatus("dc1")
 	require.NoError(err)
@@ -229,14 +229,14 @@ func TestDatacenterConditionMetrics(t *testing.T) {
 		},
 	}
 
-	SetDatacenterConditionMetric(dc, api.DatacenterReady, corev1.ConditionTrue)
+	setDatacenterConditionMetric(dc, api.DatacenterReady, corev1.ConditionTrue)
 
 	status, err := getCurrentDatacenterCondition("dc1", api.DatacenterReady)
 	require.NoError(err)
 	require.Equal(float64(1), status)
 
-	SetDatacenterConditionMetric(dc, api.DatacenterInitialized, corev1.ConditionTrue)
-	SetDatacenterConditionMetric(dc, api.DatacenterReady, corev1.ConditionFalse)
+	setDatacenterConditionMetric(dc, api.DatacenterInitialized, corev1.ConditionTrue)
+	setDatacenterConditionMetric(dc, api.DatacenterReady, corev1.ConditionFalse)
 
 	status, err = getCurrentDatacenterCondition("dc1", api.DatacenterReady)
 	require.NoError(err)

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -81,8 +81,10 @@ func TestMetricAdder(t *testing.T) {
 	require.Equal("terminating", status)
 
 	// Decommissioning should be preferred to Terminating if we are decommissioning the pod
+	// This would return "terminating" as seen from pods[1], but as we can previously see from
+	// pods[5], we will return "decommissioning" in this case.
 	pods[5].SetDeletionTimestamp(&now)
-	UpdatePodStatusMetric(pods[1])
+	UpdatePodStatusMetric(pods[5])
 	status, err = getCurrentPodStatus("pod5")
 	require.NoError(err)
 	require.Equal("decommissioning", status)

--- a/pkg/reconciliation/constructor.go
+++ b/pkg/reconciliation/constructor.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
-	"github.com/k8ssandra/cass-operator/pkg/monitoring"
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/utils"
 
@@ -91,8 +90,6 @@ func setOperatorProgressStatus(rc *ReconciliationContext, newState api.ProgressS
 		rc.ReqLogger.Error(err, "error updating the Cassandra Operator Progress state")
 		return err
 	}
-
-	monitoring.UpdateOperatorDatacenterProgressStatusMetric(rc.Datacenter, newState)
 
 	return nil
 }

--- a/pkg/reconciliation/handler.go
+++ b/pkg/reconciliation/handler.go
@@ -59,10 +59,6 @@ func (rc *ReconciliationContext) CalculateReconciliationActions() (reconcile.Res
 		return result.Output()
 	}
 
-	// if result := rc.CheckAdditionalSeedEndpoints(); result.Completed() {
-	// 	return result.Output()
-	// }
-
 	if err := rc.CalculateRackInformation(); err != nil {
 		return result.Error(err).Output()
 	}

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -2396,8 +2396,6 @@ func (rc *ReconciliationContext) setCondition(condition *api.DatacenterCondition
 	}
 
 	if updated {
-		// Modify the metric also
-		monitoring.SetDatacenterConditionMetric(dc, condition.Type, condition.Status)
 		// We use Update here to avoid removing some other changes to the Status that might have happened,
 		// as well as updating them at the same time
 		return rc.Client.Status().Update(rc.Ctx, dc)

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/k8ssandra/cass-operator/internal/result"
 	"github.com/k8ssandra/cass-operator/pkg/events"
 	"github.com/k8ssandra/cass-operator/pkg/httphelper"
-	"github.com/k8ssandra/cass-operator/pkg/monitoring"
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -377,9 +376,6 @@ func TestCheckRackPodTemplate_CanaryUpgrade(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, rc.Datacenter.Status.CassandraOperatorProgress, api.ProgressUpdating)
-	val, err := monitoring.GetMetricValue("cass_operator_datacenter_progress", map[string]string{"datacenter": rc.Datacenter.DatacenterName(), "progress": string(api.ProgressUpdating)})
-	assert.NoError(t, err)
-	assert.Equal(t, float64(1), val)
 
 	expectedStrategy := appsv1.StatefulSetUpdateStrategy{
 		Type: appsv1.RollingUpdateStatefulSetStrategyType,
@@ -3404,45 +3400,6 @@ func TestCheckRackPodTemplateWithVolumeExpansion(t *testing.T) {
 
 	res = rc.CheckRackPodTemplate()
 	require.Equal(result.Continue(), res, "Recreating StS should throw us to silence period")
-}
-
-func TestSetConditionStatus(t *testing.T) {
-	rc, _, cleanupMockScr := setupTest()
-	defer cleanupMockScr()
-	assert := assert.New(t)
-
-	assert.NoError(rc.setConditionStatus(api.DatacenterHealthy, corev1.ConditionTrue))
-	assert.Equal(corev1.ConditionTrue, rc.Datacenter.GetConditionStatus(api.DatacenterHealthy))
-	dc := &api.CassandraDatacenter{}
-	assert.NoError(rc.Client.Get(rc.Ctx, client.ObjectKeyFromObject(rc.Datacenter), dc))
-	assert.Equal(corev1.ConditionTrue, dc.GetConditionStatus(api.DatacenterHealthy))
-	val, err := monitoring.GetMetricValue("cass_operator_datacenter_status", map[string]string{"datacenter": rc.Datacenter.DatacenterName(), "condition": string(api.DatacenterHealthy)})
-	assert.NoError(err)
-	assert.Equal(float64(1), val)
-
-	assert.NoError(rc.setConditionStatus(api.DatacenterHealthy, corev1.ConditionFalse))
-	assert.Equal(corev1.ConditionFalse, rc.Datacenter.GetConditionStatus(api.DatacenterHealthy))
-	assert.NoError(rc.Client.Get(rc.Ctx, client.ObjectKeyFromObject(rc.Datacenter), dc))
-	assert.Equal(corev1.ConditionFalse, dc.GetConditionStatus(api.DatacenterHealthy))
-	val, err = monitoring.GetMetricValue("cass_operator_datacenter_status", map[string]string{"datacenter": rc.Datacenter.DatacenterName(), "condition": string(api.DatacenterHealthy)})
-	assert.NoError(err)
-	assert.Equal(float64(0), val)
-}
-
-func TestDatacenterStatus(t *testing.T) {
-	rc, _, cleanupMockScr := setupTest()
-	defer cleanupMockScr()
-	assert := assert.New(t)
-
-	assert.NoError(rc.setConditionStatus(api.DatacenterRequiresUpdate, corev1.ConditionTrue)) // This uses one StatusUpdate call
-	rc.Datacenter.Status.ObservedGeneration = 0
-	rc.Datacenter.Generation = 1
-	assert.NoError(setDatacenterStatus(rc))
-	assert.Equal(int64(1), rc.Datacenter.Status.ObservedGeneration)
-	assert.Equal(corev1.ConditionFalse, rc.Datacenter.GetConditionStatus(api.DatacenterRequiresUpdate))
-	val, err := monitoring.GetMetricValue("cass_operator_datacenter_status", map[string]string{"datacenter": rc.Datacenter.DatacenterName(), "condition": string(api.DatacenterRequiresUpdate)})
-	assert.NoError(err)
-	assert.Equal(float64(0), val)
 }
 
 func TestDatacenterPods(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This merges and reworks some of the stuff from PRs #937 and #749

All the metrics are refreshed on every reconciliation (excluding cooldown) to avoid missing them if operator has restarted or changed leadership.

Adds new state for Terminating if Pod's DeletionTimestamp != nil. Otherwise the Pod would show in a different state and this is inconsistent with what the kubectl output is.

**Which issue(s) this PR fixes**:
Fixes #943 
Fixes #936

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
