### PR TITLE
If no storageClass is set, use annotation fetching instead of label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
 * [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen
+* [BUGFIX] [#928](https://github.com/k8ssandra/cass-operator/issues/928) Fix default storageClass selector to use annotations instead of labels
 
 ## v1.31.0
 

--- a/pkg/reconciliation/reconcile_datacenter.go
+++ b/pkg/reconciliation/reconcile_datacenter.go
@@ -221,17 +221,24 @@ func (rc *ReconciliationContext) listPVCs(selector map[string]string) ([]corev1.
 func storageClass(ctx context.Context, c client.Client, storageClassName *string) (*storagev1.StorageClass, error) {
 	if storageClassName == nil || *storageClassName == "" {
 		storageClassList := &storagev1.StorageClassList{}
-		if err := c.List(ctx, storageClassList, client.MatchingLabels{"storageclass.kubernetes.io/is-default-class": "true"}); err != nil {
+		if err := c.List(ctx, storageClassList); err != nil {
 			return nil, err
 		}
 
-		if len(storageClassList.Items) > 1 {
+		defaultStorageClasses := make([]storagev1.StorageClass, 0, len(storageClassList.Items))
+		for _, storageClass := range storageClassList.Items {
+			if metav1.HasAnnotation(storageClass.ObjectMeta, "storageclass.kubernetes.io/is-default-class") && storageClass.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+				defaultStorageClasses = append(defaultStorageClasses, storageClass)
+			}
+		}
+
+		if len(defaultStorageClasses) > 1 {
 			return nil, fmt.Errorf("found multiple default storage classes, please specify StorageClassName in the CassandraDatacenter spec")
-		} else if len(storageClassList.Items) == 0 {
+		} else if len(defaultStorageClasses) == 0 {
 			return nil, fmt.Errorf("no default storage class found, please specify StorageClassName in the CassandraDatacenter spec")
 		}
 
-		return &storageClassList.Items[0], nil
+		return &defaultStorageClasses[0], nil
 	}
 
 	storageClass := &storagev1.StorageClass{}

--- a/pkg/reconciliation/reconcile_datacenter_test.go
+++ b/pkg/reconciliation/reconcile_datacenter_test.go
@@ -172,6 +172,16 @@ func TestStorageExpansionNils(t *testing.T) {
 	require.True(supports)
 }
 
+func TestStorageClassDefaultOne(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	require := require.New(t)
+
+	storageClass, err := storageClass(rc.Ctx, rc.Client, nil)
+	require.NoError(err)
+	require.Equal("standard", storageClass.Name)
+}
+
 func podWithPVC(rc *ReconciliationContext, podName string, pvcName string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciliation/testing.go
+++ b/pkg/reconciliation/testing.go
@@ -123,8 +123,8 @@ func CreateMockReconciliationContext(
 
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   storageClassName,
-			Labels: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+			Name:        storageClassName,
+			Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
If no StorageClassName was set, we incorrectly used label selector instead of annotations filtering.

**Which issue(s) this PR fixes**:
Fixes #928

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
