### PR TITLE
Read Events through an uncached APIReader instead of a cluster-wide informer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [ENHANCEMENT] [#947](https://github.com/k8ssandra/cass-operator/issues/947) Read Events through an uncached APIReader instead of a cluster-wide cached informer, removing the largest informer memory contributor in cluster-scoped deployments.
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
 * [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -237,6 +237,7 @@ func main() {
 
 	if err = (&controllers.CassandraDatacenterReconciler{
 		Client:           mgr.GetClient(),
+		APIReader:        mgr.GetAPIReader(),
 		Log:              ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
 		Scheme:           mgr.GetScheme(),
 		Recorder:         mgr.GetEventRecorder("cass-operator"),
@@ -357,16 +358,6 @@ func setupCacheIndexers(ctx context.Context, mgr ctrl.Manager) error {
 			}
 		}
 		return pvcNames
-	}); err != nil {
-		return err
-	}
-
-	if err := mgr.GetCache().IndexField(ctx, &corev1.Event{}, "involvedObject.name", func(obj client.Object) []string {
-		event := obj.(*corev1.Event)
-		if event.InvolvedObject.Kind == "Pod" {
-			return []string{event.InvolvedObject.Name}
-		}
-		return []string{}
 	}); err != nil {
 		return err
 	}

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -73,9 +73,12 @@ var (
 // CassandraDatacenterReconciler reconciles a cassandraDatacenter object
 type CassandraDatacenterReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	// APIReader is an uncached reader (mgr.GetAPIReader) used for high-cardinality
+	// reads deliberately kept out of the informer cache, such as Events.
+	APIReader client.Reader
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
 
 	// SecretWatches is used in the controller when setting up the watches and
 	// during reconciliation where we update the mappings for the watches.
@@ -114,7 +117,7 @@ func (r *CassandraDatacenterReconciler) Reconcile(ctx context.Context, request c
 
 	logger.Info("======== handler::Reconcile has been called")
 
-	rc, err := reconciliation.CreateReconciliationContext(ctx, &request, r.Client, r.Scheme, r.Recorder, r.SecretWatches, r.ImageRegistry, r.ClusterResources)
+	rc, err := reconciliation.CreateReconciliationContext(ctx, &request, r.Client, r.APIReader, r.Scheme, r.Recorder, r.SecretWatches, r.ImageRegistry, r.ClusterResources)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/internal/controllers/cassandra/suite_test.go
+++ b/internal/controllers/cassandra/suite_test.go
@@ -103,6 +103,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&CassandraDatacenterReconciler{
 		Client:        k8sManager.GetClient(),
+		APIReader:     k8sManager.GetAPIReader(),
 		Log:           ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
 		Scheme:        k8sManager.GetScheme(),
 		Recorder:      k8sManager.GetEventRecorder("cass-operator"),

--- a/pkg/reconciliation/context.go
+++ b/pkg/reconciliation/context.go
@@ -27,8 +27,11 @@ import (
 
 // ReconciliationContext contains all of the input necessary to calculate a list of ReconciliationActions
 type ReconciliationContext struct {
-	Request          *reconcile.Request
-	Client           client.Client
+	Request *reconcile.Request
+	Client  client.Client
+	// APIReader is an uncached reader (mgr.GetAPIReader) used for high-cardinality
+	// reads deliberately kept out of the informer cache, such as Events.
+	APIReader        client.Reader
 	Scheme           *runtime.Scheme
 	Datacenter       *api.CassandraDatacenter
 	NodeMgmtClient   httphelper.NodeMgmtClient
@@ -56,6 +59,7 @@ func CreateReconciliationContext(
 	ctx context.Context,
 	req *reconcile.Request,
 	cli client.Client,
+	apiReader client.Reader,
 	scheme *runtime.Scheme,
 	rec record.EventRecorder,
 	secretWatches dynamicwatch.DynamicWatches,
@@ -66,6 +70,7 @@ func CreateReconciliationContext(
 	rc := &ReconciliationContext{}
 	rc.Request = req
 	rc.Client = cli
+	rc.APIReader = apiReader
 	rc.Scheme = scheme
 	rc.SecretWatches = secretWatches
 	rc.ReqLogger = reqLogger

--- a/pkg/reconciliation/handler_reconcile_test.go
+++ b/pkg/reconciliation/handler_reconcile_test.go
@@ -101,10 +101,11 @@ func TestReconcile(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithStatusSubresource(dc).WithRuntimeObjects(trackObjects...).Build()
 
 	r := &controllers.CassandraDatacenterReconciler{
-		Client:   fakeClient,
-		Scheme:   s,
-		Recorder: record.NewFakeRecorder(100),
-		Log:      ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+		Client:    fakeClient,
+		APIReader: fakeClient,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(100),
+		Log:       ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
 	}
 
 	request := reconcile.Request{
@@ -168,8 +169,9 @@ func TestReconcile_NotFound(t *testing.T) {
 	fakeRecorder := record.NewFakeRecorder(5)
 
 	r := &controllers.CassandraDatacenterReconciler{
-		Client: fakeClient,
-		Scheme: s,
+		Client:    fakeClient,
+		APIReader: fakeClient,
+		Scheme:    s,
 	}
 	r.Recorder = events.NewLoggingEventRecorder(fakeRecorder, r.Log.WithName("reconcile_tests"))
 
@@ -234,8 +236,9 @@ func TestReconcile_Error(t *testing.T) {
 		Build()
 
 	r := &controllers.CassandraDatacenterReconciler{
-		Client: fakeClient,
-		Scheme: s,
+		Client:    fakeClient,
+		APIReader: fakeClient,
+		Scheme:    s,
 	}
 	fakeRecorder := record.NewFakeRecorder(5)
 	r.Recorder = events.NewLoggingEventRecorder(fakeRecorder, r.Log.WithName("reconcile_tests"))

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -182,7 +182,12 @@ func (rc *ReconciliationContext) failureModeDetection() (bool, string) {
 					// Pod has been over 5 minutes in Pending state. This can be normal, but lets see
 					// if we have some detected failures events like FailedScheduling
 					events := &corev1.EventList{}
-					if err := rc.Client.List(rc.Ctx, events, &client.ListOptions{Namespace: pod.Namespace, FieldSelector: fields.SelectorFromSet(fields.Set{"involvedObject.name": pod.Name})}); err != nil {
+					// Read Events through the uncached APIReader: only this one Pod's
+					// events are needed, and a cached read would instantiate a
+					// cluster-wide informer for Events — the highest-cardinality,
+					// highest-churn resource — which is prohibitively expensive in
+					// memory when the operator runs cluster-scoped.
+					if err := rc.APIReader.List(rc.Ctx, events, &client.ListOptions{Namespace: pod.Namespace, FieldSelector: fields.SelectorFromSet(fields.Set{"involvedObject.name": pod.Name})}); err != nil {
 						rc.ReqLogger.Error(err, "error getting events for pod", "pod", pod.Name)
 						return false, ""
 					}

--- a/pkg/reconciliation/reconcile_racks_test.go
+++ b/pkg/reconciliation/reconcile_racks_test.go
@@ -4044,6 +4044,7 @@ func TestFailureDetection(t *testing.T) {
 				Build()
 
 			rc.Client = fakeClient
+			rc.APIReader = fakeClient
 
 			rc.desiredRackInformation = []*RackInformation{
 				{


### PR DESCRIPTION
**What this PR does**:
Reads Events through an uncached `mgr.GetAPIReader()` instead of the cached client, and drops the `corev1.Event` field index.

The index existed to serve a single lookup (`failureModeDetection` reads the events of one pod), but registering it eagerly instantiated a **cluster-wide Event informer** at startup — Events being the highest-cardinality, highest-churn resource (27k+ objects on a mid-size cluster). In cluster-scoped deployments this informer is a major OOM driver. The field selector `involvedObject.name` is server-side supported for Events, so the live read is cheap and behavior-identical.

`APIReader` is threaded through `CassandraDatacenterReconciler` and `ReconciliationContext` so future high-cardinality reads can use the same path.

**Which issue(s) this PR fixes**:
Part of #947 (first of two PRs; the second bounds the rest of the cache)

**Checklist**
- [x] Changes manually tested — running in production on five clusters for several days, cluster-scoped, incl. chaos-mesh pod-kill runs
- [x] Automated Tests added/updated — TestFailureDetection exercises the APIReader path; envtest controller suite passes
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated
- [x] CLA Signed
