### PR TITLE
Bound the informer cache for cluster-scoped deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [ENHANCEMENT] [#947](https://github.com/k8ssandra/cass-operator/issues/947) Bound the informer cache in cluster-scoped mode: label-scope Pod/StatefulSet/PodDisruptionBudget/Service informers to operator-managed objects, read Secrets/PVCs/ConfigMaps/Endpoints/EndpointSlices/StorageClasses through live API calls with metadata-only Secret watches, and strip managedFields/last-applied from cached objects. Operator memory no longer scales with cluster size.
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
 * [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,8 +29,14 @@ import (
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -53,6 +59,7 @@ import (
 	controlcontrollers "github.com/k8ssandra/cass-operator/internal/controllers/control"
 	apiwebhook "github.com/k8ssandra/cass-operator/internal/webhooks/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/pkg/images"
+	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/utils"
 )
 
@@ -185,8 +192,46 @@ func main() {
 		setupLog.Info("webhooks disabled because --webhook-cert-path was not provided")
 	}
 
+	// Bound the informer cache so cluster-scoped mode (empty WATCH_NAMESPACE) does not
+	// cache every object of every watched type across all namespaces:
+	//
+	//   * Pod/StatefulSet/PodDisruptionBudget/Service informers are label-scoped to
+	//     managed-by=cass-operator: the operator only ever reads objects it created,
+	//     and it labels all of them. These are the hot read paths (every reconcile),
+	//     so they stay cached.
+	//   * Secrets are read through live API calls (Client.Cache.DisableFor) because
+	//     the operator also reads user-provided secrets (SuperuserSecretName,
+	//     Spec.Users, ConfigSecret, management API TLS) that carry no operator label;
+	//     the two Secret watches use metadata-only projection (builder.OnlyMetadata),
+	//     so no full-object Secret informer ever exists. PVC/StorageClass/
+	//     EndpointSlice/Endpoints/ConfigMap reads are cold paths and also go live,
+	//     avoiding lazily-created cluster-wide informers for those types.
+	//   * All cached objects are stripped of managedFields and the kubectl
+	//     last-applied-configuration annotation, which often dominate object size.
+	managedByOperator := labels.SelectorFromSet(labels.Set{
+		oplabels.ManagedByLabel: oplabels.ManagedByLabelValue,
+	})
 	options.Cache = cache.Options{
 		DefaultNamespaces: map[string]cache.Config{},
+		DefaultTransform:  stripHeavyMetadata(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}:                   {Label: managedByOperator},
+			&appsv1.StatefulSet{}:           {Label: managedByOperator},
+			&policyv1.PodDisruptionBudget{}: {Label: managedByOperator},
+			&corev1.Service{}:               {Label: managedByOperator},
+		},
+	}
+	options.Client = client.Options{
+		Cache: &client.CacheOptions{
+			DisableFor: []client.Object{
+				&corev1.Secret{},
+				&corev1.PersistentVolumeClaim{},
+				&corev1.ConfigMap{},
+				&corev1.Endpoints{},
+				&discoveryv1.EndpointSlice{},
+				&storagev1.StorageClass{},
+			},
+		},
 	}
 
 	clusterScoped := len(ns) == 0
@@ -341,6 +386,30 @@ func setupWebhookServer(webhookCertPath, webhookCertName, webhookCertKey string,
 	return webhook.NewServer(webhook.Options{
 		TLSOpts: webhookTLSOpts,
 	}), webhookCertWatcher, true, nil
+}
+
+// stripHeavyMetadata extends cache.TransformStripManagedFields by also dropping the
+// kubectl last-applied-configuration annotation from every cached object: for a
+// kubectl-applied object that annotation embeds the full object (including Secret
+// data), so it dominates cached-object size — and even survives metadata-only
+// projection, since annotations are part of PartialObjectMetadata. Nothing in the
+// operator reads it.
+func stripHeavyMetadata() toolscache.TransformFunc {
+	stripManagedFields := cache.TransformStripManagedFields()
+	return func(obj interface{}) (interface{}, error) {
+		obj, err := stripManagedFields(obj)
+		if err != nil {
+			return obj, err
+		}
+		if m, ok := obj.(metav1.Object); ok {
+			annotations := m.GetAnnotations()
+			if _, found := annotations[corev1.LastAppliedConfigAnnotation]; found {
+				delete(annotations, corev1.LastAppliedConfigAnnotation)
+				m.SetAnnotations(annotations)
+			}
+		}
+		return obj, nil
+	}
 }
 
 func setupCacheIndexers(ctx context.Context, mgr ctrl.Manager) error {

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -191,13 +191,14 @@ func (r *CassandraDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Owns(&policyv1.PodDisruptionBudget{}, builder.WithPredicates(managedByCassandraOperatorPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(managedByCassandraOperatorPredicate))
 
+	// Uses only object metadata (no *corev1.Secret assertion) so it works with the
+	// metadata-only projected watch below.
 	configSecretMapFn := func(ctx context.Context, mapObj client.Object) []reconcile.Request {
 		requests := make([]reconcile.Request, 0)
-		secret := mapObj.(*corev1.Secret)
-		if v, ok := secret.Annotations[api.DatacenterAnnotation]; ok {
+		if v, ok := mapObj.GetAnnotations()[api.DatacenterAnnotation]; ok {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: secret.Namespace,
+					Namespace: mapObj.GetNamespace(),
 					Name:      v,
 				},
 			})
@@ -229,7 +230,10 @@ func (r *CassandraDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error
 		},
 	}
 
-	c = c.Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(configSecretMapFn), builder.WithPredicates(configSecretPredicate))
+	// builder.OnlyMetadata: the map fn and predicate above only need annotations, so
+	// cache Secret metadata instead of full objects (Secret data reads go through the
+	// live client — see Client.Cache.DisableFor in cmd/main.go).
+	c = c.Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(configSecretMapFn), builder.WithPredicates(configSecretPredicate), builder.OnlyMetadata)
 
 	// Setup watches for Secrets. These secrets are often not owned by or created by
 	// the operator, so we must create a mapping back to the appropriate datacenters.
@@ -245,7 +249,8 @@ func (r *CassandraDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error
 		return requests
 	}
 
-	c = c.Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toRequests))
+	// builder.OnlyMetadata: FindWatchers only inspects metadata (name/annotations).
+	c = c.Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toRequests), builder.OnlyMetadata)
 
 	return c.Complete(r)
 }


### PR DESCRIPTION
**What this PR does**:
Bounds the manager's informer cache so operator memory no longer scales with cluster size (details and production numbers in #947):

- `cache.Options.ByObject` label-scopes the Pod/StatefulSet/PodDisruptionBudget/Service informers to `app.kubernetes.io/managed-by=cass-operator`. The operator only reads objects it created and labels; the existing `managedByCassandraOperatorPredicate` on `Owns()` already asserts the same invariant on events. Hot per-reconcile reads stay cached.
- Secrets are read live (`client.CacheOptions.DisableFor`): the operator also reads user-provided secrets (SuperuserSecretName, `Spec.Users`, ConfigSecret, management-API TLS) that carry no operator label, so they cannot be label-scoped. Both Secret watches become metadata-only projections (`builder.OnlyMetadata`); their map fn / predicate only inspect annotations. `configSecretMapFn` drops its `*corev1.Secret` type assertion accordingly.
- PVC/StorageClass/Endpoints/EndpointSlice/ConfigMap reads are cold paths (resize, decommission, additional-seeds, image config) and also go live, so no cluster-wide informers are lazily created for them.
- All cached objects are stripped of managedFields and the kubectl last-applied-configuration annotation.

Production results (cluster-scoped): OOMKilled at startup with 512Mi → **87-91Mi** steady state on clusters from 5.7k to 17.5k pods. Namespace-scoped deployments also drop ~7x.

Independent of the Events PR; both compose.

**Which issue(s) this PR fixes**:
Fixes #947

**Checklist**
- [x] Changes manually tested — production on five clusters, cluster-scoped, incl. chaos-mesh pod-kill runs against managed Cassandra clusters
- [x] Automated Tests added/updated — envtest controller suite exercises the metadata-only watches and rewritten map fn
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated
- [x] CLA Signed
