### PR TITLE
Preserve probe handler configuration for mTLS

### DIFF
--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -219,6 +219,15 @@ func NewMgmtClient(ctx context.Context, client client.Client, dc *cassdcapi.Cass
 	}, nil
 }
 
+func GetMgmtApiPortFromContainer(container *corev1.Container) int {
+	for _, port := range container.Ports {
+		if port.Name == "mgmt-api-http" {
+			return int(port.ContainerPort)
+		}
+	}
+	return MgmtApiTargetPort
+}
+
 func BuildPodHostFromPod(pod *corev1.Pod) (string, int, error) {
 	// This function previously returned the dns hostname which includes the StatefulSet's headless service,
 	// which is the datacenter service. There are times though that we want to make a mgmt api call to the pod
@@ -228,16 +237,12 @@ func BuildPodHostFromPod(pod *corev1.Pod) (string, int, error) {
 		return "", 0, newNoPodIPError(pod)
 	}
 
-	mgmtApiPort := 8080
+	mgmtApiPort := MgmtApiTargetPort
 
 	// Check for port override
 	for _, container := range pod.Spec.Containers {
 		if container.Name == "cassandra" {
-			for _, port := range container.Ports {
-				if port.Name == "mgmt-api-http" {
-					mgmtApiPort = int(port.ContainerPort)
-				}
-			}
+			mgmtApiPort = GetMgmtApiPortFromContainer(&container)
 		}
 	}
 

--- a/pkg/httphelper/client_test.go
+++ b/pkg/httphelper/client_test.go
@@ -51,6 +51,103 @@ func Test_BuildPodHostFromPod(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func Test_GetMgmtApiPortFromContainer(t *testing.T) {
+	tests := []struct {
+		name      string
+		container *corev1.Container
+		expected  int
+	}{
+		{
+			name: "default port when no mgmt-api-http port defined",
+			container: &corev1.Container{
+				Name: "cassandra",
+				Ports: []corev1.ContainerPort{
+					{Name: "native", ContainerPort: 9042},
+					{Name: "internode", ContainerPort: 7000},
+				},
+			},
+			expected: 8080,
+		},
+		{
+			name: "custom port when mgmt-api-http port defined",
+			container: &corev1.Container{
+				Name: "cassandra",
+				Ports: []corev1.ContainerPort{
+					{Name: "native", ContainerPort: 9042},
+					{Name: "mgmt-api-http", ContainerPort: 8081},
+					{Name: "internode", ContainerPort: 7000},
+				},
+			},
+			expected: 8081,
+		},
+		{
+			name: "default port when container has no ports",
+			container: &corev1.Container{
+				Name:  "cassandra",
+				Ports: []corev1.ContainerPort{},
+			},
+			expected: 8080,
+		},
+		{
+			name: "default port when container ports is nil",
+			container: &corev1.Container{
+				Name:  "cassandra",
+				Ports: nil,
+			},
+			expected: 8080,
+		},
+		{
+			name: "finds mgmt-api-http among many ports",
+			container: &corev1.Container{
+				Name: "cassandra",
+				Ports: []corev1.ContainerPort{
+					{Name: "native", ContainerPort: 9042},
+					{Name: "internode", ContainerPort: 7000},
+					{Name: "jmx", ContainerPort: 7199},
+					{Name: "mgmt-api-http", ContainerPort: 9999},
+					{Name: "metrics", ContainerPort: 9103},
+				},
+			},
+			expected: 9999,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMgmtApiPortFromContainer(tt.container)
+			assert.Equal(t, tt.expected, result, "GetMgmtApiPortFromContainer() returned unexpected port")
+		})
+	}
+}
+
+func Test_BuildPodHostFromPod_WithCustomPort(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-custom-port",
+			Namespace: "somenamespace",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "cassandra",
+					Ports: []corev1.ContainerPort{
+						{Name: "mgmt-api-http", ContainerPort: 8081},
+						{Name: "native", ContainerPort: 9042},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "1.2.3.4",
+		},
+	}
+
+	result, podPort, err := BuildPodHostFromPod(pod)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4", result)
+	assert.Equal(t, 8081, podPort, "Expected custom port 8081 to be returned")
+}
+
 func Test_parseMetadataEndpointsResponseBody(t *testing.T) {
 	endpoints, err := parseMetadataEndpointsResponseBody([]byte(`{
 		"entity": [

--- a/pkg/httphelper/probe_validation.go
+++ b/pkg/httphelper/probe_validation.go
@@ -1,0 +1,99 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package httphelper
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Phase 4: validateProbe validates that a probe complies with Kubernetes specifications
+// Returns a list of validation errors, or empty slice if probe is valid
+func validateProbe(probe *corev1.Probe, probeType string) []error {
+	var errors []error
+
+	if probe == nil {
+		return errors // nil probe is valid (means no probe)
+	}
+
+	// Count how many mechanisms are set
+	mechanismCount := 0
+	if probe.Exec != nil {
+		mechanismCount++
+	}
+	if probe.HTTPGet != nil {
+		mechanismCount++
+	}
+	if probe.TCPSocket != nil {
+		mechanismCount++
+	}
+	if probe.GRPC != nil {
+		mechanismCount++
+	}
+
+	// Validate exactly one mechanism is defined
+	if mechanismCount == 0 {
+		errors = append(errors, fmt.Errorf("%s probe has no mechanism defined (must define exactly one of: exec, httpGet, tcpSocket, or grpc)", probeType))
+	} else if mechanismCount > 1 {
+		errors = append(errors, fmt.Errorf("%s probe has multiple mechanisms defined (must define exactly one of: exec, httpGet, tcpSocket, or grpc)", probeType))
+	}
+
+	// Validate successThreshold for liveness/startup probes
+	// Per Kubernetes spec: "Must be 1 for liveness and startup Probes"
+	if (probeType == "liveness" || probeType == "startup") && probe.SuccessThreshold != 0 && probe.SuccessThreshold != 1 {
+		errors = append(errors, fmt.Errorf("%s probe successThreshold must be 1 (got %d)", probeType, probe.SuccessThreshold))
+	}
+
+	// Validate timing values are positive
+	if probe.TimeoutSeconds < 0 {
+		errors = append(errors, fmt.Errorf("%s probe timeoutSeconds must be >= 0 (got %d)", probeType, probe.TimeoutSeconds))
+	}
+	if probe.PeriodSeconds < 0 {
+		errors = append(errors, fmt.Errorf("%s probe periodSeconds must be >= 0 (got %d)", probeType, probe.PeriodSeconds))
+	}
+	if probe.InitialDelaySeconds < 0 {
+		errors = append(errors, fmt.Errorf("%s probe initialDelaySeconds must be >= 0 (got %d)", probeType, probe.InitialDelaySeconds))
+	}
+	if probe.FailureThreshold < 0 {
+		errors = append(errors, fmt.Errorf("%s probe failureThreshold must be >= 0 (got %d)", probeType, probe.FailureThreshold))
+	}
+	if probe.SuccessThreshold < 0 {
+		errors = append(errors, fmt.Errorf("%s probe successThreshold must be >= 0 (got %d)", probeType, probe.SuccessThreshold))
+	}
+
+	// Validate port numbers if applicable
+	if probe.HTTPGet != nil {
+		if probe.HTTPGet.Port.IntVal < 1 || probe.HTTPGet.Port.IntVal > 65535 {
+			errors = append(errors, fmt.Errorf("%s probe httpGet port must be in range 1-65535 (got %d)", probeType, probe.HTTPGet.Port.IntVal))
+		}
+	}
+	if probe.TCPSocket != nil {
+		if probe.TCPSocket.Port.IntVal < 1 || probe.TCPSocket.Port.IntVal > 65535 {
+			errors = append(errors, fmt.Errorf("%s probe tcpSocket port must be in range 1-65535 (got %d)", probeType, probe.TCPSocket.Port.IntVal))
+		}
+	}
+	if probe.GRPC != nil {
+		if probe.GRPC.Port < 1 || probe.GRPC.Port > 65535 {
+			errors = append(errors, fmt.Errorf("%s probe grpc port must be in range 1-65535 (got %d)", probeType, probe.GRPC.Port))
+		}
+	}
+
+	return errors
+}
+
+// ValidateLivenessProbe validates a liveness probe
+func ValidateLivenessProbe(probe *corev1.Probe) []error {
+	return validateProbe(probe, "liveness")
+}
+
+// ValidateReadinessProbe validates a readiness probe
+func ValidateReadinessProbe(probe *corev1.Probe) []error {
+	return validateProbe(probe, "readiness")
+}
+
+// ValidateStartupProbe validates a startup probe
+func ValidateStartupProbe(probe *corev1.Probe) []error {
+	return validateProbe(probe, "startup")
+}

--- a/pkg/httphelper/probe_validation_test.go
+++ b/pkg/httphelper/probe_validation_test.go
@@ -1,0 +1,280 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package httphelper
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestValidateProbe_NilProbe(t *testing.T) {
+	errors := validateProbe(nil, "liveness")
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for nil probe, got %d errors", len(errors))
+	}
+}
+
+func TestValidateProbe_NoMechanism(t *testing.T) {
+	probe := &corev1.Probe{}
+	errors := validateProbe(probe, "liveness")
+	if len(errors) != 1 {
+		t.Errorf("Expected 1 error for probe with no mechanism, got %d", len(errors))
+	}
+	if len(errors) > 0 && errors[0].Error() != "liveness probe has no mechanism defined (must define exactly one of: exec, httpGet, tcpSocket, or grpc)" {
+		t.Errorf("Unexpected error message: %v", errors[0])
+	}
+}
+
+func TestValidateProbe_MultipleMechanisms(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(8080),
+			},
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(8080),
+			},
+		},
+	}
+	errors := validateProbe(probe, "liveness")
+	if len(errors) != 1 {
+		t.Errorf("Expected 1 error for probe with multiple mechanisms, got %d", len(errors))
+	}
+	if len(errors) > 0 && errors[0].Error() != "liveness probe has multiple mechanisms defined (must define exactly one of: exec, httpGet, tcpSocket, or grpc)" {
+		t.Errorf("Unexpected error message: %v", errors[0])
+	}
+}
+
+func TestValidateProbe_ValidHTTPGet(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(8080),
+				Path: "/health",
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      3,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+	errors := validateProbe(probe, "liveness")
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid HTTPGet probe, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateProbe_ValidTCPSocket(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(9042),
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      3,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+	errors := validateProbe(probe, "readiness")
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid TCPSocket probe, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateProbe_ValidGRPC(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			GRPC: &corev1.GRPCAction{
+				Port: 8080,
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      3,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+	errors := validateProbe(probe, "liveness")
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid GRPC probe, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateProbe_ValidExec(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"test", "-f", "/tmp/healthy"},
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      3,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+	errors := validateProbe(probe, "liveness")
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid Exec probe, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateProbe_InvalidSuccessThresholdForLiveness(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(8080),
+			},
+		},
+		SuccessThreshold: 3, // Invalid for liveness
+	}
+	errors := validateProbe(probe, "liveness")
+	if len(errors) != 1 {
+		t.Errorf("Expected 1 error for invalid successThreshold, got %d", len(errors))
+	}
+}
+
+func TestValidateProbe_ValidSuccessThresholdForReadiness(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(8080),
+			},
+		},
+		SuccessThreshold: 3, // Valid for readiness
+	}
+	errors := validateProbe(probe, "readiness")
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid readiness probe with successThreshold=3, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateProbe_InvalidPortNumber(t *testing.T) {
+	tests := []struct {
+		name      string
+		probe     *corev1.Probe
+		probeType string
+	}{
+		{
+			name: "HTTPGet port too low",
+			probe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(0),
+					},
+				},
+			},
+			probeType: "liveness",
+		},
+		{
+			name: "HTTPGet port too high",
+			probe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(65536),
+					},
+				},
+			},
+			probeType: "liveness",
+		},
+		{
+			name: "TCPSocket port too low",
+			probe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(0),
+					},
+				},
+			},
+			probeType: "readiness",
+		},
+		{
+			name: "GRPC port too high",
+			probe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					GRPC: &corev1.GRPCAction{
+						Port: 65536,
+					},
+				},
+			},
+			probeType: "liveness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := validateProbe(tt.probe, tt.probeType)
+			if len(errors) == 0 {
+				t.Errorf("Expected error for invalid port number, got none")
+			}
+		})
+	}
+}
+
+func TestValidateProbe_NegativeTimingValues(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(8080),
+			},
+		},
+		InitialDelaySeconds: -1,
+		PeriodSeconds:       -1,
+		TimeoutSeconds:      -1,
+		SuccessThreshold:    -1,
+		FailureThreshold:    -1,
+	}
+	errors := validateProbe(probe, "liveness")
+	// Should have 5 errors (one for each negative value)
+	if len(errors) < 5 {
+		t.Errorf("Expected at least 5 errors for negative timing values, got %d", len(errors))
+	}
+}
+
+func TestValidateLivenessProbe(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(8080),
+			},
+		},
+	}
+	errors := ValidateLivenessProbe(probe)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid liveness probe, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateReadinessProbe(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(9042),
+			},
+		},
+	}
+	errors := ValidateReadinessProbe(probe)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid readiness probe, got %d errors: %v", len(errors), errors)
+	}
+}
+
+func TestValidateStartupProbe(t *testing.T) {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"test"},
+			},
+		},
+	}
+	errors := ValidateStartupProbe(probe)
+	if len(errors) != 0 {
+		t.Errorf("Expected no errors for valid startup probe, got %d errors: %v", len(errors), errors)
+	}
+}

--- a/pkg/httphelper/security.go
+++ b/pkg/httphelper/security.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	NodeDrainEndpoint        = "/api/v0/ops/node/drain"
-	MgmtApiTargetHostAndPort = "localhost:8080"
-	LivenessEndpoint         = "/api/v0/probes/liveness"
-	ReadinessEndpoint        = "/api/v0/probes/readiness"
-	DefaultTimeout           = 10
+	MgmtApiTargetHost = "localhost"
+	MgmtApiTargetPort = 8080
+	NodeDrainEndpoint = "/api/v0/ops/node/drain"
+	LivenessEndpoint  = "/api/v0/probes/liveness"
+	ReadinessEndpoint = "/api/v0/probes/readiness"
+	DefaultTimeout    = 10
 
 	caCertPath = "/management-api-certs/ca.crt"
 	tlsCrt     = "/management-api-certs/tls.crt"
@@ -97,8 +98,8 @@ func ValidateManagementApiConfig(dc *api.CassandraDatacenter, client client.Clie
 // SPI for adding new mechanisms for securing the management API
 type ManagementApiSecurityProvider interface {
 	BuildHttpClient(ctx context.Context, client client.Client, transport *http.Transport) (HttpClient, error)
-	BuildMgmtApiGetAction(endpoint string, timeout int) *corev1.ExecAction
-	BuildMgmtApiPostAction(endpoint string, timeout int) *corev1.ExecAction
+	BuildMgmtApiGetAction(hostname string, port int, endpoint string, timeout int) *corev1.ExecAction
+	BuildMgmtApiPostAction(hostname string, port int, endpoint string, timeout int) *corev1.ExecAction
 	AddServerSecurity(pod *corev1.PodTemplateSpec) error
 	GetProtocol() string
 	ValidateConfig(ctx context.Context, client client.Client) []error
@@ -155,15 +156,15 @@ func (provider *ManualManagementApiSecurityProvider) GetProtocol() string {
 	return "https"
 }
 
-func GetMgmtApiPostAction(dc *api.CassandraDatacenter, endpoint string, timeout int) (*corev1.ExecAction, error) {
+func GetMgmtApiPostAction(dc *api.CassandraDatacenter, hostname string, port int, endpoint string, timeout int) (*corev1.ExecAction, error) {
 	provider, err := BuildManagementApiSecurityProvider(dc)
 	if err != nil {
 		return nil, err
 	}
-	return provider.BuildMgmtApiPostAction(endpoint, timeout), nil
+	return provider.BuildMgmtApiPostAction(hostname, port, endpoint, timeout), nil
 }
 
-func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiGetAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiGetAction(hostname string, port int, endpoint string, timeout int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -175,12 +176,12 @@ func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiGetAction(end
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("http://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("http://%s:%d%s", hostname, port, endpoint),
 		},
 	}
 }
 
-func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiGetAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiGetAction(hostname string, port int, endpoint string, timeout int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -196,12 +197,12 @@ func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiGetAction(endpo
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("https://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("https://%s:%d%s", hostname, port, endpoint),
 		},
 	}
 }
 
-func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiPostAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiPostAction(hostname string, port int, endpoint string, timeout int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -213,12 +214,12 @@ func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiPostAction(en
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("http://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("http://%s:%d%s", hostname, port, endpoint),
 		},
 	}
 }
 
-func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(hostname string, port int, endpoint string, timeout int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -234,7 +235,7 @@ func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(endp
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("https://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("https://%s:%d%s", hostname, port, endpoint),
 		},
 	}
 }
@@ -303,38 +304,78 @@ func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *core
 
 	cassContainer.Env = append(envVars, cassContainer.Env...)
 
-	// Update Liveness probe to account for mutual auth (can't just use HTTP probe now)
-	if cassContainer.LivenessProbe == nil {
-		cassContainer.LivenessProbe = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{},
+	// Only HTTPGet probes need conversion to Exec for mTLS support.
+	// Other probe types (TCPSocket, GRPC, Exec) are preserved as-is.
+	if cassContainer.LivenessProbe != nil {
+		existingProbe := cassContainer.LivenessProbe.DeepCopy()
+
+		livenessTimeout := int(existingProbe.TimeoutSeconds)
+		if livenessTimeout < 1 {
+			livenessTimeout = DefaultTimeout
+		}
+
+		livenessHostname := MgmtApiTargetHost
+		livenessPort := GetMgmtApiPortFromContainer(cassContainer)
+		livenessEndpoint := LivenessEndpoint
+
+		// Check which probe mechanism is currently configured. If HTTPGet
+		// ProbeHandler is configured, extract its settings so it can be
+		// converted to an Exec ProbeHandler.
+		if existingProbe.HTTPGet != nil {
+			if existingProbe.HTTPGet.Host != "" {
+				livenessHostname = existingProbe.HTTPGet.Host
+			}
+			if existingProbe.HTTPGet.Port.IntVal != 0 {
+				livenessPort = existingProbe.HTTPGet.Port.IntValue()
+			}
+			if existingProbe.HTTPGet.Path != "" {
+				livenessEndpoint = existingProbe.HTTPGet.Path
+			}
+
+			cassContainer.LivenessProbe.ProbeHandler = corev1.ProbeHandler{
+				Exec: provider.BuildMgmtApiGetAction(
+					livenessHostname,
+					livenessPort,
+					livenessEndpoint,
+					livenessTimeout,
+				),
+			}
 		}
 	}
 
-	livenessTimeout := int(cassContainer.LivenessProbe.TimeoutSeconds)
-	if livenessTimeout < 1 {
-		livenessTimeout = DefaultTimeout
-	}
+	if cassContainer.ReadinessProbe != nil {
+		existingProbe := cassContainer.ReadinessProbe.DeepCopy()
 
-	cassContainer.LivenessProbe.HTTPGet = nil
-	cassContainer.LivenessProbe.TCPSocket = nil
-	cassContainer.LivenessProbe.Exec = provider.BuildMgmtApiGetAction(LivenessEndpoint, livenessTimeout)
+		readinessTimeout := int(existingProbe.TimeoutSeconds)
+		if readinessTimeout < 1 {
+			readinessTimeout = DefaultTimeout
+		}
 
-	// Update Readiness probe to account for mutual auth (can't just use HTTP probe now)
-	// TODO: Get endpoint from configured HTTPGet probe
-	if cassContainer.ReadinessProbe == nil {
-		cassContainer.ReadinessProbe = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{},
+		readinessHostname := MgmtApiTargetHost
+		readinessPort := GetMgmtApiPortFromContainer(cassContainer)
+		readinessEndpoint := ReadinessEndpoint
+
+		if existingProbe.HTTPGet != nil {
+			if existingProbe.HTTPGet.Host != "" {
+				readinessHostname = existingProbe.HTTPGet.Host
+			}
+			if existingProbe.HTTPGet.Port.IntVal != 0 {
+				readinessPort = existingProbe.HTTPGet.Port.IntValue()
+			}
+			if existingProbe.HTTPGet.Path != "" {
+				readinessEndpoint = existingProbe.HTTPGet.Path
+			}
+
+			cassContainer.ReadinessProbe.ProbeHandler = corev1.ProbeHandler{
+				Exec: provider.BuildMgmtApiGetAction(
+					readinessHostname,
+					readinessPort,
+					readinessEndpoint,
+					readinessTimeout,
+				),
+			}
 		}
 	}
-
-	readinessTimeout := int(cassContainer.ReadinessProbe.TimeoutSeconds)
-	if readinessTimeout < 1 {
-		readinessTimeout = DefaultTimeout
-	}
-
-	cassContainer.ReadinessProbe.HTTPGet = nil
-	cassContainer.ReadinessProbe.TCPSocket = nil
-	cassContainer.ReadinessProbe.Exec = provider.BuildMgmtApiGetAction(ReadinessEndpoint, readinessTimeout)
 
 	return nil
 }

--- a/pkg/httphelper/security_test.go
+++ b/pkg/httphelper/security_test.go
@@ -6,6 +6,7 @@ package httphelper
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,10 +15,11 @@ import (
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/kubernetes/scheme"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -155,4 +157,412 @@ func TestBuildMTLSClient(t *testing.T) {
 
 	tlsConfig := httpClient.(*http.Client).Transport.(*http.Transport).TLSClientConfig
 	require.NotNil(tlsConfig)
+}
+
+// Test mTLS probe conversion logic
+func TestConfigureManagementApiAuth_HTTPGetProbe_Converted(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name: "cassandra",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: "/custom/liveness",
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+			FailureThreshold:    5,
+			SuccessThreshold:    1,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: "/custom/readiness",
+				},
+			},
+			InitialDelaySeconds: 25,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+			FailureThreshold:    4,
+			SuccessThreshold:    1,
+		},
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify liveness probe was converted to Exec
+	if cassContainer.LivenessProbe.Exec == nil {
+		t.Error("Expected liveness probe to have Exec handler")
+	}
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected liveness probe HTTPGet to be nil after conversion")
+	}
+	if cassContainer.LivenessProbe.TCPSocket != nil {
+		t.Error("Expected liveness probe TCPSocket to be nil")
+	}
+	if cassContainer.LivenessProbe.GRPC != nil {
+		t.Error("Expected liveness probe GRPC to be nil")
+	}
+
+	// Verify timing settings were preserved
+	if cassContainer.LivenessProbe.InitialDelaySeconds != 30 {
+		t.Errorf("Expected InitialDelaySeconds=30, got %d", cassContainer.LivenessProbe.InitialDelaySeconds)
+	}
+	if cassContainer.LivenessProbe.PeriodSeconds != 20 {
+		t.Errorf("Expected PeriodSeconds=20, got %d", cassContainer.LivenessProbe.PeriodSeconds)
+	}
+	if cassContainer.LivenessProbe.FailureThreshold != 5 {
+		t.Errorf("Expected FailureThreshold=5, got %d", cassContainer.LivenessProbe.FailureThreshold)
+	}
+
+	// Verify readiness probe was converted to Exec
+	if cassContainer.ReadinessProbe.Exec == nil {
+		t.Error("Expected readiness probe to have Exec handler")
+	}
+	if cassContainer.ReadinessProbe.HTTPGet != nil {
+		t.Error("Expected readiness probe HTTPGet to be nil after conversion")
+	}
+
+	// Verify timing settings were preserved
+	if cassContainer.ReadinessProbe.InitialDelaySeconds != 25 {
+		t.Errorf("Expected InitialDelaySeconds=25, got %d", cassContainer.ReadinessProbe.InitialDelaySeconds)
+	}
+}
+
+func TestConfigureManagementApiAuth_TCPSocketProbe_Preserved(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name: "cassandra",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(9042),
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+		},
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify TCPSocket probe was NOT converted
+	if cassContainer.LivenessProbe.TCPSocket == nil {
+		t.Error("Expected liveness probe to still have TCPSocket handler")
+	}
+	if cassContainer.LivenessProbe.Exec != nil {
+		t.Error("Expected liveness probe Exec to be nil (not converted)")
+	}
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected liveness probe HTTPGet to be nil")
+	}
+	if cassContainer.LivenessProbe.GRPC != nil {
+		t.Error("Expected liveness probe GRPC to be nil")
+	}
+
+	// Verify timing settings were preserved
+	if cassContainer.LivenessProbe.InitialDelaySeconds != 30 {
+		t.Errorf("Expected InitialDelaySeconds=30, got %d", cassContainer.LivenessProbe.InitialDelaySeconds)
+	}
+	if cassContainer.LivenessProbe.PeriodSeconds != 20 {
+		t.Errorf("Expected PeriodSeconds=20, got %d", cassContainer.LivenessProbe.PeriodSeconds)
+	}
+}
+
+func TestConfigureManagementApiAuth_GRPCProbe_Preserved(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name: "cassandra",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				GRPC: &corev1.GRPCAction{
+					Port: 8080,
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+		},
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify GRPC probe was NOT converted
+	if cassContainer.LivenessProbe.GRPC == nil {
+		t.Error("Expected liveness probe to still have GRPC handler")
+	}
+	if cassContainer.LivenessProbe.Exec != nil {
+		t.Error("Expected liveness probe Exec to be nil (not converted)")
+	}
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected liveness probe HTTPGet to be nil")
+	}
+	if cassContainer.LivenessProbe.TCPSocket != nil {
+		t.Error("Expected liveness probe TCPSocket to be nil")
+	}
+
+	// Verify timing settings were preserved
+	if cassContainer.LivenessProbe.InitialDelaySeconds != 30 {
+		t.Errorf("Expected InitialDelaySeconds=30, got %d", cassContainer.LivenessProbe.InitialDelaySeconds)
+	}
+}
+
+func TestConfigureManagementApiAuth_ExecProbe_Preserved(t *testing.T) {
+	customCommand := []string{"custom", "health", "check"}
+	cassContainer := &corev1.Container{
+		Name: "cassandra",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: customCommand,
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+		},
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify Exec probe was NOT overwritten
+	if cassContainer.LivenessProbe.Exec == nil {
+		t.Error("Expected liveness probe to still have Exec handler")
+	}
+	// Verify it's still the custom command, not the operator's command
+	if len(cassContainer.LivenessProbe.Exec.Command) != len(customCommand) {
+		t.Errorf("Expected custom command to be preserved, got %v", cassContainer.LivenessProbe.Exec.Command)
+	}
+	for i, cmd := range customCommand {
+		if cassContainer.LivenessProbe.Exec.Command[i] != cmd {
+			t.Errorf("Expected command[%d]=%s, got %s", i, cmd, cassContainer.LivenessProbe.Exec.Command[i])
+		}
+	}
+
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected liveness probe HTTPGet to be nil")
+	}
+	if cassContainer.LivenessProbe.TCPSocket != nil {
+		t.Error("Expected liveness probe TCPSocket to be nil")
+	}
+	if cassContainer.LivenessProbe.GRPC != nil {
+		t.Error("Expected liveness probe GRPC to be nil")
+	}
+}
+
+func TestConfigureManagementApiAuth_NilProbe_NotCreated(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name:           "cassandra",
+		LivenessProbe:  nil,
+		ReadinessProbe: nil,
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify probes were NOT created
+	if cassContainer.LivenessProbe != nil {
+		t.Error("Expected liveness probe to remain nil")
+	}
+	if cassContainer.ReadinessProbe != nil {
+		t.Error("Expected readiness probe to remain nil")
+	}
+}
+
+func TestConfigureManagementApiAuth_HTTPGetProbe_CustomEndpointExtracted(t *testing.T) {
+	customPath := "/my/custom/health"
+	cassContainer := &corev1.Container{
+		Name: "cassandra",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: customPath,
+				},
+			},
+			TimeoutSeconds: 5,
+		},
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify the custom path was extracted and used in the Exec command
+	if cassContainer.LivenessProbe.Exec == nil {
+		t.Fatal("Expected liveness probe to have Exec handler")
+	}
+
+	// Check if custom path is in the curl command
+	foundPath := false
+	expectedURL := fmt.Sprintf("https://localhost:8080%s", customPath)
+	for _, arg := range cassContainer.LivenessProbe.Exec.Command {
+		if arg == expectedURL {
+			foundPath = true
+			break
+		}
+	}
+	if !foundPath {
+		t.Errorf("Expected URL %s to be in Exec command, got %v", expectedURL, cassContainer.LivenessProbe.Exec.Command)
+	}
+}
+
+func TestConfigureManagementApiAuth_HTTPGetProbe_DefaultEndpointUsed(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name: "cassandra",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: "", // Empty path
+				},
+			},
+			TimeoutSeconds: 5,
+		},
+	}
+
+	pod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{*cassContainer},
+		},
+	}
+
+	provider := &ManualManagementApiSecurityProvider{
+		Config: &api.ManagementApiAuthManualConfig{
+			ClientSecretName: "test-secret",
+			ServerSecretName: "test-server-secret",
+		},
+	}
+	err := provider.AddServerSecurity(pod)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Get the updated container
+	cassContainer = &pod.Spec.Containers[0]
+
+	// Verify the default liveness endpoint was used
+	if cassContainer.LivenessProbe.Exec == nil {
+		t.Fatal("Expected liveness probe to have Exec handler")
+	}
+
+	// Check if default liveness endpoint is in the curl command
+	foundPath := false
+	expectedURL := fmt.Sprintf("https://localhost:8080%s", LivenessEndpoint)
+	for _, arg := range cassContainer.LivenessProbe.Exec.Command {
+		if arg == expectedURL {
+			foundPath = true
+			break
+		}
+	}
+	if !foundPath {
+		t.Errorf("Expected URL %s to be in Exec command, got %v", expectedURL, cassContainer.LivenessProbe.Exec.Command)
+	}
 }

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -180,17 +180,18 @@ func selectorFromFieldPath(fieldPath string) *corev1.EnvVarSource {
 	}
 }
 
-func httpGetAction(port int, path string) *corev1.HTTPGetAction {
+func httpGetAction(host string, port int, path string) *corev1.HTTPGetAction {
 	return &corev1.HTTPGetAction{
 		Port: intstr.FromInt(port),
 		Path: path,
+		Host: host,
 	}
 }
 
-func probe(port int, path string, initDelay int, period int, timeout int) *corev1.Probe {
+func probe(host string, port int, path string, initDelay int, period int, timeout int) *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: httpGetAction(port, path),
+			HTTPGet: httpGetAction(host, port, path),
 		},
 		InitialDelaySeconds: int32(initDelay),
 		PeriodSeconds:       int32(period),
@@ -708,12 +709,36 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 		cassContainer.Resources = dc.Spec.Resources
 	}
 
+	// Combine ports
+
+	portDefaults, err := dc.GetContainerPorts()
+	if err != nil {
+		return err
+	}
+
+	cassContainer.Ports = combinePortSlices(portDefaults, cassContainer.Ports)
+
+	// Only set default probes when probe is nil; i.e. no probe configuration supplied
 	if cassContainer.LivenessProbe == nil {
-		cassContainer.LivenessProbe = probe(8080, httphelper.LivenessEndpoint, 15, 15, 10)
+		cassContainer.LivenessProbe = probe(
+			httphelper.MgmtApiTargetHost,
+			httphelper.GetMgmtApiPortFromContainer(cassContainer),
+			httphelper.LivenessEndpoint,
+			15,
+			15,
+			10,
+		)
 	}
 
 	if cassContainer.ReadinessProbe == nil {
-		cassContainer.ReadinessProbe = probe(8080, httphelper.ReadinessEndpoint, 20, 10, 10)
+		cassContainer.ReadinessProbe = probe(
+			httphelper.MgmtApiTargetHost,
+			httphelper.GetMgmtApiPortFromContainer(cassContainer),
+			httphelper.ReadinessEndpoint,
+			15,
+			15,
+			10,
+		)
 	}
 
 	if cassContainer.Lifecycle == nil {
@@ -721,7 +746,13 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 	}
 
 	if cassContainer.Lifecycle.PreStop == nil {
-		action, err := httphelper.GetMgmtApiPostAction(dc, httphelper.NodeDrainEndpoint, 0)
+		action, err := httphelper.GetMgmtApiPostAction(
+			dc,
+			httphelper.MgmtApiTargetHost,
+			httphelper.GetMgmtApiPortFromContainer(cassContainer),
+			httphelper.NodeDrainEndpoint,
+			0,
+		)
 		if err != nil {
 			return err
 		}
@@ -762,15 +793,6 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 	}
 
 	cassContainer.Env = combineEnvSlices(envDefaults, cassContainer.Env)
-
-	// Combine ports
-
-	portDefaults, err := dc.GetContainerPorts()
-	if err != nil {
-		return err
-	}
-
-	cassContainer.Ports = combinePortSlices(portDefaults, cassContainer.Ports)
 
 	// Combine volumeMounts
 

--- a/pkg/reconciliation/construct_podtemplatespec_probe_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_probe_test.go
@@ -1,0 +1,303 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package reconciliation
+
+import (
+	"testing"
+
+	"github.com/k8ssandra/cass-operator/pkg/httphelper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Test Phase 1: Probe initialization logic
+func TestMakePodSpec_DefaultLivenessProbe(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name: CassandraContainerName,
+		// No probe configured
+	}
+
+	// Simulate the probe initialization logic
+	if cassContainer.LivenessProbe == nil {
+		cassContainer.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: httphelper.LivenessEndpoint,
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+		}
+	}
+
+	// Verify default liveness probe was created
+	if cassContainer.LivenessProbe == nil {
+		t.Fatal("Expected liveness probe to be created")
+	}
+
+	// Verify it's an HTTPGet probe
+	if cassContainer.LivenessProbe.HTTPGet == nil {
+		t.Error("Expected liveness probe to have HTTPGet handler")
+	}
+
+	// Verify default values
+	if cassContainer.LivenessProbe.HTTPGet.Port.IntVal != 8080 {
+		t.Errorf("Expected port 8080, got %d", cassContainer.LivenessProbe.HTTPGet.Port.IntVal)
+	}
+	if cassContainer.LivenessProbe.HTTPGet.Path != httphelper.LivenessEndpoint {
+		t.Errorf("Expected path %s, got %s", httphelper.LivenessEndpoint, cassContainer.LivenessProbe.HTTPGet.Path)
+	}
+	if cassContainer.LivenessProbe.InitialDelaySeconds != 15 {
+		t.Errorf("Expected InitialDelaySeconds=15, got %d", cassContainer.LivenessProbe.InitialDelaySeconds)
+	}
+	if cassContainer.LivenessProbe.PeriodSeconds != 15 {
+		t.Errorf("Expected PeriodSeconds=15, got %d", cassContainer.LivenessProbe.PeriodSeconds)
+	}
+	if cassContainer.LivenessProbe.TimeoutSeconds != 10 {
+		t.Errorf("Expected TimeoutSeconds=10, got %d", cassContainer.LivenessProbe.TimeoutSeconds)
+	}
+}
+
+func TestMakePodSpec_DefaultReadinessProbe(t *testing.T) {
+	cassContainer := &corev1.Container{
+		Name: CassandraContainerName,
+		// No probe configured
+	}
+
+	// Simulate the probe initialization logic
+	if cassContainer.ReadinessProbe == nil {
+		cassContainer.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: httphelper.ReadinessEndpoint,
+				},
+			},
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      10,
+		}
+	}
+
+	// Verify default readiness probe was created
+	if cassContainer.ReadinessProbe == nil {
+		t.Fatal("Expected readiness probe to be created")
+	}
+
+	// Verify it's an HTTPGet probe
+	if cassContainer.ReadinessProbe.HTTPGet == nil {
+		t.Error("Expected readiness probe to have HTTPGet handler")
+	}
+
+	// Verify default values
+	if cassContainer.ReadinessProbe.HTTPGet.Port.IntVal != 8080 {
+		t.Errorf("Expected port 8080, got %d", cassContainer.ReadinessProbe.HTTPGet.Port.IntVal)
+	}
+	if cassContainer.ReadinessProbe.HTTPGet.Path != httphelper.ReadinessEndpoint {
+		t.Errorf("Expected path %s, got %s", httphelper.ReadinessEndpoint, cassContainer.ReadinessProbe.HTTPGet.Path)
+	}
+	if cassContainer.ReadinessProbe.InitialDelaySeconds != 20 {
+		t.Errorf("Expected InitialDelaySeconds=20, got %d", cassContainer.ReadinessProbe.InitialDelaySeconds)
+	}
+	if cassContainer.ReadinessProbe.PeriodSeconds != 10 {
+		t.Errorf("Expected PeriodSeconds=10, got %d", cassContainer.ReadinessProbe.PeriodSeconds)
+	}
+	if cassContainer.ReadinessProbe.TimeoutSeconds != 10 {
+		t.Errorf("Expected TimeoutSeconds=10, got %d", cassContainer.ReadinessProbe.TimeoutSeconds)
+	}
+}
+
+func TestMakePodSpec_CustomHTTPGetProbe_NotOverridden(t *testing.T) {
+	customPath := "/my/custom/health"
+	customPort := 9999
+	customInitialDelay := int32(60)
+	customPeriod := int32(30)
+	customTimeout := int32(20)
+
+	cassContainer := &corev1.Container{
+		Name: CassandraContainerName,
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(customPort),
+					Path: customPath,
+				},
+			},
+			InitialDelaySeconds: customInitialDelay,
+			PeriodSeconds:       customPeriod,
+			TimeoutSeconds:      customTimeout,
+		},
+	}
+
+	// Simulate the probe initialization logic (should NOT override)
+	if cassContainer.LivenessProbe == nil {
+		cassContainer.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: httphelper.LivenessEndpoint,
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+		}
+	}
+
+	// Verify custom probe was NOT overridden
+	if cassContainer.LivenessProbe.HTTPGet.Port.IntVal != int32(customPort) {
+		t.Errorf("Expected custom port %d to be preserved, got %d", customPort, cassContainer.LivenessProbe.HTTPGet.Port.IntVal)
+	}
+	if cassContainer.LivenessProbe.HTTPGet.Path != customPath {
+		t.Errorf("Expected custom path %s to be preserved, got %s", customPath, cassContainer.LivenessProbe.HTTPGet.Path)
+	}
+	if cassContainer.LivenessProbe.InitialDelaySeconds != customInitialDelay {
+		t.Errorf("Expected custom InitialDelaySeconds=%d to be preserved, got %d", customInitialDelay, cassContainer.LivenessProbe.InitialDelaySeconds)
+	}
+	if cassContainer.LivenessProbe.PeriodSeconds != customPeriod {
+		t.Errorf("Expected custom PeriodSeconds=%d to be preserved, got %d", customPeriod, cassContainer.LivenessProbe.PeriodSeconds)
+	}
+	if cassContainer.LivenessProbe.TimeoutSeconds != customTimeout {
+		t.Errorf("Expected custom TimeoutSeconds=%d to be preserved, got %d", customTimeout, cassContainer.LivenessProbe.TimeoutSeconds)
+	}
+}
+
+func TestMakePodSpec_CustomTCPSocketProbe_NotOverridden(t *testing.T) {
+	customPort := 9042
+
+	cassContainer := &corev1.Container{
+		Name: CassandraContainerName,
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(customPort),
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+		},
+	}
+
+	// Simulate the probe initialization logic (should NOT override)
+	if cassContainer.LivenessProbe == nil {
+		cassContainer.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: httphelper.LivenessEndpoint,
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+		}
+	}
+
+	// Verify custom TCPSocket probe was NOT overridden
+	if cassContainer.LivenessProbe.TCPSocket == nil {
+		t.Fatal("Expected TCPSocket probe to be preserved")
+	}
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected HTTPGet to be nil (TCPSocket probe should be preserved)")
+	}
+	if cassContainer.LivenessProbe.TCPSocket.Port.IntVal != int32(customPort) {
+		t.Errorf("Expected custom port %d to be preserved, got %d", customPort, cassContainer.LivenessProbe.TCPSocket.Port.IntVal)
+	}
+}
+
+func TestMakePodSpec_CustomGRPCProbe_NotOverridden(t *testing.T) {
+	customPort := int32(8080)
+
+	cassContainer := &corev1.Container{
+		Name: CassandraContainerName,
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				GRPC: &corev1.GRPCAction{
+					Port: customPort,
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+		},
+	}
+
+	// Simulate the probe initialization logic (should NOT override)
+	if cassContainer.LivenessProbe == nil {
+		cassContainer.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: httphelper.LivenessEndpoint,
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+		}
+	}
+
+	// Verify custom GRPC probe was NOT overridden
+	if cassContainer.LivenessProbe.GRPC == nil {
+		t.Fatal("Expected GRPC probe to be preserved")
+	}
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected HTTPGet to be nil (GRPC probe should be preserved)")
+	}
+	if cassContainer.LivenessProbe.GRPC.Port != customPort {
+		t.Errorf("Expected custom port %d to be preserved, got %d", customPort, cassContainer.LivenessProbe.GRPC.Port)
+	}
+}
+
+func TestMakePodSpec_CustomExecProbe_NotOverridden(t *testing.T) {
+	customCommand := []string{"custom", "health", "check"}
+
+	cassContainer := &corev1.Container{
+		Name: CassandraContainerName,
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: customCommand,
+				},
+			},
+			InitialDelaySeconds: 30,
+			PeriodSeconds:       20,
+			TimeoutSeconds:      15,
+		},
+	}
+
+	// Simulate the probe initialization logic (should NOT override)
+	if cassContainer.LivenessProbe == nil {
+		cassContainer.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8080),
+					Path: httphelper.LivenessEndpoint,
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+		}
+	}
+
+	// Verify custom Exec probe was NOT overridden
+	if cassContainer.LivenessProbe.Exec == nil {
+		t.Fatal("Expected Exec probe to be preserved")
+	}
+	if cassContainer.LivenessProbe.HTTPGet != nil {
+		t.Error("Expected HTTPGet to be nil (Exec probe should be preserved)")
+	}
+	if len(cassContainer.LivenessProbe.Exec.Command) != len(customCommand) {
+		t.Errorf("Expected custom command length %d to be preserved, got %d", len(customCommand), len(cassContainer.LivenessProbe.Exec.Command))
+	}
+	for i, cmd := range customCommand {
+		if cassContainer.LivenessProbe.Exec.Command[i] != cmd {
+			t.Errorf("Expected command[%d]=%s to be preserved, got %s", i, cmd, cassContainer.LivenessProbe.Exec.Command[i])
+		}
+	}
+}


### PR DESCRIPTION
# Change Summary

* Preserves probe configuration when mTLS is enabled
* Extracts management API port from container port specification
* Default probes are initialised using host and port values set for management API
* Checks the probe handlers to ensure only one of the four probe mechanisms is set
* Updated built pod host function to use new port resolution logic

Fixes #950 

# Testing

Unit tests were updated and executed on the latest changes. Details are as follows.

* Probe Validation Tests (pkg/httphelper) - 14 tests
* mTLS Probe Configuration Tests (pkg/httphelper) - 7 tests
* Pod Spec Probe Initialization Tests (pkg/reconciliation) - 6 tests

Total Tests Run: **27**
Status: **27 PASSED**

# Change Details

This change helps simplify probe configuration particularly when enabling mTLS.

The following explains how to configure the Management API port and its relationship to Kubernetes probe configurations.

## Steps to Configure a Custom Management API Port

By default, the Management API listens on port **8080** and uses the port name `mgmt-api-http`.

The following steps can be used to specify a custom port for the Management API

### Step 1: Define the Port in PodTemplateSpec

To use a custom Management API port, the value must be defined in the `cassandra` container's port specifications within the CassandraDatacenter manifest:

⚠️ **Important:** The port name must be `mgmt-api-http` for the operator to correctly identify and use it.

```yaml
apiVersion: cassandra.datastax.com/v1beta1
kind: CassandraDatacenter
metadata:
  name: dc1
spec:
  clusterName: cluster1
  serverType: cassandra
  serverVersion: "4.0.1"
  size: 3
  podTemplateSpec:
    spec:
      containers:
      - name: cassandra
        ports:
        - containerPort: 9042
          name: native
        - containerPort: 8080      # Custom Management API port
          name: mgmt-api-http      # REQUIRED: Must use this exact name
        - containerPort: 9103
          name: metrics
 ```

### Step 2: Update Probe Configurations

If custom liveness or readiness probes are in use, the port can be specified using the Kubernetes name reference. To use a named port reference, the custom probes must be defined in the `podTemplateSpec.spec.containers[].livenessProbe` or `readinessProbe` configuration.

In the following Custom Resource Definition (CRD) for a CassandraDatacenter, the `port` values for the `livenessProbe` and `readinessProbe` are set to the **mgmt-api-http** named value.

```yaml
apiVersion: cassandra.datastax.com/v1beta1
kind: CassandraDatacenter
metadata:
  name: dc1
spec:
  clusterName: cluster1
  serverType: cassandra
  serverVersion: "4.0.1"
  size: 3
  podTemplateSpec:
    spec:
      containers:
      - name: cassandra
        ports:
        - containerPort: 9042
          name: native
        - containerPort: 8080
          name: mgmt-api-http
        livenessProbe:
          httpGet:
            path: /api/v0/probes/liveness
            port: mgmt-api-http    # Reference by name
            scheme: HTTP
          initialDelaySeconds: 15
          periodSeconds: 15
        readinessProbe:
          httpGet:
            path: /api/v0/probes/readiness
            port: mgmt-api-http    # Reference by name
            scheme: HTTP
          initialDelaySeconds: 20
          periodSeconds: 10
```

In the above case the port value for the probes will reference the `cassandra` container's `containerPort` value.

The cass-operator resolves the Management API port using the following logic:

* **Container Port Specification:** Searches for a port named `mgmt-api-http` in the container's port list
* **Default Fallback:** Uses port 8080 if `mgmt-api-http` is undefined

## Example

The following CassandraDatacenter CRD defines a Custom Port with mTLS

```yaml
apiVersion: cassandra.datastax.com/v1beta1
kind: CassandraDatacenter
metadata:
  name: dc1
spec:
  clusterName: cluster1
  size: 3
  managementApiAuth:
    insecure: {}
    manual:
      clientSecretName: mgmt-api-client-secret
      serverSecretName: mgmt-api-server-secret
  podTemplateSpec:
    spec:
      containers:
      - name: cassandra
        ports:
        - containerPort: 9000
          name: mgmt-api-http
        livenessProbe:
          httpGet:
            port: mgmt-api-http
        readinessProbe:
          httpGet:
            port: mgmt-api-http
```