### PR TITLE
Allow to configure mgmt-api-http port

### DIFF
--- a/.github/workflows/kindIntegTest.yml
+++ b/.github/workflows/kindIntegTest.yml
@@ -180,6 +180,7 @@ jobs:
           - additional_serviceoptions
           - scheduled_task
           - additional_volumes
+          - mgmt_api_port_change
           # - delete_node_terminated_container # This does not test any operator behavior
           # - podspec_simple
           # - terminate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 * [ENHANCEMENT] [#943](https://github.com/k8ssandra/cass-operator/issues/943) Add terminating state as one of the Pod status metrics
 * [ENHANCEMENT] [#936](https://github.com/k8ssandra/cass-operator/issues/936) Every reconcile of the CassandraDatacenter should refresh the metrics for up-to-date state
+* [ENHANCEMENT] [#242](https://github.com/k8ssandra/cass-operator/issues/242) Allow configuring the mgmt-api port. Setting cassandra container's mgmt-api-http containerPort will override the default 8080 value.
 * [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
 * [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen

--- a/apis/cassandra/v1beta1/cassandradatacenter_types.go
+++ b/apis/cassandra/v1beta1/cassandradatacenter_types.go
@@ -101,6 +101,7 @@ const (
 
 	DefaultNativePort    = 9042
 	DefaultInternodePort = 7000
+	DefaultMgmtApiPort   = 8080
 )
 
 type AllowUpdateType string
@@ -792,7 +793,7 @@ func (dc *CassandraDatacenter) GetContainerPorts() ([]corev1.ContainerPort, erro
 		namedPort("internode", internodePort),
 		namedPort("tls-internode", 7001),
 		namedPort("jmx", 7199),
-		namedPort("mgmt-api-http", 8080),
+		namedPort("mgmt-api-http", DefaultMgmtApiPort),
 		namedPort("prometheus", 9103),
 		namedPort("metrics", 9000),
 	}

--- a/pkg/httphelper/client.go
+++ b/pkg/httphelper/client.go
@@ -228,20 +228,22 @@ func BuildPodHostFromPod(pod *corev1.Pod) (string, int, error) {
 		return "", 0, newNoPodIPError(pod)
 	}
 
-	mgmtApiPort := 8080
+	return pod.Status.PodIP, GetMgmtApiPort(pod.Spec.Containers), nil
+}
 
-	// Check for port override
-	for _, container := range pod.Spec.Containers {
+// GetMgmtApiPort returns the named mgmt-api port from the cassandra container.
+func GetMgmtApiPort(containers []corev1.Container) int {
+	for _, container := range containers {
 		if container.Name == "cassandra" {
 			for _, port := range container.Ports {
 				if port.Name == "mgmt-api-http" {
-					mgmtApiPort = int(port.ContainerPort)
+					return int(port.ContainerPort)
 				}
 			}
 		}
 	}
 
-	return pod.Status.PodIP, mgmtApiPort, nil
+	return cassdcapi.DefaultMgmtApiPort
 }
 
 func GetPodHost(podName, clusterName, dcName, namespace string) string {
@@ -1274,7 +1276,7 @@ func callNodeMgmtEndpoint(client *NodeMgmtClient, request nodeMgmtRequest, conte
 		nodeMgmtCallDurationMetric.WithLabelValues(request.method, urlForMetric(request.endpoint), callResult).Observe(time.Since(startTime).Seconds())
 	}()
 
-	port := 8080
+	port := cassdcapi.DefaultMgmtApiPort
 	if request.port > 0 {
 		port = request.port
 	}

--- a/pkg/httphelper/client_test.go
+++ b/pkg/httphelper/client_test.go
@@ -51,6 +51,63 @@ func Test_BuildPodHostFromPod(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestGetMgmtApiPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []corev1.Container
+		expected   int
+	}{
+		{
+			name:     "default without containers",
+			expected: api.DefaultMgmtApiPort,
+		},
+		{
+			name: "ignore management API port on another container",
+			containers: []corev1.Container{
+				{
+					Name:  "sidecar",
+					Ports: []corev1.ContainerPort{{Name: "mgmt-api-http", ContainerPort: 8081}},
+				},
+			},
+			expected: api.DefaultMgmtApiPort,
+		},
+		{
+			name: "ignore other Cassandra ports",
+			containers: []corev1.Container{
+				{
+					Name: "cassandra",
+					Ports: []corev1.ContainerPort{
+						{Name: "native", ContainerPort: 9042},
+						{Name: "metrics", ContainerPort: 9000},
+					},
+				},
+			},
+			expected: api.DefaultMgmtApiPort,
+		},
+		{
+			name: "custom management API port among other Cassandra ports",
+			containers: []corev1.Container{
+				{Name: "sidecar", Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8082}}},
+				{
+					Name: "cassandra",
+					Ports: []corev1.ContainerPort{
+						{Name: "native", ContainerPort: 9042},
+						{Name: "mgmt-api-http", ContainerPort: 8081},
+						{Name: "metrics", ContainerPort: 9000},
+					},
+				},
+			},
+			expected: 8081,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, GetMgmtApiPort(test.containers))
+		})
+	}
+}
+
 func Test_parseMetadataEndpointsResponseBody(t *testing.T) {
 	endpoints, err := parseMetadataEndpointsResponseBody([]byte(`{
 		"entity": [

--- a/pkg/httphelper/security.go
+++ b/pkg/httphelper/security.go
@@ -21,11 +21,10 @@ import (
 )
 
 const (
-	NodeDrainEndpoint        = "/api/v0/ops/node/drain"
-	MgmtApiTargetHostAndPort = "localhost:8080"
-	LivenessEndpoint         = "/api/v0/probes/liveness"
-	ReadinessEndpoint        = "/api/v0/probes/readiness"
-	DefaultTimeout           = 10
+	NodeDrainEndpoint = "/api/v0/ops/node/drain"
+	LivenessEndpoint  = "/api/v0/probes/liveness"
+	ReadinessEndpoint = "/api/v0/probes/readiness"
+	DefaultTimeout    = 10
 
 	caCertPath = "/management-api-certs/ca.crt"
 	tlsCrt     = "/management-api-certs/tls.crt"
@@ -97,14 +96,18 @@ func ValidateManagementApiConfig(dc *api.CassandraDatacenter, client client.Clie
 // SPI for adding new mechanisms for securing the management API
 type ManagementApiSecurityProvider interface {
 	BuildHttpClient(ctx context.Context, client client.Client, transport *http.Transport) (HttpClient, error)
-	BuildMgmtApiGetAction(endpoint string, timeout int) *corev1.ExecAction
-	BuildMgmtApiPostAction(endpoint string, timeout int) *corev1.ExecAction
+	BuildMgmtApiGetAction(endpoint string, timeout int, port int) *corev1.ExecAction
+	BuildMgmtApiPostAction(endpoint string, timeout int, port int) *corev1.ExecAction
 	AddServerSecurity(pod *corev1.PodTemplateSpec) error
 	GetProtocol() string
 	ValidateConfig(ctx context.Context, client client.Client) []error
 }
 
 type InsecureManagementApiSecurityProvider struct{}
+
+func mgmtApiTargetHostAndPort(port int) string {
+	return fmt.Sprintf("localhost:%d", port)
+}
 
 func buildInsecureManagementApiSecurityProvider(dc *api.CassandraDatacenter) (ManagementApiSecurityProvider, error) {
 	// If both are nil, then default to insecure
@@ -155,15 +158,15 @@ func (provider *ManualManagementApiSecurityProvider) GetProtocol() string {
 	return "https"
 }
 
-func GetMgmtApiPostAction(dc *api.CassandraDatacenter, endpoint string, timeout int) (*corev1.ExecAction, error) {
+func GetMgmtApiPostAction(dc *api.CassandraDatacenter, endpoint string, timeout int, port int) (*corev1.ExecAction, error) {
 	provider, err := BuildManagementApiSecurityProvider(dc)
 	if err != nil {
 		return nil, err
 	}
-	return provider.BuildMgmtApiPostAction(endpoint, timeout), nil
+	return provider.BuildMgmtApiPostAction(endpoint, timeout, port), nil
 }
 
-func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiGetAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiGetAction(endpoint string, timeout int, port int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -175,12 +178,12 @@ func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiGetAction(end
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("http://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("http://%s%s", mgmtApiTargetHostAndPort(port), endpoint),
 		},
 	}
 }
 
-func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiGetAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiGetAction(endpoint string, timeout int, port int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -196,12 +199,12 @@ func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiGetAction(endpo
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("https://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("https://%s%s", mgmtApiTargetHostAndPort(port), endpoint),
 		},
 	}
 }
 
-func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiPostAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiPostAction(endpoint string, timeout int, port int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -213,12 +216,12 @@ func (provider *InsecureManagementApiSecurityProvider) BuildMgmtApiPostAction(en
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("http://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("http://%s%s", mgmtApiTargetHostAndPort(port), endpoint),
 		},
 	}
 }
 
-func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(endpoint string, timeout int) *corev1.ExecAction {
+func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(endpoint string, timeout int, port int) *corev1.ExecAction {
 	return &corev1.ExecAction{
 		Command: []string{
 			"curl",
@@ -234,7 +237,7 @@ func (provider *ManualManagementApiSecurityProvider) BuildMgmtApiPostAction(endp
 			"/dev/null",
 			"--show-error",
 			"--fail",
-			fmt.Sprintf("https://%s%s", MgmtApiTargetHostAndPort, endpoint),
+			fmt.Sprintf("https://%s%s", mgmtApiTargetHostAndPort(port), endpoint),
 		},
 	}
 }
@@ -281,6 +284,8 @@ func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *core
 		return fmt.Errorf("could not find cassandra container")
 	}
 
+	mgmtApiPort := GetMgmtApiPort(pod.Spec.Containers)
+
 	// Configure Management API to use certificates
 	envVars := []corev1.EnvVar{
 		{
@@ -317,10 +322,10 @@ func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *core
 
 	cassContainer.LivenessProbe.HTTPGet = nil
 	cassContainer.LivenessProbe.TCPSocket = nil
-	cassContainer.LivenessProbe.Exec = provider.BuildMgmtApiGetAction(LivenessEndpoint, livenessTimeout)
+	cassContainer.LivenessProbe.GRPC = nil
+	cassContainer.LivenessProbe.Exec = provider.BuildMgmtApiGetAction(LivenessEndpoint, livenessTimeout, mgmtApiPort)
 
 	// Update Readiness probe to account for mutual auth (can't just use HTTP probe now)
-	// TODO: Get endpoint from configured HTTPGet probe
 	if cassContainer.ReadinessProbe == nil {
 		cassContainer.ReadinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{},
@@ -334,7 +339,8 @@ func (provider *ManualManagementApiSecurityProvider) AddServerSecurity(pod *core
 
 	cassContainer.ReadinessProbe.HTTPGet = nil
 	cassContainer.ReadinessProbe.TCPSocket = nil
-	cassContainer.ReadinessProbe.Exec = provider.BuildMgmtApiGetAction(ReadinessEndpoint, readinessTimeout)
+	cassContainer.ReadinessProbe.GRPC = nil
+	cassContainer.ReadinessProbe.Exec = provider.BuildMgmtApiGetAction(ReadinessEndpoint, readinessTimeout, mgmtApiPort)
 
 	return nil
 }

--- a/pkg/reconciliation/construct_podtemplatespec.go
+++ b/pkg/reconciliation/construct_podtemplatespec.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -708,12 +709,14 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 		cassContainer.Resources = dc.Spec.Resources
 	}
 
+	managementApiPort := httphelper.GetMgmtApiPort(baseTemplate.Spec.Containers)
+
 	if cassContainer.LivenessProbe == nil {
-		cassContainer.LivenessProbe = probe(8080, httphelper.LivenessEndpoint, 15, 15, 10)
+		cassContainer.LivenessProbe = probe(managementApiPort, httphelper.LivenessEndpoint, 15, 15, 10)
 	}
 
 	if cassContainer.ReadinessProbe == nil {
-		cassContainer.ReadinessProbe = probe(8080, httphelper.ReadinessEndpoint, 20, 10, 10)
+		cassContainer.ReadinessProbe = probe(managementApiPort, httphelper.ReadinessEndpoint, 20, 10, 10)
 	}
 
 	if cassContainer.Lifecycle == nil {
@@ -721,7 +724,7 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 	}
 
 	if cassContainer.Lifecycle.PreStop == nil {
-		action, err := httphelper.GetMgmtApiPostAction(dc, httphelper.NodeDrainEndpoint, 0)
+		action, err := httphelper.GetMgmtApiPostAction(dc, httphelper.NodeDrainEndpoint, 0, managementApiPort)
 		if err != nil {
 			return err
 		}
@@ -741,6 +744,7 @@ func buildContainers(dc *api.CassandraDatacenter, baseTemplate *corev1.PodTempla
 		{Name: "USE_MGMT_API", Value: "true"},
 		{Name: "MGMT_API_NO_KEEP_ALIVE", Value: "true"},
 		{Name: "MGMT_API_EXPLICIT_START", Value: "true"},
+		{Name: "MGMT_API_LISTEN_TCP_PORT", Value: strconv.Itoa(managementApiPort)},
 	}
 
 	if dc.Spec.ServerType == "dse" {

--- a/pkg/reconciliation/construct_podtemplatespec_test.go
+++ b/pkg/reconciliation/construct_podtemplatespec_test.go
@@ -441,6 +441,7 @@ func TestCassandraContainerEnvVars(t *testing.T) {
 	useMgmtApiEnvVar := corev1.EnvVar{Name: "USE_MGMT_API", Value: "true"}
 	explicitStartEnvVar := corev1.EnvVar{Name: "MGMT_API_EXPLICIT_START", Value: "true"}
 	noKeepAliveEnvVar := corev1.EnvVar{Name: "MGMT_API_NO_KEEP_ALIVE", Value: "true"}
+	listenPortEnvVar := corev1.EnvVar{Name: "MGMT_API_LISTEN_TCP_PORT", Value: "8080"}
 
 	templateSpec := &corev1.PodTemplateSpec{}
 	dc := &api.CassandraDatacenter{
@@ -468,6 +469,55 @@ func TestCassandraContainerEnvVars(t *testing.T) {
 	assert.True(envVarsContains(cassContainer.Env, useMgmtApiEnvVar))
 	assert.True(envVarsContains(cassContainer.Env, explicitStartEnvVar))
 	assert.True(envVarsContains(cassContainer.Env, noKeepAliveEnvVar))
+	assert.True(envVarsContains(cassContainer.Env, listenPortEnvVar))
+}
+
+func TestCustomMgmtApiPortConfiguration(t *testing.T) {
+	const mgmtApiPort int32 = 8081
+	dc := &api.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
+		Spec: api.CassandraDatacenterSpec{
+			ClusterName:   "test",
+			ServerType:    "cassandra",
+			ServerVersion: "4.0.7",
+			ManagementApiAuth: api.ManagementApiAuthConfig{
+				Manual: &api.ManagementApiAuthManualConfig{},
+			},
+			PodTemplateSpec: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: CassandraContainerName,
+							Ports: []corev1.ContainerPort{
+								{Name: "mgmt-api-http", ContainerPort: mgmtApiPort},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	templateSpec := dc.Spec.PodTemplateSpec.DeepCopy()
+
+	require.NoError(t, buildContainers(dc, templateSpec, imageRegistry))
+	cassContainer := findContainer(templateSpec.Spec.Containers, CassandraContainerName)
+	require.NotNil(t, cassContainer)
+
+	assert.True(t, envVarsContains(cassContainer.Env, corev1.EnvVar{
+		Name:  "MGMT_API_LISTEN_TCP_PORT",
+		Value: "8081",
+	}))
+	require.NotNil(t, cassContainer.LivenessProbe)
+	require.NotNil(t, cassContainer.LivenessProbe.HTTPGet)
+	assert.Equal(t, mgmtApiPort, cassContainer.LivenessProbe.HTTPGet.Port.IntVal)
+	require.NotNil(t, cassContainer.ReadinessProbe)
+	require.NotNil(t, cassContainer.ReadinessProbe.HTTPGet)
+	assert.Equal(t, mgmtApiPort, cassContainer.ReadinessProbe.HTTPGet.Port.IntVal)
+	require.NotNil(t, cassContainer.Lifecycle)
+	require.NotNil(t, cassContainer.Lifecycle.PreStop)
+	require.NotNil(t, cassContainer.Lifecycle.PreStop.Exec)
+	assert.Contains(t, cassContainer.Lifecycle.PreStop.Exec.Command,
+		"https://localhost:8081/api/v0/ops/node/drain")
 }
 
 func TestHCDContainerEnvVars(t *testing.T) {

--- a/pkg/reconciliation/construct_service.go
+++ b/pkg/reconciliation/construct_service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/k8ssandra/cass-operator/pkg/httphelper"
 	"github.com/k8ssandra/cass-operator/pkg/oplabels"
 	"github.com/k8ssandra/cass-operator/pkg/utils"
 
@@ -31,11 +32,12 @@ func newServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev1.Servi
 	if dc.IsNodePortEnabled() {
 		nativePort = dc.GetNodePortNativePort()
 	}
+	mgmtApiPort := managementApiPortForDatacenter(dc)
 
 	ports := []corev1.ServicePort{
 		namedServicePort("native", nativePort, nativePort),
 		namedServicePort("tls-native", 9142, 9142),
-		namedServicePort("mgmt-api", 8080, 8080),
+		namedServicePort("mgmt-api", mgmtApiPort, mgmtApiPort),
 		namedServicePort("prometheus", 9103, 9103),
 		namedServicePort("metrics", 9000, 9000),
 	}
@@ -100,6 +102,13 @@ func addAdditionalOptions(service *corev1.Service, serviceConfig *api.ServiceCon
 
 func namedServicePort(name string, port int, targetPort int) corev1.ServicePort {
 	return corev1.ServicePort{Name: name, Port: int32(port), TargetPort: intstr.FromInt(targetPort)}
+}
+
+func managementApiPortForDatacenter(dc *api.CassandraDatacenter) int {
+	if dc.Spec.PodTemplateSpec == nil {
+		return httphelper.GetMgmtApiPort(nil)
+	}
+	return httphelper.GetMgmtApiPort(dc.Spec.PodTemplateSpec.Spec.Containers)
 }
 
 func buildLabelSelectorForSeedService(dc *api.CassandraDatacenter) map[string]string {
@@ -279,13 +288,14 @@ func newAllPodsServiceForCassandraDatacenter(dc *api.CassandraDatacenter) *corev
 	if dc.IsNodePortEnabled() {
 		nativePort = dc.GetNodePortNativePort()
 	}
+	mgmtApiPort := managementApiPortForDatacenter(dc)
 
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Name: "native", Port: int32(nativePort), TargetPort: intstr.FromInt(nativePort),
 		},
 		{
-			Name: "mgmt-api", Port: 8080, TargetPort: intstr.FromInt(8080),
+			Name: "mgmt-api", Port: int32(mgmtApiPort), TargetPort: intstr.FromInt(mgmtApiPort),
 		},
 		{
 			Name: "prometheus", Port: 9103, TargetPort: intstr.FromInt(9103),

--- a/pkg/reconciliation/construct_service_test.go
+++ b/pkg/reconciliation/construct_service_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 )
@@ -481,6 +482,7 @@ func TestServicePorts(t *testing.T) {
 		dc                  *api.CassandraDatacenter
 		dcServicePorts      []int32
 		allPodsServicePorts []int32
+		mgmtApiPort         int32
 	}{
 		{
 			name: "Cassandra 3.11.14",
@@ -505,6 +507,31 @@ func TestServicePorts(t *testing.T) {
 			},
 			dcServicePorts:      []int32{8080, 9000, 9042, 9103, 9142},
 			allPodsServicePorts: []int32{8080, 9000, 9042, 9103},
+		},
+		{
+			name: "Cassandra 4.0.7 with custom management API port",
+			dc: &api.CassandraDatacenter{
+				Spec: api.CassandraDatacenterSpec{
+					ClusterName:   "bob",
+					ServerType:    "cassandra",
+					ServerVersion: "4.0.7",
+					PodTemplateSpec: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "cassandra",
+									Ports: []corev1.ContainerPort{
+										{Name: "mgmt-api-http", ContainerPort: 8081},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			dcServicePorts:      []int32{8081, 9000, 9042, 9103, 9142},
+			allPodsServicePorts: []int32{8081, 9000, 9042, 9103},
+			mgmtApiPort:         8081,
 		},
 		{
 			name: "DSE 6.8.31",
@@ -557,15 +584,30 @@ func TestServicePorts(t *testing.T) {
 				}
 				return servicePorts
 			}
+			assertMgmtApiPort := func(svc *corev1.Service) {
+				if test.mgmtApiPort == 0 {
+					return
+				}
+				for _, port := range svc.Spec.Ports {
+					if port.Name == "mgmt-api" {
+						assert.Equal(t, test.mgmtApiPort, port.Port)
+						assert.Equal(t, intstr.FromInt(int(test.mgmtApiPort)), port.TargetPort)
+						return
+					}
+				}
+				assert.Fail(t, "mgmt-api service port not found")
+			}
 			t.Run("dc service", func(t *testing.T) {
 				svc := newServiceForCassandraDatacenter(test.dc)
 				servicePorts := getServicePorts(svc)
 				assert.ElementsMatch(t, servicePorts, test.dcServicePorts)
+				assertMgmtApiPort(svc)
 			})
 			t.Run("all pods service", func(t *testing.T) {
 				svc := newAllPodsServiceForCassandraDatacenter(test.dc)
 				servicePorts := getServicePorts(svc)
 				assert.ElementsMatch(t, servicePorts, test.allPodsServicePorts)
+				assertMgmtApiPort(svc)
 			})
 		})
 	}

--- a/pkg/reconciliation/construct_statefulset_test.go
+++ b/pkg/reconciliation/construct_statefulset_test.go
@@ -870,6 +870,24 @@ func TestAddManagementApiServerSecurity(t *testing.T) {
 			ClusterName:   "pleasenobob",
 			ServerType:    "cassandra",
 			ServerVersion: "5.0.6",
+			PodTemplateSpec: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: CassandraContainerName,
+							Ports: []corev1.ContainerPort{
+								{Name: "mgmt-api-http", ContainerPort: 8081},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{GRPC: &corev1.GRPCAction{Port: 8081}},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{GRPC: &corev1.GRPCAction{Port: 8081}},
+							},
+						},
+					},
+				},
+			},
 			ManagementApiAuth: api.ManagementApiAuthConfig{
 				Manual: &api.ManagementApiAuthManualConfig{
 					ClientSecretName: "mgmt-api-client-credentials",
@@ -911,4 +929,17 @@ func TestAddManagementApiServerSecurity(t *testing.T) {
 		}
 		require.True(foundServerCertsMount, "did not find management api server certs volume mount in container %s", c.Name)
 	}
+
+	cassContainer := findContainer(podTemplateSpec.Spec.Containers, CassandraContainerName)
+	require.NotNil(cassContainer)
+	require.NotNil(cassContainer.LivenessProbe)
+	require.Nil(cassContainer.LivenessProbe.GRPC)
+	require.NotNil(cassContainer.LivenessProbe.Exec)
+	require.Contains(cassContainer.LivenessProbe.Exec.Command,
+		"https://localhost:8081/api/v0/probes/liveness")
+	require.NotNil(cassContainer.ReadinessProbe)
+	require.Nil(cassContainer.ReadinessProbe.GRPC)
+	require.NotNil(cassContainer.ReadinessProbe.Exec)
+	require.Contains(cassContainer.ReadinessProbe.Exec.Command,
+		"https://localhost:8081/api/v0/probes/readiness")
 }

--- a/tests/mgmt_api_port_change/mgmt_api_port_change_suite_test.go
+++ b/tests/mgmt_api_port_change/mgmt_api_port_change_suite_test.go
@@ -1,0 +1,80 @@
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+package mgmt_api_port_change
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8ssandra/cass-operator/tests/kustomize"
+	ginkgo_util "github.com/k8ssandra/cass-operator/tests/util/ginkgo"
+	"github.com/k8ssandra/cass-operator/tests/util/kubectl"
+)
+
+const managementApiPort = 8087
+
+var (
+	testName   = "Management API port change"
+	namespace  = "test-mgmt-api-port-change"
+	dcName     = "dc2"
+	dcYaml     = "../testdata/default-single-rack-single-node-dc.yaml"
+	dcResource = fmt.Sprintf("CassandraDatacenter/%s", dcName)
+	podName    = "cluster2-dc2-r1-sts-0"
+	ns         = ginkgo_util.NewWrapper(testName, namespace)
+)
+
+func TestLifecycle(t *testing.T) {
+	ginkgo_util.RunTestLifecycle(t, testName, ns)
+}
+
+var _ = Describe(testName, func() {
+	Context("when a datacenter is running", func() {
+		Specify("the operator changes the management API port", func() {
+			By("deploy cass-operator with kustomize")
+			err := kustomize.Deploy(namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			ns.WaitForOperatorReady()
+
+			step := "creating a datacenter resource with 1 rack/1 node"
+			testFile, err := ginkgo_util.CreateTestFile(dcYaml)
+			Expect(err).ToNot(HaveOccurred())
+
+			k := kubectl.ApplyFiles(testFile)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterReady(dcName)
+
+			step = fmt.Sprintf("changing the management API port to %d", managementApiPort)
+			patch := fmt.Sprintf(`{"spec":{"podTemplateSpec":{"spec":{"containers":[{"name":"cassandra","ports":[{"name":"mgmt-api-http","containerPort":%d}]}]}}}}`, managementApiPort)
+			k = kubectl.PatchMerge(dcResource, patch)
+			ns.ExecAndLog(step, k)
+
+			ns.WaitForDatacenterOperatorProgress(dcName, "Updating", 60)
+			ns.WaitForDatacenterReady(dcName)
+
+			step = "checking the management API container port on the running pod"
+			json := `jsonpath={.spec.containers[?(@.name=='cassandra')].ports[?(@.name=='mgmt-api-http')].containerPort}`
+			k = kubectl.Get(fmt.Sprintf("pod/%s", podName)).FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, fmt.Sprintf("%d", managementApiPort), 30)
+
+			step = "checking the management API listen port environment variable"
+			json = `jsonpath={.spec.containers[?(@.name=='cassandra')].env[?(@.name=='MGMT_API_LISTEN_TCP_PORT')].value}`
+			k = kubectl.Get(fmt.Sprintf("pod/%s", podName)).FormatOutput(json)
+			ns.WaitForOutputAndLog(step, k, fmt.Sprintf("%d", managementApiPort), 30)
+
+			step = fmt.Sprintf("calling the management API on port %d", managementApiPort)
+			k = kubectl.ExecOnPod(
+				podName,
+				"-c", "cassandra", "--",
+				"curl", "-s", "-o", "/dev/null", "--show-error", "--fail",
+				fmt.Sprintf("http://localhost:%d/api/v0/probes/liveness", managementApiPort),
+			)
+			ns.ExecAndLog(step, k)
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Extracts the information from containerPort in the cassandra container to check if the port has been overridden. Applies the correct adjustments to probes/envVars/preStop.

**Which issue(s) this PR fixes**:
Fixes #242 
Fixes #950 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
