### PR TITLE
Add three new flags to configure concurrency, reconcile timeouts and pprof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
+* [FEATURE] [#964](https://github.com/k8ssandra/cass-operator/issues/964) Add `--max-concurrent-reconciles` to configure reconciling concurrency (default is `1`), `--pprof-bind-address` to enable profiling, and `--reconciliation-timeout` to limit reconciliation time (default is `2m`)
+
 ## v1.32.0
 
 * [ENHANCEMENT] [#943](https://github.com/k8ssandra/cass-operator/issues/943) Add terminating state as one of the Pod status metrics
@@ -21,6 +23,14 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 * [BUGFIX] [#930](https://github.com/k8ssandra/cass-operator/issues/930) Add the missing resource-hash annotation to the NodePort service so changes to it are detected and reconciled.
 * [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen
 * [BUGFIX] [#928](https://github.com/k8ssandra/cass-operator/issues/928) Fix default storageClass selector to use annotations instead of labels
+
+## v1.30.3
+
+* [BUGFIX] [#938](https://github.com/k8ssandra/cass-operator/issues/938) Stripping of passwords from logs was failing if the password included characters that caused URLEncode to happen
+
+## v1.30.2
+
+* [BUGFIX] [#933](https://github.com/k8ssandra/cass-operator/issues/933) Fix regression introduced in the CassandraTask replacement process introduced in the full rack replacement feature.
 
 ## v1.31.0
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -71,8 +73,11 @@ func init() {
 
 func main() {
 	var metricsAddr string
+	var pprofAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var maxConcurrentReconciles int
+	var reconciliationTimeout time.Duration
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -81,7 +86,13 @@ func main() {
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "0", "The address the pprof endpoint binds to. "+
+		"Use :8082 to enable the pprof endpoint, or leave as 0 to disable it.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
+		"Maximum number of concurrent reconciles for each controller.")
+	flag.DurationVar(&reconciliationTimeout, "reconciliation-timeout", 2*time.Minute,
+		"Timeout for each reconciliation.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -174,9 +185,14 @@ func main() {
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
+		PprofBindAddress:       pprofAddr,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b569adb7.cassandra.datastax.com",
+		Controller: config.Controller{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			ReconciliationTimeout:   reconciliationTimeout,
+		},
 	}
 
 	if webhookEnabled {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,7 +90,7 @@ func main() {
 		"Use :8082 to enable the pprof endpoint, or leave as 0 to disable it.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
-		"Maximum number of concurrent reconciles for each controller.")
+		"Maximum number of concurrent CassandraDatacenter reconciles.")
 	flag.DurationVar(&reconciliationTimeout, "reconciliation-timeout", 2*time.Minute,
 		"Timeout for each reconciliation.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -190,8 +190,7 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b569adb7.cassandra.datastax.com",
 		Controller: config.Controller{
-			MaxConcurrentReconciles: maxConcurrentReconciles,
-			ReconciliationTimeout:   reconciliationTimeout,
+			ReconciliationTimeout: reconciliationTimeout,
 		},
 	}
 
@@ -252,12 +251,13 @@ func main() {
 	}
 
 	if err = (&controllers.CassandraDatacenterReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
-		Scheme:           mgr.GetScheme(),
-		Recorder:         mgr.GetEventRecorder("cass-operator"),
-		ImageRegistry:    registry,
-		ClusterResources: clusterScoped,
+		Client:                  mgr.GetClient(),
+		Log:                     ctrl.Log.WithName("controllers").WithName("CassandraDatacenter"),
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorder("cass-operator"),
+		ImageRegistry:           registry,
+		ClusterResources:        clusterScoped,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CassandraDatacenter")
 		os.Exit(1)
@@ -271,8 +271,9 @@ func main() {
 	}
 
 	if err = (&controlcontrollers.CassandraTaskReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		LifecycleContext: ctx,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CassandraTask")
 		os.Exit(1)

--- a/internal/controllers/cassandra/cassandradatacenter_controller.go
+++ b/internal/controllers/cassandra/cassandradatacenter_controller.go
@@ -38,6 +38,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -85,6 +86,8 @@ type CassandraDatacenterReconciler struct {
 
 	ImageRegistry    images.ImageRegistry
 	ClusterResources bool
+
+	MaxConcurrentReconciles int
 }
 
 // Reconcile reads that state of the cluster for a Datacenter object
@@ -251,7 +254,9 @@ func (r *CassandraDatacenterReconciler) SetupWithManager(mgr ctrl.Manager) error
 
 	c = c.Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toRequests))
 
-	return c.Complete(r)
+	return c.
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		Complete(r)
 }
 
 // blank assignment to verify that CassandraDatacenterReconciler implements reconciliation.Reconciler

--- a/internal/controllers/cassandra/suite_test.go
+++ b/internal/controllers/cassandra/suite_test.go
@@ -117,8 +117,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&control.CassandraTaskReconciler{
-		Client: k8sClient,
-		Scheme: k8sManager.GetScheme(),
+		Client:           k8sClient,
+		Scheme:           k8sManager.GetScheme(),
+		LifecycleContext: ctx,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controllers/control/cassandratask_controller.go
+++ b/internal/controllers/control/cassandratask_controller.go
@@ -60,7 +60,8 @@ var (
 // CassandraTaskReconciler reconciles a CassandraJob object
 type CassandraTaskReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme           *runtime.Scheme
+	LifecycleContext context.Context
 }
 
 // AsyncTaskExecutorFunc is called for all methods that support async processing
@@ -772,58 +773,61 @@ func (r *CassandraTaskReconciler) startPodTask(
 			}
 		}
 
-		if len(jobRunner) >= cap(jobRunner) {
-			status.Status = api.PodWaiting
-			cassTask.Status.PodStatuses[pod.Name] = status
-			return nil
-		}
-
 		if status.Status == api.PodRunning {
-			go func() {
-				// Write value to the jobRunner to indicate we're running
+			select {
+			case jobRunner <- 1:
 				taskKey := types.NamespacedName{Name: cassTask.Name, Namespace: cassTask.Namespace}
-				logger.V(1).Info("starting execution of sync blocking job", "Pod", pod)
-				jobRunner <- 1
-				defer func() {
-					// Remove the value from the jobRunner
-					<-jobRunner
+				taskCtx := log.IntoContext(r.LifecycleContext, logger)
+				syncTaskConfig := *taskConfig
+				syncTaskConfig.Context = taskCtx
+				syncStatus := status
+
+				go func() {
+					logger := log.FromContext(taskCtx)
+					logger.V(1).Info("starting execution of sync blocking job", "Pod", pod)
+					defer func() {
+						<-jobRunner
+					}()
+
+					if syncTaskConfig.PreProcessFunc != nil {
+						if err := syncTaskConfig.PreProcessFunc(&syncTaskConfig); err != nil {
+							logger.Error(err, "executing preprocessing functionality failed", "Pod", pod)
+							syncStatus.Error = err.Error()
+							syncStatus.Status = api.PodError
+						}
+					}
+
+					if syncStatus.Error == "" {
+						if err := syncTaskConfig.SyncFunc(nodeMgmtClient, pod, &syncTaskConfig); err != nil {
+							// We only log, nothing else to do - we won't even retry this pod.
+							logger.Error(err, "executing the sync task failed", "Pod", pod)
+							syncStatus.Error = err.Error()
+							syncStatus.Status = api.PodError
+						} else {
+							syncStatus.Status = api.PodCompleted
+							syncStatus.CompletionTime = new(metav1.Now())
+						}
+					}
+
+					cassTask := &api.CassandraTask{}
+					if err := r.Get(taskCtx, taskKey, cassTask); err != nil {
+						logger.Error(err, "Failed to get task for status update", "CassandraTask", taskKey)
+						return
+					}
+
+					taskPatch := client.MergeFrom(cassTask.DeepCopy())
+					if cassTask.Status.PodStatuses == nil {
+						cassTask.Status.PodStatuses = make(map[string]api.PodProcessingStatus)
+					}
+					cassTask.Status.PodStatuses[pod.Name] = syncStatus
+
+					if err := r.Status().Patch(taskCtx, cassTask, taskPatch); err != nil {
+						logger.Error(err, "Failed to update cassandraTask's status", "CassandraTask", taskKey)
+					}
 				}()
-
-				if taskConfig.PreProcessFunc != nil {
-					if err := taskConfig.PreProcessFunc(taskConfig); err != nil {
-						logger.Error(err, "executing preprocessing functionality failed", "Pod", pod)
-						status.Error = err.Error()
-						status.Status = api.PodError
-					}
-				}
-
-				if status.Error == "" {
-					if err = taskConfig.SyncFunc(nodeMgmtClient, pod, taskConfig); err != nil {
-						// We only log, nothing else to do - we won't even retry this pod.
-						logger.Error(err, "executing the sync task failed", "Pod", pod)
-						status.Error = err.Error()
-						status.Status = api.PodError
-					} else {
-						status.Status = api.PodCompleted
-						status.CompletionTime = new(metav1.Now())
-					}
-				}
-
-				cassTask := &api.CassandraTask{}
-				if err := r.Get(context.Background(), taskKey, cassTask); err != nil {
-					logger.Error(err, "Failed to get task for status update", "CassandraTask", cassTask)
-				}
-
-				taskPatch := client.MergeFrom(cassTask.DeepCopy())
-				if cassTask.Status.PodStatuses == nil {
-					cassTask.Status.PodStatuses = make(map[string]api.PodProcessingStatus)
-				}
-				cassTask.Status.PodStatuses[pod.Name] = status
-
-				if err = r.Status().Patch(ctx, cassTask, taskPatch); err != nil {
-					logger.Error(err, "Failed to update cassandraTask's status", "CassandraTask", cassTask)
-				}
-			}()
+			default:
+				status.Status = api.PodWaiting
+			}
 		}
 	}
 

--- a/internal/controllers/control/suite_test.go
+++ b/internal/controllers/control/suite_test.go
@@ -82,8 +82,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&CassandraTaskReconciler{
-		Client: k8sClient,
-		Scheme: k8sManager.GetScheme(),
+		Client:           k8sClient,
+		Scheme:           k8sManager.GetScheme(),
+		LifecycleContext: ctx,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allow modifying controller-runtime settings around concurrency, timeouts and pprof.

Previously the reconcile could take infinite time, this will limit it to 2 minutes.

Also fix CHANGELOG with missing versions

**Which issue(s) this PR fixes**:
Fixes #964 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
