### PR TITLE
Remove metric of the last decommissioned pod and avoid an error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 
 ## unreleased
 
-* [CHANGE] [#969](https://github.com/k8ssandra/cass-operator/issues/969) Pull cass-config-builder from GHCR
+* [CHANGE] [#969](https://github.com/k8ssandra/cass-operator/issues/969) Pull cass-config-builder from ghcr.io instead of docker.io where its no longer updated
+* [BUGFIX] [#971](https://github.com/k8ssandra/cass-operator/issues/971) Decommissioning last pod of a datacenter left its pod_status metric abandoned instead of being removed. And also we got an error logline which wasn't a real error
 
 ## v1.32.0
 

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -341,6 +341,11 @@ func (rc *ReconciliationContext) RemoveDecommissionedPodFromSts(pod *corev1.Pod)
 	}
 
 	maxReplicas := *sts.Spec.Replicas
+	if maxReplicas == 0 {
+		monitoring.RemovePodStatusMetric(pod)
+		return nil
+	}
+
 	lastPodSuffix := stsLastPodSuffix(maxReplicas)
 	if strings.HasSuffix(pod.Name, lastPodSuffix) {
 		monitoring.RemovePodStatusMetric(pod)

--- a/pkg/reconciliation/decommission_node_test.go
+++ b/pkg/reconciliation/decommission_node_test.go
@@ -5,16 +5,101 @@ package reconciliation
 
 import (
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/internal/result"
 	"github.com/k8ssandra/cass-operator/pkg/httphelper"
+	"github.com/k8ssandra/cass-operator/pkg/monitoring"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestRemoveDecommissionedPodFromZeroReplicaSts(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+	require := require.New(t)
+
+	var logs []string
+	rc.ReqLogger = funcr.NewJSON(func(log string) {
+		logs = append(logs, log)
+	}, funcr.Options{})
+
+	replicas := int32(0)
+	rc.statefulSets = []*appsv1.StatefulSet{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-dc2-default-sts",
+			Labels: map[string]string{
+				api.RackLabel: "default",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dc2-default-sts-0",
+			Namespace: "remove-dc",
+			Labels: map[string]string{
+				api.ClusterLabel:    "test",
+				api.DatacenterLabel: "dc2",
+				api.RackLabel:       "default",
+			},
+		},
+	}
+	defer monitoring.RemovePodStatusMetric(pod)
+
+	statuses := []monitoring.PodStatus{
+		monitoring.PodStatusInitializing,
+		monitoring.PodStatusReady,
+		monitoring.PodStatusPending,
+		monitoring.PodStatusError,
+		monitoring.PodStatusDecommissioning,
+		monitoring.PodStatusTerminating,
+	}
+	for _, status := range statuses {
+		status := strings.ToLower(string(status))
+		monitoring.PodStatusVec.WithLabelValues(
+			pod.Namespace,
+			pod.Labels[api.ClusterLabel],
+			pod.Labels[api.DatacenterLabel],
+			pod.Labels[api.RackLabel],
+			pod.Name,
+			status,
+		).Set(1)
+		_, err := monitoring.GetMetricValue("cass_operator_datacenter_pods_status", map[string]string{
+			"namespace":  pod.Namespace,
+			"cluster":    pod.Labels[api.ClusterLabel],
+			"datacenter": pod.Labels[api.DatacenterLabel],
+			"rack":       pod.Labels[api.RackLabel],
+			"pod":        pod.Name,
+			"status":     status,
+		})
+		require.NoError(err, "expected %s pod status metric to be registered", status)
+	}
+
+	require.NoError(rc.RemoveDecommissionedPodFromSts(pod), "expected an already scaled-down StatefulSet to be a no-op")
+	require.NotContains(strings.Join(logs, "\n"), "sts--1", "expected cleanup not to look for a negative pod ordinal")
+	require.Equal(int32(0), *rc.statefulSets[0].Spec.Replicas, "expected replicas to remain at zero")
+	for _, status := range statuses {
+		status := strings.ToLower(string(status))
+		_, err := monitoring.GetMetricValue("cass_operator_datacenter_pods_status", map[string]string{
+			"namespace":  pod.Namespace,
+			"cluster":    pod.Labels[api.ClusterLabel],
+			"datacenter": pod.Labels[api.DatacenterLabel],
+			"rack":       pod.Labels[api.RackLabel],
+			"pod":        pod.Name,
+			"status":     status,
+		})
+		require.Error(err, "expected %s pod status metric to be removed", status)
+	}
+}
 
 func TestRetryDecommissionNode(t *testing.T) {
 	rc, _, cleanupMockScr := setupTest()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Small fix to end the decommission at the Replicas = 0, but only do the removal of pod_status_metric

**Which issue(s) this PR fixes**:
Fixes #971 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
