### PR TITLE
Prevent premature decommission cleanup when metadata requests fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Cass Operator, new PRs should update the `main / unreleased` secti
 ## unreleased
 
 * [CHANGE] [#969](https://github.com/k8ssandra/cass-operator/issues/969) Pull cass-config-builder from GHCR
+* [BUGFIX] [#973](https://github.com/k8ssandra/cass-operator/issues/973) Prevent premature decommission cleanup when Cassandra metadata requests fail.
 
 ## v1.32.0
 

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -45,7 +45,7 @@ func (rc *ReconciliationContext) CalculateRackInfoForDecomm(currentSize int) ([]
 	return decommRackInfo, nil
 }
 
-func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadataEndpoints) result.ReconcileResult {
+func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadataEndpoints, metadataErr error) result.ReconcileResult {
 	logger := rc.ReqLogger
 	logger.Info("reconcile_racks::DecommissionNodes")
 	dc := rc.Datacenter
@@ -65,6 +65,9 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 
 	if currentSize <= targetSize {
 		return result.Continue()
+	}
+	if metadataErr != nil {
+		return result.Error(fmt.Errorf("cannot decommission a node without Cassandra metadata: %w", metadataErr))
 	}
 
 	decommRackInfo, err := rc.CalculateRackInfoForDecomm(int(currentSize))
@@ -178,7 +181,7 @@ func (rc *ReconciliationContext) callDecommission(pod *corev1.Pod) error {
 }
 
 // Wait for decommissioning nodes to finish before continuing to reconcile
-func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.CassMetadataEndpoints) result.ReconcileResult {
+func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.CassMetadataEndpoints, metadataErr error) result.ReconcileResult {
 	rc.ReqLogger.Info("reconcile_racks::CheckDecommissioningNodes")
 	if rc.Datacenter.GetConditionStatus(api.DatacenterScalingDown) != corev1.ConditionTrue {
 		return result.Continue()
@@ -188,6 +191,9 @@ func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.Cas
 
 	for _, pod := range rc.dcPods {
 		if pod.Labels[api.CassNodeState] == stateDecommissioning {
+			if metadataErr != nil {
+				return result.Error(fmt.Errorf("cannot check decommissioning node %s without Cassandra metadata: %w", pod.Name, metadataErr))
+			}
 			if !IsDoneDecommissioning(pod, epData, nodeStatuses, rc.ReqLogger) {
 				if !HasStartedDecommissioning(pod, epData, nodeStatuses) {
 					rc.ReqLogger.V(1).Info("Decommission has not started trying again", "Pod", pod.Name)

--- a/pkg/reconciliation/decommission_node.go
+++ b/pkg/reconciliation/decommission_node.go
@@ -45,7 +45,7 @@ func (rc *ReconciliationContext) CalculateRackInfoForDecomm(currentSize int) ([]
 	return decommRackInfo, nil
 }
 
-func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadataEndpoints, metadataErr error) result.ReconcileResult {
+func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadataEndpoints) result.ReconcileResult {
 	logger := rc.ReqLogger
 	logger.Info("reconcile_racks::DecommissionNodes")
 	dc := rc.Datacenter
@@ -66,8 +66,8 @@ func (rc *ReconciliationContext) DecommissionNodes(epData httphelper.CassMetadat
 	if currentSize <= targetSize {
 		return result.Continue()
 	}
-	if metadataErr != nil {
-		return result.Error(fmt.Errorf("cannot decommission a node without Cassandra metadata: %w", metadataErr))
+	if len(epData.Entity) == 0 {
+		return result.Error(fmt.Errorf("cannot decommission a node without Cassandra metadata"))
 	}
 
 	decommRackInfo, err := rc.CalculateRackInfoForDecomm(int(currentSize))
@@ -181,7 +181,7 @@ func (rc *ReconciliationContext) callDecommission(pod *corev1.Pod) error {
 }
 
 // Wait for decommissioning nodes to finish before continuing to reconcile
-func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.CassMetadataEndpoints, metadataErr error) result.ReconcileResult {
+func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.CassMetadataEndpoints) result.ReconcileResult {
 	rc.ReqLogger.Info("reconcile_racks::CheckDecommissioningNodes")
 	if rc.Datacenter.GetConditionStatus(api.DatacenterScalingDown) != corev1.ConditionTrue {
 		return result.Continue()
@@ -191,8 +191,8 @@ func (rc *ReconciliationContext) CheckDecommissioningNodes(epData httphelper.Cas
 
 	for _, pod := range rc.dcPods {
 		if pod.Labels[api.CassNodeState] == stateDecommissioning {
-			if metadataErr != nil {
-				return result.Error(fmt.Errorf("cannot check decommissioning node %s without Cassandra metadata: %w", pod.Name, metadataErr))
+			if len(epData.Entity) == 0 {
+				return result.Error(fmt.Errorf("cannot check decommissioning node %s without Cassandra metadata", pod.Name))
 			}
 			if !IsDoneDecommissioning(pod, epData, nodeStatuses, rc.ReqLogger) {
 				if !HasStartedDecommissioning(pod, epData, nodeStatuses) {

--- a/pkg/reconciliation/decommission_node_test.go
+++ b/pkg/reconciliation/decommission_node_test.go
@@ -4,7 +4,6 @@
 package reconciliation
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -81,7 +80,7 @@ func TestRetryDecommissionNode(t *testing.T) {
 			},
 		},
 	}
-	r := rc.CheckDecommissioningNodes(epData, nil)
+	r := rc.CheckDecommissioningNodes(epData)
 	if r != result.RequeueSoon(5) {
 		t.Fatalf("expected result of result.RequeueSoon(5) but got %s", r)
 	}
@@ -134,7 +133,7 @@ func TestRemoveResourcesWhenDone(t *testing.T) {
 		},
 	}
 
-	r := rc.CheckDecommissioningNodes(epData, nil)
+	r := rc.CheckDecommissioningNodes(epData)
 	if r != result.RequeueSoon(5) {
 		t.Fatalf("expected result of blah but got %s", r)
 	}
@@ -217,9 +216,6 @@ func TestReconcileAllRacksDoesNotCleanUpDecommissioningNodeWhenMetadataRequestFa
 
 	_, err = rc.ReconcileAllRacks()
 	require.Error(t, err)
-	var requestErr *httphelper.RequestError
-	require.ErrorAs(t, err, &requestErr)
-	require.Equal(t, http.StatusInternalServerError, requestErr.StatusCode)
 	server.assertCallCount(t, "/api/v0/metadata/endpoints", 2)
 	server.assertCallCount(t, "/api/v0/ops/node/decommission", 0)
 
@@ -244,12 +240,10 @@ func TestDecommissionNodesRequiresMetadata(t *testing.T) {
 	rc.statefulSets = []*appsv1.StatefulSet{{
 		Spec: appsv1.StatefulSetSpec{Replicas: &two},
 	}}
-	metadataErr := errors.New("metadata unavailable")
-
-	reconcileResult := rc.DecommissionNodes(httphelper.CassMetadataEndpoints{}, metadataErr)
+	reconcileResult := rc.DecommissionNodes(httphelper.CassMetadataEndpoints{})
 	require.True(t, reconcileResult.Completed())
 	_, err := reconcileResult.Output()
-	require.ErrorIs(t, err, metadataErr)
+	require.Error(t, err)
 	require.NotEqual(t, corev1.ConditionTrue, rc.Datacenter.GetConditionStatus(api.DatacenterScalingDown))
 	require.Equal(t, int32(2), *rc.statefulSets[0].Spec.Replicas)
 }

--- a/pkg/reconciliation/decommission_node_test.go
+++ b/pkg/reconciliation/decommission_node_test.go
@@ -4,6 +4,8 @@
 package reconciliation
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -11,9 +13,12 @@ import (
 	api "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/internal/result"
 	"github.com/k8ssandra/cass-operator/pkg/httphelper"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestRetryDecommissionNode(t *testing.T) {
@@ -76,7 +81,7 @@ func TestRetryDecommissionNode(t *testing.T) {
 			},
 		},
 	}
-	r := rc.CheckDecommissioningNodes(epData)
+	r := rc.CheckDecommissioningNodes(epData, nil)
 	if r != result.RequeueSoon(5) {
 		t.Fatalf("expected result of result.RequeueSoon(5) but got %s", r)
 	}
@@ -129,8 +134,122 @@ func TestRemoveResourcesWhenDone(t *testing.T) {
 		},
 	}
 
-	r := rc.CheckDecommissioningNodes(epData)
+	r := rc.CheckDecommissioningNodes(epData, nil)
 	if r != result.RequeueSoon(5) {
 		t.Fatalf("expected result of blah but got %s", r)
 	}
+}
+
+func TestReconcileAllRacksDoesNotCleanUpDecommissioningNodeWhenMetadataRequestFails(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+
+	rc.Datacenter.Spec.Size = 1
+	rc.Datacenter.SetCondition(api.DatacenterCondition{
+		Status: corev1.ConditionTrue,
+		Type:   api.DatacenterScalingDown,
+	})
+
+	server := newFakeMgmtApiServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/metadata/endpoints" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	rc.NodeMgmtClient = server.client(rc.ReqLogger)
+
+	statefulSet, err := newStatefulSetForCassandraDatacenter(
+		nil,
+		"default",
+		rc.Datacenter,
+		2,
+		imageRegistry,
+	)
+	require.NoError(t, err)
+	statefulSet.Status.ObservedGeneration = statefulSet.Generation
+
+	podName := getStatefulSetPodNameForIdx(statefulSet, 1)
+	pvcName := fmt.Sprintf("%s-%s", PvcName, podName)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: rc.Datacenter.Namespace,
+			Labels: map[string]string{
+				api.ClusterLabel:    rc.Datacenter.Spec.ClusterName,
+				api.DatacenterLabel: rc.Datacenter.Name,
+				api.CassNodeState:   stateDecommissioning,
+				api.RackLabel:       "default",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "cassandra"}},
+			Volumes: []corev1.Volume{{
+				Name: "server-data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "cassandra", Ready: true}},
+		},
+	}
+	server.attachToPod(t, pod)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: rc.Datacenter.Namespace},
+	}
+	remainingPod := pod.DeepCopy()
+	remainingPod.Name = getStatefulSetPodNameForIdx(statefulSet, 0)
+	remainingPod.Labels[api.CassNodeState] = stateStarted
+	remainingPVC := pvc.DeepCopy()
+	remainingPVC.Name = fmt.Sprintf("%s-%s", PvcName, remainingPod.Name)
+	remainingPod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName = remainingPVC.Name
+	rc.Client = fake.NewClientBuilder().
+		WithScheme(setupScheme()).
+		WithStatusSubresource(rc.Datacenter, statefulSet).
+		WithRuntimeObjects(rc.Datacenter, statefulSet, pod, pvc, remainingPod, remainingPVC).
+		WithIndex(&corev1.Pod{}, podPVCClaimNameField, podPVCClaimNames).
+		Build()
+	rc.desiredRackInformation = []*RackInformation{{RackName: "default", NodeCount: 1, SeedCount: 1}}
+	rc.statefulSets = []*appsv1.StatefulSet{statefulSet}
+
+	_, err = rc.ReconcileAllRacks()
+	require.Error(t, err)
+	var requestErr *httphelper.RequestError
+	require.ErrorAs(t, err, &requestErr)
+	require.Equal(t, http.StatusInternalServerError, requestErr.StatusCode)
+	server.assertCallCount(t, "/api/v0/metadata/endpoints", 2)
+	server.assertCallCount(t, "/api/v0/ops/node/decommission", 0)
+
+	storedPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, rc.Client.Get(rc.Ctx, types.NamespacedName{
+		Name: pvcName, Namespace: rc.Datacenter.Namespace,
+	}, storedPVC))
+
+	storedStatefulSet := &appsv1.StatefulSet{}
+	require.NoError(t, rc.Client.Get(rc.Ctx, types.NamespacedName{
+		Name: statefulSet.Name, Namespace: statefulSet.Namespace,
+	}, storedStatefulSet))
+	require.Equal(t, int32(2), *storedStatefulSet.Spec.Replicas)
+}
+
+func TestDecommissionNodesRequiresMetadata(t *testing.T) {
+	rc, _, cleanupMockScr := setupTest()
+	defer cleanupMockScr()
+
+	rc.Datacenter.Spec.Size = 1
+	two := int32(2)
+	rc.statefulSets = []*appsv1.StatefulSet{{
+		Spec: appsv1.StatefulSetSpec{Replicas: &two},
+	}}
+	metadataErr := errors.New("metadata unavailable")
+
+	reconcileResult := rc.DecommissionNodes(httphelper.CassMetadataEndpoints{}, metadataErr)
+	require.True(t, reconcileResult.Completed())
+	_, err := reconcileResult.Output()
+	require.ErrorIs(t, err, metadataErr)
+	require.NotEqual(t, corev1.ConditionTrue, rc.Datacenter.GetConditionStatus(api.DatacenterScalingDown))
+	require.Equal(t, int32(2), *rc.statefulSets[0].Spec.Replicas)
 }

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1395,24 +1395,34 @@ func isNodeStuckAfterLosingReadiness(pod *corev1.Pod) bool {
 	return hasBeenXMinutesSinceReady(10, pod)
 }
 
-func (rc *ReconciliationContext) getCassMetadataEndpoints() httphelper.CassMetadataEndpoints {
-	var metadata httphelper.CassMetadataEndpoints
+func (rc *ReconciliationContext) getCassMetadataEndpoints() (httphelper.CassMetadataEndpoints, error) {
+	var lastErr error
 	for _, pod := range rc.clusterPods {
-		// Try to query the first ready pod we find.
-		// We won't get any endpoints back if no pods are ready yet.
+		// A cluster may have no ready pods while starting, so callers decide
+		// whether unavailable metadata should stop their reconciliation step.
 		if !isServerReady(pod) {
 			continue
 		}
 
-		metadata, _ = rc.NodeMgmtClient.CallMetadataEndpointsEndpoint(pod)
-
-		if len(metadata.Entity) == 0 {
+		metadata, err := rc.NodeMgmtClient.CallMetadataEndpointsEndpoint(pod)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get Cassandra metadata endpoints from pod %s: %w", pod.Name, err)
 			continue
 		}
-		break
+
+		if len(metadata.Entity) == 0 {
+			// A ready Cassandra node should report at least its own endpoint.
+			continue
+		}
+
+		return metadata, nil
 	}
 
-	return metadata
+	if lastErr != nil {
+		return httphelper.CassMetadataEndpoints{}, lastErr
+	}
+
+	return httphelper.CassMetadataEndpoints{}, fmt.Errorf("no usable Cassandra metadata endpoints available from ready pods")
 }
 
 // When a vmware taint occurs and we delete the pvc, pv, and
@@ -2699,7 +2709,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 	rc.clusterPods = pods
 	rc.dcPods = rc.datacenterPods()
 
-	endpointData := rc.getCassMetadataEndpoints()
+	endpointData, endpointErr := rc.getCassMetadataEndpoints()
 
 	if recResult := rc.CheckStatefulSetControllerCaughtUp(); recResult.Completed() {
 		return recResult.Output()
@@ -2721,7 +2731,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	if recResult := rc.CheckDecommissioningNodes(endpointData); recResult.Completed() {
+	if recResult := rc.CheckDecommissioningNodes(endpointData, endpointErr); recResult.Completed() {
 		return recResult.Output()
 	}
 
@@ -2753,7 +2763,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	if recResult := rc.DecommissionNodes(endpointData); recResult.Completed() {
+	if recResult := rc.DecommissionNodes(endpointData, endpointErr); recResult.Completed() {
 		return recResult.Output()
 	}
 

--- a/pkg/reconciliation/reconcile_racks.go
+++ b/pkg/reconciliation/reconcile_racks.go
@@ -1395,34 +1395,24 @@ func isNodeStuckAfterLosingReadiness(pod *corev1.Pod) bool {
 	return hasBeenXMinutesSinceReady(10, pod)
 }
 
-func (rc *ReconciliationContext) getCassMetadataEndpoints() (httphelper.CassMetadataEndpoints, error) {
-	var lastErr error
+func (rc *ReconciliationContext) getCassMetadataEndpoints() httphelper.CassMetadataEndpoints {
+	var metadata httphelper.CassMetadataEndpoints
 	for _, pod := range rc.clusterPods {
-		// A cluster may have no ready pods while starting, so callers decide
-		// whether unavailable metadata should stop their reconciliation step.
+		// Try to query the first ready pod we find.
+		// We won't get any endpoints back if no pods are ready yet.
 		if !isServerReady(pod) {
 			continue
 		}
 
-		metadata, err := rc.NodeMgmtClient.CallMetadataEndpointsEndpoint(pod)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to get Cassandra metadata endpoints from pod %s: %w", pod.Name, err)
-			continue
-		}
+		metadata, _ = rc.NodeMgmtClient.CallMetadataEndpointsEndpoint(pod)
 
 		if len(metadata.Entity) == 0 {
-			// A ready Cassandra node should report at least its own endpoint.
 			continue
 		}
-
-		return metadata, nil
+		break
 	}
 
-	if lastErr != nil {
-		return httphelper.CassMetadataEndpoints{}, lastErr
-	}
-
-	return httphelper.CassMetadataEndpoints{}, fmt.Errorf("no usable Cassandra metadata endpoints available from ready pods")
+	return metadata
 }
 
 // When a vmware taint occurs and we delete the pvc, pv, and
@@ -2709,7 +2699,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 	rc.clusterPods = pods
 	rc.dcPods = rc.datacenterPods()
 
-	endpointData, endpointErr := rc.getCassMetadataEndpoints()
+	endpointData := rc.getCassMetadataEndpoints()
 
 	if recResult := rc.CheckStatefulSetControllerCaughtUp(); recResult.Completed() {
 		return recResult.Output()
@@ -2731,7 +2721,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	if recResult := rc.CheckDecommissioningNodes(endpointData, endpointErr); recResult.Completed() {
+	if recResult := rc.CheckDecommissioningNodes(endpointData); recResult.Completed() {
 		return recResult.Output()
 	}
 
@@ -2763,7 +2753,7 @@ func (rc *ReconciliationContext) ReconcileAllRacks() (reconcile.Result, error) {
 		return recResult.Output()
 	}
 
-	if recResult := rc.DecommissionNodes(endpointData, endpointErr); recResult.Completed() {
+	if recResult := rc.DecommissionNodes(endpointData); recResult.Completed() {
 		return recResult.Output()
 	}
 


### PR DESCRIPTION
**What this PR does**:

When Cassandra metadata requests failed, the error was ignored, and reconciliation continued with an empty endpoint list. During decommission, that could make the node look absent from the ring, causing the operator to scale down its StatefulSet and delete its PVC before decommission finished.

This change returns the metadata error and stops reconciliation before starting or completing a decommission until usable metadata is available. Valid metadata where the node is LEFT or absent keeps the existing completion behavior.

**Which issue(s) this PR fixes**:

Fixes #973

**Testing**

- `go test ./pkg/reconciliation -count=1` passed.
- Focused decommission tests passed with the race detector. The regression fails on the original code and passes with the fix.
- `make docker-build docker-logger-build` passed.
- Local Kind `scale_down` and `decommission_dc` passed with Cassandra 5.0.6.

**Checklist**

- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
